### PR TITLE
fix: remove invalid release_commits field from package section

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -14,8 +14,8 @@ git_release_enable = true
 dependencies_update = false
 # Disable processing of all workspace packages by default
 release = false
-# Process all commits for release detection (removed regex filter)
-# release_commits = "^(feat|fix|docs|style|refactor|perf|test|chore|build|ci).*"
+# Process all commits for release detection
+release_commits = "^(feat|fix|docs|style|refactor|perf|test|chore|build|ci).*"
 # Add labels to release PRs
 pr_labels = ["release", "automated"]
 # Use git-based versioning instead of registry checks
@@ -148,8 +148,6 @@ git_release_draft = false
 publish = false
 # Generate releases based on git history, not registry state
 git_release_type = "auto"
-# Override release detection to process recent commits
-release_commits = ".*"
 # Skip build verification to avoid dependency conflicts
 publish_no_verify = true
 # Include commits from workspace packages in main package changelog


### PR DESCRIPTION
## 🐛 Problem

The release-plz workflow was failing with a TOML parse error:
```
TOML parse error at line 131, column 1
       |
   131 | [[package]]
       | ^^^^^^^^^^^
unknown field `release_commits`
```

The `release_commits` field is not valid in the `[[package]]` section according to release-plz configuration schema.

## 🔧 Solution

- **Remove invalid field**: Removed `release_commits = ".*"` from the `[[package]]` section for the `vx` package
- **Restore global config**: Uncommented and restored the `release_commits` configuration in the global scope where it belongs
- **Fix TOML syntax**: Ensure the configuration file follows the correct release-plz schema

## 🧪 Testing

This should resolve the TOML parse error and allow release-plz to:
- Parse the configuration file successfully
- Apply conventional commit filtering at the global level
- Process the main `vx` package for releases

## 📝 Changes

- Fixed TOML syntax error in `release-plz.toml`
- Moved `release_commits` to the correct global scope
- Maintained all other package-specific configurations

Signed-off-by: longhao <hal.long@outlook.com>

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author