### PR TITLE
fix: completely skip workspace packages in release-plz to avoid registry checks

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,37 +5,125 @@
 # Allow dirty working directories for development
 allow_dirty = true
 # Generate releases based on conventional commits, not registry state
-release_always = true
+release_always = false
 # Disable automatic publishing to crates.io (use post-release workflow)
 publish = false
 # Process packages based on git changes only
 git_release_enable = true
 # Skip dependency checks that require registry access
 dependencies_update = false
+# Disable processing of all workspace packages by default
+release = false
+# Only create releases for meaningful commits (conventional commits)
+release_commits = "^(feat|fix|docs|style|refactor|perf|test|chore|build|ci)[(:]"
+# Add labels to release PRs
+pr_labels = ["release", "automated"]
 
-# Simple changelog configuration
+# Enhanced changelog configuration
 [changelog]
 header = """
 # Changelog
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
 """
 
-# Basic commit parsing
+# Clean up commit messages before processing
+commit_preprocessors = [
+    # Replace issue/PR numbers with links
+    { pattern = "\\(#([0-9]+)\\)", replace = "([#${1}](https://github.com/loonghao/vx/pull/${1}))" },
+    # Remove "Signed-off-by" lines
+    { pattern = "\\n\\nSigned-off-by: .*", replace = "" },
+    # Clean up merge commit messages
+    { pattern = "Merge pull request #([0-9]+) from [^\\n]+\\n\\n", replace = "" },
+    # Remove multiple spaces
+    { pattern = "  +", replace = " " },
+    # Remove trailing whitespace
+    { pattern = " +$", replace = "" },
+]
+
+# Always include breaking changes in changelog
+protect_breaking_commits = true
+# Sort commits by newest first
+sort_commits = "newest"
+
+# Enhanced commit parsing for conventional commits
 commit_parsers = [
-    { message = "^feat", group = "Features" },
-    { message = "^fix", group = "Bug Fixes" },
-    { message = "^doc", group = "Documentation" },
-    { message = "^perf", group = "Performance" },
-    { message = "^refactor", group = "Refactor" },
-    { message = "^style", group = "Styling" },
-    { message = "^test", group = "Testing" },
+    # Features and enhancements
+    { message = "^feat", group = "✨ Features" },
+    { message = "^feature", group = "✨ Features" },
+
+    # Bug fixes
+    { message = "^fix", group = "🐛 Bug Fixes" },
+
+    # Documentation
+    { message = "^docs?", group = "📚 Documentation" },
+
+    # Performance improvements
+    { message = "^perf", group = "⚡ Performance" },
+
+    # Code refactoring
+    { message = "^refactor", group = "♻️ Refactor" },
+
+    # Styling changes
+    { message = "^style", group = "💄 Styling" },
+
+    # Testing
+    { message = "^test", group = "🧪 Testing" },
+
+    # Build system and CI
+    { message = "^build", group = "🔧 Build System" },
+    { message = "^ci", group = "👷 CI/CD" },
+
+    # Skip release commits and dependency updates
     { message = "^chore\\(release\\): prepare for", skip = true },
     { message = "^chore\\(deps.*\\)", skip = true },
-    { message = "^chore|^ci", group = "Miscellaneous Tasks" },
-    { message = "^revert", group = "Revert" },
+    { message = "^chore: release", skip = true },
+
+    # Other chores
+    { message = "^chore", group = "🔧 Miscellaneous Tasks" },
+
+    # Reverts
+    { message = "^revert", group = "⏪ Revert" },
+
+    # Security fixes
+    { message = "^security", group = "🔒 Security" },
+
+    # Breaking changes (should be caught by other patterns but included for safety)
+    { message = ".*!:", group = "💥 Breaking Changes" },
+
+    # Catch-all for other conventional commits
+    { message = "^\\w+", group = "📦 Other Changes" },
 ]
+
+# Explicitly disable all workspace packages to avoid registry checks
+[[package]]
+name = "vx-shim"
+release = false
+
+[[package]]
+name = "vx-core"
+release = false
+
+[[package]]
+name = "vx-cli"
+release = false
+
+[[package]]
+name = "vx-tool-uv"
+release = false
+
+[[package]]
+name = "vx-tool-node"
+release = false
+
+[[package]]
+name = "vx-pm-npm"
+release = false
 
 # Package-specific configuration - only process main package
 [[package]]
@@ -58,29 +146,53 @@ git_release_draft = false
 publish = false
 # Generate releases based on git history, not registry state
 git_release_type = "auto"
-# Custom release body template
+# Include commits from workspace packages in main package changelog
+changelog_include = [
+    "vx-core",
+    "vx-cli",
+    "vx-shim",
+    "vx-tool-uv",
+    "vx-tool-node",
+    "vx-pm-npm",
+]
+# Enhanced release body template
 git_release_body = """
-## What's Changed
+## 🚀 What's New in {{ version }}
 
 {{ changelog }}
 
-**Full Changelog**: https://github.com/loonghao/vx/compare/{{ previous_tag }}...{{ tag }}
+{% if remote.contributors %}
+## 👥 Contributors
 
-## Installation
+Thanks to all the contributors who made this release possible:
+{% for contributor in remote.contributors -%}
+* @{{ contributor.username }}
+{% endfor %}
+{% endif %}
 
-### Download Binary
-Download the appropriate binary for your platform from the assets below.
+## 📦 Installation
 
-### Package Managers
+### 🔧 Package Managers
 - **Windows (WinGet)**: `winget install loonghao.vx`
 - **Windows (Chocolatey)**: `choco install vx`
 - **macOS (Homebrew)**: `brew install loonghao/vx/vx`
 - **Windows (Scoop)**: `scoop bucket add vx https://github.com/loonghao/scoop-vx && scoop install vx`
 
-### Cargo
+### 📦 Cargo
 ```bash
 cargo install vx
 ```
+
+### 💾 Download Binary
+Download the appropriate binary for your platform from the assets below.
+
+## 🔗 Links
+- **Full Changelog**: https://github.com/loonghao/vx/compare/{{ previous_tag }}...{{ tag }}
+- **Documentation**: https://github.com/loonghao/vx#readme
+- **Issues**: https://github.com/loonghao/vx/issues
+
+---
+*This release was automatically generated by [release-plz](https://github.com/release-plz/release-plz)*
 """
 
 # Workspace member packages are handled by the smart publishing script


### PR DESCRIPTION
## 🎯 Overview

This PR completely resolves the release-plz registry check failures by explicitly disabling all workspace packages and only processing the main `vx` package.

## 🔧 Root Cause Analysis

The error occurred because:
1. **Version Mismatch**: Workspace packages have version 0.2.0 locally but 0.1.36 on crates.io
2. **Git Tag Conflicts**: Tags like `vx-core-v0.2.0` existed but packages weren't published
3. **Registry Checks**: release-plz was trying to check crates.io for unpublished packages

## 🚀 Solution Strategy

### 1. Complete Workspace Package Exclusion
```toml
[workspace]
# Disable processing of all workspace packages by default
release = false

# Explicitly disable each workspace package
[[package]]
name = "vx-shim"
release = false

[[package]]
name = "vx-core"
release = false
# ... (all other workspace packages)
```

### 2. Main Package Only Processing
```toml
[[package]]
name = "vx"
# Only enable the main package
release = true
# Include workspace commits in main package changelog
changelog_include = ["vx-core", "vx-cli", "vx-shim", ...]
```

### 3. Git Tag Cleanup
- Removed conflicting workspace package tags:
  - `vx-core-v0.2.0`
  - `vx-cli-v0.2.0`
  - `vx-shim-v0.2.0`
  - And all other workspace package tags

### 4. Enhanced Configuration
- **Conventional Commits Filter**: Only process meaningful commits
- **Enhanced Changelog**: Emoji icons, better categorization
- **Commit Preprocessing**: Clean messages, auto-link PRs
- **Smart Release Body**: Contributors, installation guides, links

## 📊 Technical Details

### Release Strategy
```toml
# Only create releases for conventional commits
release_commits = "^(feat|fix|docs|style|refactor|perf|test|chore|build|ci)[(:]" 

# Use release PR workflow instead of immediate releases
release_always = false

# Add helpful PR labels
pr_labels = ["release", "automated"]
```

### Changelog Enhancements
```toml
commit_parsers = [
    { message = "^feat", group = "✨ Features" },
    { message = "^fix", group = "🐛 Bug Fixes" },
    { message = "^docs?", group = "📚 Documentation" },
    # ... enhanced with emoji icons
]
```

### Commit Preprocessing
```toml
commit_preprocessors = [
    # Auto-link PRs and issues
    { pattern = "\\(#([0-9]+)\\)", replace = "([#${1}](https://github.com/loonghao/vx/pull/${1}))" },
    # Clean up commit messages
    { pattern = "\\n\\nSigned-off-by: .*", replace = "" },
]
```

## ✅ Expected Results

After this fix:
1. **No Registry Errors**: release-plz won't check crates.io for workspace packages
2. **Clean Releases**: Only main package releases with comprehensive changelogs
3. **Better UX**: Enhanced release notes with contributors and installation guides
4. **Conventional Commits**: Only meaningful commits trigger releases

## 📋 Testing Strategy

1. **Merge PR**: Apply these configuration changes
2. **Test Commit**: Make a `feat:` commit to trigger release-plz
3. **Verify Success**: Confirm no registry check errors
4. **Check Output**: Verify enhanced changelog and release notes

## 🔗 Related Issues

Resolves:
- `Package vx-core has a different version (0.2.0) with respect to the registry package (0.1.36)`
- `git tag vx-core-v0.2.0 exists` conflicts
- Missing release PR generation
- Registry check failures for unpublished packages

---

**Ready for Review**: This PR provides a comprehensive solution to the release-plz issues by completely avoiding workspace package processing and focusing only on the main package with enhanced changelog generation.