### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.5](https://github.com/loonghao/vx/compare/v0.2.4...v0.2.5) - 2025-06-18
+
+### Fixed
+
+- Installer script for powershell
+- simplify release-plz.toml following shimexe best practices
+- optimize release-plz configuration to prevent duplicate CI triggers
+- improve CI checkout for fork PRs and optimize release workflows
+
 ## [0.2.4](https://github.com/loonghao/vx/compare/v0.2.3...v0.2.4) - 2025-06-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "vx"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -2621,7 +2621,7 @@ dependencies = [
 
 [[package]]
 name = "vx-core"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "vx-pm-npm"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-go"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-node"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2713,7 +2713,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-rust"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-uv"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ name = "config_management_demo"
 path = "examples/config_management_demo.rs"
 
 [dependencies]
-vx-cli = { version = "0.2.4", path = "crates/vx-cli" }
+vx-cli = { version = "0.2.5", path = "crates/vx-cli" }
 tokio = { workspace = true }
 anyhow = { workspace = true }
 
@@ -48,15 +48,15 @@ anyhow = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 # Test dependencies for integration tests
-vx-core = { version = "0.2.4", path = "crates/vx-core" }
-vx-tool-node = { version = "0.2.4", path = "crates/vx-tools/vx-tool-node" }
-vx-tool-go = { version = "0.2.4", path = "crates/vx-tools/vx-tool-go" }
-vx-tool-rust = { version = "0.2.4", path = "crates/vx-tools/vx-tool-rust" }
-vx-tool-uv = { version = "0.2.4", path = "crates/vx-tools/vx-tool-uv" }
+vx-core = { version = "0.2.5", path = "crates/vx-core" }
+vx-tool-node = { version = "0.2.5", path = "crates/vx-tools/vx-tool-node" }
+vx-tool-go = { version = "0.2.5", path = "crates/vx-tools/vx-tool-go" }
+vx-tool-rust = { version = "0.2.5", path = "crates/vx-tools/vx-tool-rust" }
+vx-tool-uv = { version = "0.2.5", path = "crates/vx-tools/vx-tool-uv" }
 
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 description = "Universal Development Tool Manager"
 license = "MIT"

--- a/crates/vx-cli/Cargo.toml
+++ b/crates/vx-cli/Cargo.toml
@@ -13,12 +13,12 @@ rust-version.workspace = true
 
 
 [dependencies]
-vx-core = { version = "0.2.4", path = "../vx-core" }
-vx-tool-node = { version = "0.2.4", path = "../vx-tools/vx-tool-node" }
-vx-tool-go = { version = "0.2.4", path = "../vx-tools/vx-tool-go" }
-vx-tool-rust = { version = "0.2.4", path = "../vx-tools/vx-tool-rust" }
-vx-tool-uv = { version = "0.2.4", path = "../vx-tools/vx-tool-uv" }
-vx-pm-npm = { version = "0.2.4", path = "../vx-package-managers/vx-pm-npm" }
+vx-core = { version = "0.2.5", path = "../vx-core" }
+vx-tool-node = { version = "0.2.5", path = "../vx-tools/vx-tool-node" }
+vx-tool-go = { version = "0.2.5", path = "../vx-tools/vx-tool-go" }
+vx-tool-rust = { version = "0.2.5", path = "../vx-tools/vx-tool-rust" }
+vx-tool-uv = { version = "0.2.5", path = "../vx-tools/vx-tool-uv" }
+vx-pm-npm = { version = "0.2.5", path = "../vx-package-managers/vx-pm-npm" }
 clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-core/Cargo.toml
+++ b/crates/vx-core/Cargo.toml
@@ -28,7 +28,7 @@ chrono = { version = "0.4", features = ["serde"] }
 zip = "4.0"
 tar = "0.4"
 flate2 = "1.0"
-vx-shim = { version = "0.2.2", path = "../vx-shim" }
+vx-shim = { version = "0.2.3", path = "../vx-shim" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/vx-package-managers/vx-pm-npm/Cargo.toml
+++ b/crates/vx-package-managers/vx-pm-npm/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.4", path = "../../vx-core" }
+vx-core = { version = "0.2.5", path = "../../vx-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-shim/CHANGELOG.md
+++ b/crates/vx-shim/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [0.2.3](https://github.com/loonghao/vx/compare/vx-shim-v0.2.2...vx-shim-v0.2.3) - 2025-06-18
+
+### Other
+
+- update Cargo.lock dependencies

--- a/crates/vx-shim/Cargo.toml
+++ b/crates/vx-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vx-shim"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 description = "Cross-platform shim executable for vx tool manager"

--- a/crates/vx-tools/vx-tool-go/Cargo.toml
+++ b/crates/vx-tools/vx-tool-go/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.4", path = "../../vx-core" }
+vx-core = { version = "0.2.5", path = "../../vx-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-node/Cargo.toml
+++ b/crates/vx-tools/vx-tool-node/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.4", path = "../../vx-core" }
-vx-pm-npm = { version = "0.2.4", path = "../../vx-package-managers/vx-pm-npm" }
+vx-core = { version = "0.2.5", path = "../../vx-core" }
+vx-pm-npm = { version = "0.2.5", path = "../../vx-package-managers/vx-pm-npm" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-rust/Cargo.toml
+++ b/crates/vx-tools/vx-tool-rust/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.4", path = "../../vx-core" }
+vx-core = { version = "0.2.5", path = "../../vx-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-uv/Cargo.toml
+++ b/crates/vx-tools/vx-tool-uv/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.4", path = "../../vx-core" }
+vx-core = { version = "0.2.5", path = "../../vx-core" }
 anyhow = { workspace = true }
 which = "8.0"
 async-trait = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `vx-shim`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `vx-core`: 0.2.4 -> 0.2.5
* `vx-pm-npm`: 0.2.4 -> 0.2.5
* `vx-tool-go`: 0.2.4 -> 0.2.5
* `vx-tool-node`: 0.2.4 -> 0.2.5
* `vx-tool-rust`: 0.2.4 -> 0.2.5
* `vx-tool-uv`: 0.2.4 -> 0.2.5
* `vx-cli`: 0.2.4 -> 0.2.5
* `vx`: 0.2.4 -> 0.2.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `vx-shim`

<blockquote>

## [0.2.3](https://github.com/loonghao/vx/compare/vx-shim-v0.2.2...vx-shim-v0.2.3) - 2025-06-18

### Other

- update Cargo.lock dependencies
</blockquote>

## `vx-core`

<blockquote>

## [0.2.0](https://github.com/loonghao/vx/compare/vx-core-v0.1.36...vx-core-v0.2.0) - 2025-06-15

### Bug Fixes

- resolve venv test failures and improve workspace publishing script
</blockquote>






## `vx-cli`

<blockquote>

## [0.2.0](https://github.com/loonghao/vx/compare/vx-cli-v0.1.36...vx-cli-v0.2.0) - 2025-06-15

### Bug Fixes

- remove deprecated use command and fix binary installation
- resolve venv test failures and improve workspace publishing script
- remove useless format! usage in venv command
- improve remove command error handling in force mode
- resolve CI issues and update documentation
- implement release-please best practices for output handling

### Features

- unify all workspace versions to 0.1.36
- add version numbers to workspace dependencies and automated publishing
- implement complete venv command functionality with VenvManager integration
- implement npx and uvx support with environment isolation

### Refactor

- simplify main package by reusing vx-cli main function
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).