### PR TITLE
fix: enable release PR creation by setting release_always = true

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,8 +4,8 @@
 [workspace]
 # Allow dirty working directories for development
 allow_dirty = true
-# Generate releases based on conventional commits, not registry state
-release_always = false
+# Always try to create releases when there are changes (this enables PR creation)
+release_always = true
 # Disable automatic publishing to crates.io (use post-release workflow)
 publish = false
 # Process packages based on git changes only


### PR DESCRIPTION
## 🎯 Problem

The release-plz workflow was failing to create release PRs because `release_always = false` was configured. This setting means release-plz only creates releases when merging release PRs, but never creates the initial release PRs.

From the CI logs:
```
skipping release: current commit is not from a release PR
```

## 🔧 Solution

- Change `release_always` from `false` to `true` in `release-plz.toml`
- This enables release-plz to create release PRs when there are new commits that warrant a release
- The workflow will now be able to generate release PRs automatically

## 🧪 Testing

After merging this PR, the release workflow should:
1. Detect the new commits since the last release
2. Create a release PR with updated changelog and version bumps
3. Allow manual review and merging of the release PR
4. Create the actual GitHub release when the release PR is merged

## 📝 Changes

- Updated `release-plz.toml` to set `release_always = true`
- Added clear documentation explaining the purpose of this setting

Signed-off-by: longhao <hal.long@outlook.com>