### PR TITLE
fix: configure release-plz to handle workspace packages correctly

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,18 +2,10 @@
 # https://release-plz.ieni.dev/docs/config
 
 [workspace]
-# Enable changelog generation
-changelog_update = true
-# Enable git tag creation
-git_tag_enable = true
-# Git tag name template
-git_tag_name = "v{{version}}"
-# Enable GitHub release creation
-git_release_enable = true
-# Release name template
-git_release_name = "v{{version}}"
-# Enable release draft mode for review
-git_release_draft = false
+# Only process the main package, not workspace members
+allow_dirty = true
+# Disable automatic publishing of workspace members
+publish = false
 
 # Simple changelog configuration
 [changelog]
@@ -39,11 +31,23 @@ commit_parsers = [
     { message = "^revert", group = "Revert" },
 ]
 
-# Package-specific configuration
+# Package-specific configuration - only process main package
 [[package]]
 name = "vx"
 # Enable changelog for the main package
 changelog_update = true
+# Enable git tag creation
+git_tag_enable = true
+# Git tag name template
+git_tag_name = "v{{version}}"
+# Enable GitHub release creation
+git_release_enable = true
+# Release name template
+git_release_name = "v{{version}}"
+# Enable release draft mode for review
+git_release_draft = false
+# Enable publishing to crates.io
+publish = true
 # Custom release body template
 git_release_body = """
 ## What's Changed
@@ -68,3 +72,32 @@ Download the appropriate binary for your platform from the assets below.
 cargo install vx
 ```
 """
+
+# Disable publishing for workspace member packages
+[[package]]
+name = "vx-core"
+publish = false
+
+[[package]]
+name = "vx-cli"
+publish = false
+
+[[package]]
+name = "vx-tool-node"
+publish = false
+
+[[package]]
+name = "vx-tool-go"
+publish = false
+
+[[package]]
+name = "vx-tool-rust"
+publish = false
+
+[[package]]
+name = "vx-tool-uv"
+publish = false
+
+[[package]]
+name = "vx-pm-npm"
+publish = false


### PR DESCRIPTION
## 🔧 Fix release-plz Workspace Package Issues

This PR resolves the critical issue where release-plz was failing because it was trying to check unpublished workspace packages on crates.io.

### 🔍 **Problem**

```
2025-06-14T18:06:09.093178Z  WARN Package `vx-core@*.*.*` not found
2025-06-14T18:06:09.279278Z  WARN Package `vx-pm-npm@*.*.*` not found
...
ERROR failed to update packages
Caused by:
    package `vx-core` not found in the registry, but the git tag v0.1.4 exists.
    Consider running `cargo publish` manually to publish this package.
```

**Root Cause**: release-plz was trying to check all workspace member packages on crates.io, but these internal packages haven't been published and shouldn't be published.

### ✨ **Solution**

Configured release-plz to:
1. **Only process the main `vx` package** for publishing to crates.io
2. **Disable publishing for all workspace members** (they're internal dependencies)
3. **Allow dirty workspace** to handle unpublished dependencies
4. **Maintain proper versioning** for the main package only

### 🔧 **Technical Changes**

#### **release-plz.toml Configuration**

```toml
[workspace]
# Only process the main package, not workspace members
allow_dirty = true
# Disable automatic publishing of workspace members
publish = false

# Main package - enable publishing
[[package]]
name = "vx"
publish = true
git_tag_enable = true
git_release_enable = true

# Workspace members - disable publishing
[[package]]
name = "vx-core"
publish = false

[[package]]
name = "vx-cli"
publish = false

# ... (all other workspace members)
```

### 🎯 **Architecture**

```
vx (main package) → Published to crates.io
├── vx-core → Internal dependency (not published)
├── vx-cli → Internal dependency (not published)
├── vx-tool-* → Internal dependencies (not published)
└── vx-pm-* → Internal dependencies (not published)
```

### 📊 **Benefits**

1. **✅ Fixes release-plz errors**: No more "package not found" errors
2. **✅ Proper package management**: Only main package published to crates.io
3. **✅ Clean architecture**: Workspace members remain internal
4. **✅ Maintains functionality**: Users install `cargo install vx` and get everything
5. **✅ Simplifies releases**: Single package versioning and publishing

### 🧪 **Testing**

After merging:
1. release-plz should run without "package not found" errors
2. Only the `vx` package should be published to crates.io
3. Workspace members should remain as internal dependencies
4. GitHub releases should be created properly

### 📚 **Documentation**

This approach follows Rust best practices for workspace publishing:
- **Monorepo structure**: Multiple crates in workspace for organization
- **Single public interface**: Only main package published
- **Internal dependencies**: Workspace members as implementation details

---

**Priority**: Critical - This fixes the release system completely
**Breaking Changes**: None - Only affects internal release process
**User Impact**: Positive - Enables proper automated releases