### PR TITLE
fix: improve release-plz commit detection configuration

### DIFF
--- a/crates/vx-cli/tests/execute_unit_tests.rs
+++ b/crates/vx-cli/tests/execute_unit_tests.rs
@@ -11,10 +11,10 @@ use common::{cleanup_test_env, create_test_registry};
 fn test_execute_module_compilation() {
     // This test ensures the execute module compiles correctly
     let registry = create_test_registry();
-    
+
     // Test basic registry operations
     assert!(registry.get_tool("nonexistent").is_none());
-    
+
     cleanup_test_env();
 }
 
@@ -23,12 +23,12 @@ fn test_execute_module_compilation() {
 #[test]
 fn test_registry_operations() {
     let registry = create_test_registry();
-    
+
     // Test that registry handles invalid tool names gracefully
     assert!(registry.get_tool("").is_none());
     assert!(registry.get_tool("invalid/tool").is_none());
     assert!(registry.get_tool("nonexistent-tool-12345").is_none());
-    
+
     cleanup_test_env();
 }
 
@@ -40,11 +40,11 @@ fn test_argument_vectors() {
     let empty_args: Vec<String> = Vec::new();
     let single_arg = vec!["--version".to_string()];
     let multiple_args = vec!["--help".to_string(), "--verbose".to_string()];
-    
+
     assert_eq!(empty_args.len(), 0);
     assert_eq!(single_arg.len(), 1);
     assert_eq!(multiple_args.len(), 2);
     assert_eq!(single_arg[0], "--version");
-    
+
     cleanup_test_env();
 }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -14,8 +14,8 @@ git_release_enable = true
 dependencies_update = false
 # Disable processing of all workspace packages by default
 release = false
-# Only create releases for meaningful commits (conventional commits)
-release_commits = "^(feat|fix|docs|style|refactor|perf|test|chore|build|ci)[(:]"
+# Process all commits for release detection (removed regex filter)
+# release_commits = "^(feat|fix|docs|style|refactor|perf|test|chore|build|ci).*"
 # Add labels to release PRs
 pr_labels = ["release", "automated"]
 # Use git-based versioning instead of registry checks
@@ -148,6 +148,8 @@ git_release_draft = false
 publish = false
 # Generate releases based on git history, not registry state
 git_release_type = "auto"
+# Override release detection to process recent commits
+release_commits = ".*"
 # Skip build verification to avoid dependency conflicts
 publish_no_verify = true
 # Include commits from workspace packages in main package changelog


### PR DESCRIPTION
## 🐛 Problem

The release-plz workflow was failing with the error:
```
INFO vx: no commit matches the `release_commits` regex
```

This was preventing the creation of release PRs even when there were valid conventional commits.

## 🔧 Solution

- **Remove restrictive regex**: Commented out the workspace-level `release_commits` regex that was too restrictive
- **Add package-level override**: Added `release_commits = ".*"` to the main `vx` package configuration to catch all commits
- **Maintain changelog quality**: The changelog parsers will still properly categorize commits, so we don't lose commit filtering for the changelog

## 🧪 Testing

This should resolve the issue where release-plz couldn't detect recent commits like:
- `fix: replace problematic execute tests with safe unit tests`
- `feat: optimize package publishing order based on dependency hierarchy`

## 📝 Changes

- Modified `release-plz.toml` to improve commit detection
- Ensured all conventional commits are processed for release consideration
- Maintained existing changelog parsing and categorization

Signed-off-by: longhao <hal.long@outlook.com>