### PR TITLE
fix: align bootstrap-sha with v0.2.0 tag to resolve untagged PR issue

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,6 +9,6 @@
   },
   "separate-pull-requests": false,
   "skip-github-release": true,
-  "bootstrap-sha": "391be7d",
-  "last-release-sha": "391be7d"
+  "bootstrap-sha": "81c0cba",
+  "last-release-sha": "81c0cba"
 }


### PR DESCRIPTION
## 🔧 Problem

After extensive investigation, I found the **root cause** of the persistent "There are untagged, merged release PRs outstanding" error:

```
⚠️ There are untagged, merged release PRs outstanding - aborting
```

## 🔍 Root Cause: Version Misalignment

The issue was a **bootstrap-sha mismatch**:

- **v0.2.0 git tag** points to commit: `81c0cba`
- **bootstrap-sha in config** was set to: `391be7d` (a LATER commit)
- **Commits after v0.2.0**: `391be7d`, `b6d0c16` (these appear "untagged" to release-please)

### Why This Caused the Error

Release-please saw:
1. ✅ v0.2.0 tag exists at commit `81c0cba`
2. ⚠️ Bootstrap-sha set to `391be7d` (after the tag)
3. ⚠️ Commits `391be7d` and `b6d0c16` appear as "merged but untagged"
4. ❌ Release-please aborts thinking there are untagged release PRs

## ✅ Solution: Correct Bootstrap SHA

This PR fixes the version alignment by:

### 1. Correct Bootstrap SHA
- **Before**: `bootstrap-sha: "391be7d"` (wrong - after v0.2.0)
- **After**: `bootstrap-sha: "81c0cba"` (correct - actual v0.2.0 tag commit)

### 2. Aligned Last Release SHA
- **Before**: `last-release-sha: "391be7d"` (wrong)
- **After**: `last-release-sha: "81c0cba"` (correct)

### 3. Version Consistency
- **Cargo.toml workspace version**: `0.2.0` ✅
- **Git tag**: `v0.2.0` ✅
- **Release-please manifest**: `0.2.0` ✅
- **Bootstrap SHA**: `81c0cba` (v0.2.0 tag commit) ✅

## 📚 How This Fixes the Issue

With the correct bootstrap-sha:
1. ✅ Release-please starts tracking from the actual v0.2.0 tag
2. ✅ Commits `391be7d` and `b6d0c16` are correctly seen as "new commits since last release"
3. ✅ No more "untagged merged PRs" error
4. ✅ Future conventional commits will create release PRs for v0.2.1

## 🧪 Expected Results

After merging this PR:
1. ✅ Release-please will no longer see "untagged merged PRs"
2. ✅ The next conventional commit will trigger a v0.2.1 release PR
3. ✅ Release workflow will function normally
4. ✅ No more manual intervention needed

## 📋 Changes Made

- **Fixed**: `bootstrap-sha` from `391be7d` to `81c0cba` (actual v0.2.0 tag)
- **Fixed**: `last-release-sha` from `391be7d` to `81c0cba`
- **Verified**: `.release-please-manifest.json` correctly set to `0.2.0`
- **Verified**: `Cargo.toml` workspace version matches at `0.2.0`

## 🎯 Impact

- ✅ **Resolves the root cause**: Fixes the actual version misalignment
- ✅ **Proper tracking**: Release-please will track from correct baseline
- ✅ **Future-proof**: Enables normal automated release workflow
- ✅ **No data loss**: All existing tags and releases remain intact
- ✅ **Clean solution**: Uses official bootstrap mechanism correctly

## 🔄 Next Steps

After merging:
1. Release-please will correctly track from v0.2.0 tag
2. New conventional commits will create v0.2.1 release PRs
3. The release automation will work as designed
4. No more "untagged merged PRs" errors

## 📚 Technical Details

**Git History Analysis:**
```
b6d0c16 (HEAD, main) fix: bootstrap release-please with correct SHA and version
391be7d fix: resolve release-please untagged PR issue  
a1019bd fix: resolve GoReleaser before hooks shell script parsing error
81c0cba (tag: v0.2.0) fix: resolve CI sccache and cargo-audit issues  ← CORRECT
```

**The Fix:**
- Bootstrap-sha now correctly points to `81c0cba` (the actual v0.2.0 tag)
- Release-please will see commits `391be7d` and `b6d0c16` as new changes for v0.2.1
- No more confusion about "untagged merged PRs"

This is the **definitive fix** based on understanding the actual cause of the issue.

Signed-off-by: longhao <hal.long@outlook.com>

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author