### PR TITLE
fix: enhance CI permissions and configure release-please for PR-only mode

### DIFF
--- a/.github/workflows/permissions-test.yml
+++ b/.github/workflows/permissions-test.yml
@@ -1,0 +1,87 @@
+name: Test Permissions
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_type:
+        description: 'Type of permission test to run'
+        required: true
+        default: 'basic'
+        type: choice
+        options:
+          - basic
+          - release-please
+          - labels
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  repository-projects: write
+  actions: read
+
+jobs:
+  test-permissions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Test basic permissions
+        if: ${{ github.event.inputs.test_type == 'basic' }}
+        run: |
+          echo "🔍 Testing basic GitHub API access..."
+          
+          # Test repository access
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}"
+          
+          echo "✅ Repository access successful"
+
+      - name: Test release-please permissions
+        if: ${{ github.event.inputs.test_type == 'release-please' }}
+        run: |
+          echo "🔍 Testing release-please permissions..."
+          
+          # Test if we can read releases
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/releases"
+          
+          # Test if we can read pull requests
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/pulls"
+          
+          echo "✅ Release-please permissions test completed"
+
+      - name: Test label permissions
+        if: ${{ github.event.inputs.test_type == 'labels' }}
+        run: |
+          echo "🔍 Testing label permissions..."
+          
+          # Test if we can read labels
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/labels"
+          
+          echo "✅ Label permissions test completed"
+
+      - name: Test release-please dry run
+        if: ${{ github.event.inputs.test_type == 'release-please' }}
+        uses: googleapis/release-please-action@v4
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          token: ${{ secrets.GITHUB_TOKEN }}
+          dry-run: true
+
+      - name: Display results
+        run: |
+          echo "🎉 Permission test completed successfully!"
+          echo "Test type: ${{ github.event.inputs.test_type }}"
+          echo "Repository: ${{ github.repository }}"
+          echo "Actor: ${{ github.actor }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
+  repository-projects: write
+  actions: read
 
 jobs:
   release-please:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,7 @@
       "include-v-in-tag": true,
       "initial-version": "0.1.0",
       "separate-pull-requests": false,
-      "skip-github-release": false,
+      "skip-github-release": true,
       "skip-labeling": true,
       "always-link-local": false,
       "changelog-sections": [
@@ -83,6 +83,7 @@
   "changelog-path": "CHANGELOG.md",
   "changelog-type": "github",
   "skip-github-pull-request": false,
+  "skip-github-release": true,
   "sequential-calls": true,
   "tag-separator": "/",
   "include-component-in-tag": false,


### PR DESCRIPTION
## Problem

The release-please workflow is failing with permission errors:

```
release-please failed: You do not have permission to create labels on this repository
```

## Solution

This PR implements comprehensive permission and configuration fixes:

### 🔒 Enhanced Workflow Permissions

- **contents: write**: Repository access and file modifications
- **pull-requests: write**: PR creation and management  
- **issues: write**: Issue management (required by release-please)
- **repository-projects: write**: Project management
- **actions: read**: Workflow access

### ⚙️ Release-Please Configuration

- **skip-github-release: true**: PR-only mode
- **skip-labeling: true**: Prevents label creation errors
- **skip-github-pull-request: false**: Enables PR creation

### 🧪 Permission Testing Workflow

- Manual testing workflow for permission validation
- API access tests and release-please dry run
- Label permission checks

## Benefits

- 🛡️ **Reliability**: No permission errors
- 🔧 **Maintainability**: Clear workflow separation
- 🚀 **Performance**: No workflow conflicts

## Testing

1. Run permissions-test.yml workflow
2. Push conventional commit to test PR creation
3. Verify release flow works end-to-end

Signed-off-by: longhao <hal.long@outlook.com>