### PR TITLE
fix: remove invalid allow_dirty field from package section

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -148,8 +148,6 @@ git_release_draft = false
 publish = false
 # Generate releases based on git history, not registry state
 git_release_type = "auto"
-# Skip registry checks for this package
-allow_dirty = true
 # Skip build verification to avoid dependency conflicts
 publish_no_verify = true
 # Include commits from workspace packages in main package changelog


### PR DESCRIPTION
## 🐛 Problem

The release-plz workflow was failing with a TOML parse error:

```
TOML parse error at line 131, column 1
unknown field `allow_dirty`
```

## 🔧 Solution

Removed the `allow_dirty = true` field from the `[[package]]` section for the "vx" package. According to the [release-plz documentation](https://release-plz.dev/docs/config#the-allow_dirty-field), the `allow_dirty` field is only supported in the `[workspace]` section, not in individual `[[package]]` sections.

## ✅ Changes

- Removed invalid `allow_dirty = true` from the vx package configuration
- The `allow_dirty = true` setting in the `[workspace]` section remains and provides the same functionality

## 🧪 Testing

This fix should resolve the release-plz configuration parsing error and allow the release workflow to proceed successfully.

---

Fixes the TOML parse error in release-plz workflow.