### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.2.4](https://github.com/loonghao/vx/compare/v0.2.3...v0.2.4) - 2025-06-17
+
+### Added
+
+- simplify release-plz configuration based on shimexe best practices
+- simplify release workflow based on shimexe best practices
+- improve CI configuration based on shimexe best practices
+
+### Fixed
+
+- separate cross-compilation build from native testing
+- add cross-compilation dependencies for ARM64 target
+- temporarily disable ARM64 cross-compilation due to linker issues
+- use correct release-plz action and resolve version sync issues
+- move release-plz dry-run to CI and enhance token troubleshooting
+
+### Other
+
+- update README installation instructions
 ## [Unreleased]
 
 ## [0.2.3](https://github.com/loonghao/vx/compare/v0.2.2...v0.2.3) - 2025-06-16

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "vx"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -2621,7 +2621,7 @@ dependencies = [
 
 [[package]]
 name = "vx-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "vx-pm-npm"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-go"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-node"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2713,7 +2713,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-rust"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-uv"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ name = "config_management_demo"
 path = "examples/config_management_demo.rs"
 
 [dependencies]
-vx-cli = { version = "0.2.2", path = "crates/vx-cli" }
+vx-cli = { version = "0.2.4", path = "crates/vx-cli" }
 tokio = { workspace = true }
 anyhow = { workspace = true }
 
@@ -48,15 +48,15 @@ anyhow = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 # Test dependencies for integration tests
-vx-core = { version = "0.2.2", path = "crates/vx-core" }
-vx-tool-node = { version = "0.2.2", path = "crates/vx-tools/vx-tool-node" }
-vx-tool-go = { version = "0.2.2", path = "crates/vx-tools/vx-tool-go" }
-vx-tool-rust = { version = "0.2.2", path = "crates/vx-tools/vx-tool-rust" }
-vx-tool-uv = { version = "0.2.2", path = "crates/vx-tools/vx-tool-uv" }
+vx-core = { version = "0.2.4", path = "crates/vx-core" }
+vx-tool-node = { version = "0.2.4", path = "crates/vx-tools/vx-tool-node" }
+vx-tool-go = { version = "0.2.4", path = "crates/vx-tools/vx-tool-go" }
+vx-tool-rust = { version = "0.2.4", path = "crates/vx-tools/vx-tool-rust" }
+vx-tool-uv = { version = "0.2.4", path = "crates/vx-tools/vx-tool-uv" }
 
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 description = "Universal Development Tool Manager"
 license = "MIT"

--- a/crates/vx-cli/CHANGELOG.md
+++ b/crates/vx-cli/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 
 ## [0.2.0](https://github.com/loonghao/vx/compare/vx-cli-v0.1.36...vx-cli-v0.2.0) - 2025-06-15
 

--- a/crates/vx-cli/Cargo.toml
+++ b/crates/vx-cli/Cargo.toml
@@ -13,12 +13,12 @@ rust-version.workspace = true
 
 
 [dependencies]
-vx-core = { version = "0.2.2", path = "../vx-core" }
-vx-tool-node = { version = "0.2.2", path = "../vx-tools/vx-tool-node" }
-vx-tool-go = { version = "0.2.2", path = "../vx-tools/vx-tool-go" }
-vx-tool-rust = { version = "0.2.2", path = "../vx-tools/vx-tool-rust" }
-vx-tool-uv = { version = "0.2.2", path = "../vx-tools/vx-tool-uv" }
-vx-pm-npm = { version = "0.2.2", path = "../vx-package-managers/vx-pm-npm" }
+vx-core = { version = "0.2.4", path = "../vx-core" }
+vx-tool-node = { version = "0.2.4", path = "../vx-tools/vx-tool-node" }
+vx-tool-go = { version = "0.2.4", path = "../vx-tools/vx-tool-go" }
+vx-tool-rust = { version = "0.2.4", path = "../vx-tools/vx-tool-rust" }
+vx-tool-uv = { version = "0.2.4", path = "../vx-tools/vx-tool-uv" }
+vx-pm-npm = { version = "0.2.4", path = "../vx-package-managers/vx-pm-npm" }
 clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-core/CHANGELOG.md
+++ b/crates/vx-core/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 
 ## [0.2.0](https://github.com/loonghao/vx/compare/vx-core-v0.1.36...vx-core-v0.2.0) - 2025-06-15
 

--- a/crates/vx-package-managers/vx-pm-npm/CHANGELOG.md
+++ b/crates/vx-package-managers/vx-pm-npm/CHANGELOG.md
@@ -2,3 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+

--- a/crates/vx-package-managers/vx-pm-npm/Cargo.toml
+++ b/crates/vx-package-managers/vx-pm-npm/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.2", path = "../../vx-core" }
+vx-core = { version = "0.2.4", path = "../../vx-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-go/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-go/CHANGELOG.md
@@ -2,3 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+

--- a/crates/vx-tools/vx-tool-go/Cargo.toml
+++ b/crates/vx-tools/vx-tool-go/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.2", path = "../../vx-core" }
+vx-core = { version = "0.2.4", path = "../../vx-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-node/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-node/CHANGELOG.md
@@ -2,3 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+

--- a/crates/vx-tools/vx-tool-node/Cargo.toml
+++ b/crates/vx-tools/vx-tool-node/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.2", path = "../../vx-core" }
-vx-pm-npm = { version = "0.2.2", path = "../../vx-package-managers/vx-pm-npm" }
+vx-core = { version = "0.2.4", path = "../../vx-core" }
+vx-pm-npm = { version = "0.2.4", path = "../../vx-package-managers/vx-pm-npm" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-rust/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-rust/CHANGELOG.md
@@ -2,3 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+

--- a/crates/vx-tools/vx-tool-rust/Cargo.toml
+++ b/crates/vx-tools/vx-tool-rust/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.2", path = "../../vx-core" }
+vx-core = { version = "0.2.4", path = "../../vx-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-uv/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-uv/CHANGELOG.md
@@ -2,3 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+

--- a/crates/vx-tools/vx-tool-uv/Cargo.toml
+++ b/crates/vx-tools/vx-tool-uv/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.2", path = "../../vx-core" }
+vx-core = { version = "0.2.4", path = "../../vx-core" }
 anyhow = { workspace = true }
 which = "8.0"
 async-trait = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `vx-core`: 0.2.3 -> 0.2.4
* `vx-pm-npm`: 0.2.3 -> 0.2.4
* `vx-tool-go`: 0.2.3 -> 0.2.4
* `vx-tool-node`: 0.2.3 -> 0.2.4
* `vx-tool-rust`: 0.2.3 -> 0.2.4
* `vx-tool-uv`: 0.2.3 -> 0.2.4
* `vx-cli`: 0.2.3 -> 0.2.4
* `vx`: 0.2.3 -> 0.2.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `vx-core`

<blockquote>

## [0.2.0](https://github.com/loonghao/vx/compare/vx-core-v0.1.36...vx-core-v0.2.0) - 2025-06-15

### Bug Fixes

- resolve venv test failures and improve workspace publishing script
</blockquote>






## `vx-cli`

<blockquote>

## [0.2.0](https://github.com/loonghao/vx/compare/vx-cli-v0.1.36...vx-cli-v0.2.0) - 2025-06-15

### Bug Fixes

- remove deprecated use command and fix binary installation
- resolve venv test failures and improve workspace publishing script
- remove useless format! usage in venv command
- improve remove command error handling in force mode
- resolve CI issues and update documentation
- implement release-please best practices for output handling

### Features

- unify all workspace versions to 0.1.36
- add version numbers to workspace dependencies and automated publishing
- implement complete venv command functionality with VenvManager integration
- implement npx and uvx support with environment isolation

### Refactor

- simplify main package by reusing vx-cli main function
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).