### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.0](https://github.com/loonghao/vx/compare/v0.2.6...v0.3.0) - 2025-06-19
+
+### Added
+
+- fix compilation errors and add comprehensive test suite
+- refactor vx-core architecture with closed-loop toolchain design
+- complete vx project modular refactoring
+- [**breaking**] remove vx-shim and improve GitHub API handling
+- optimize core logic with shimexe-core integration and progress bars
+
+### Fixed
+
+- resolve coverage testing compilation errors and warnings
+- resolve Linux musl cross-compilation OpenSSL issues
+- resolve import errors and clippy warnings in tool packages
+
+### Other
+
+- *(deps)* update codecov/codecov-action action to v5
+- update README with upcoming tool support
+
 ## [0.2.6](https://github.com/loonghao/vx/compare/v0.2.5...v0.2.6) - 2025-06-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "vx"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -2580,7 +2580,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "vx-core"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "vx-dependency"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "vx-plugin"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-bun"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-go"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-node"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-npm"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-pnpm"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-rust"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-standard"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -2817,7 +2817,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-uv"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-yarn"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ name = "config_management_demo"
 path = "examples/config_management_demo.rs"
 
 [dependencies]
-vx-cli = { version = "0.2.6", path = "crates/vx-cli" }
+vx-cli = { version = "0.3.0", path = "crates/vx-cli" }
 tokio = { workspace = true }
 anyhow = { workspace = true }
 
@@ -56,19 +56,19 @@ anyhow = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 # Test dependencies for integration tests
-vx-core = { version = "0.2.6", path = "crates/vx-core" }
-vx-tool-node = { version = "0.2.6", path = "crates/vx-tools/vx-tool-node" }
-vx-tool-go = { version = "0.2.6", path = "crates/vx-tools/vx-tool-go" }
-vx-tool-rust = { version = "0.2.6", path = "crates/vx-tools/vx-tool-rust" }
-vx-tool-uv = { version = "0.2.6", path = "crates/vx-tools/vx-tool-uv" }
-vx-tool-npm = { version = "0.2.6", path = "crates/vx-tools/vx-tool-npm" }
-vx-tool-pnpm = { version = "0.2.6", path = "crates/vx-tools/vx-tool-pnpm" }
-vx-tool-yarn = { version = "0.2.6", path = "crates/vx-tools/vx-tool-yarn" }
-vx-tool-bun = { version = "0.2.6", path = "crates/vx-tools/vx-tool-bun" }
+vx-core = { version = "0.3.0", path = "crates/vx-core" }
+vx-tool-node = { version = "0.3.0", path = "crates/vx-tools/vx-tool-node" }
+vx-tool-go = { version = "0.3.0", path = "crates/vx-tools/vx-tool-go" }
+vx-tool-rust = { version = "0.3.0", path = "crates/vx-tools/vx-tool-rust" }
+vx-tool-uv = { version = "0.3.0", path = "crates/vx-tools/vx-tool-uv" }
+vx-tool-npm = { version = "0.3.0", path = "crates/vx-tools/vx-tool-npm" }
+vx-tool-pnpm = { version = "0.3.0", path = "crates/vx-tools/vx-tool-pnpm" }
+vx-tool-yarn = { version = "0.3.0", path = "crates/vx-tools/vx-tool-yarn" }
+vx-tool-bun = { version = "0.3.0", path = "crates/vx-tools/vx-tool-bun" }
 
 
 [workspace.package]
-version = "0.2.6"
+version = "0.3.0"
 edition = "2021"
 description = "Universal Development Tool Manager"
 license = "MIT"

--- a/crates/vx-cli/CHANGELOG.md
+++ b/crates/vx-cli/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.3.0](https://github.com/loonghao/vx/compare/vx-cli-v0.2.6...vx-cli-v0.3.0) - 2025-06-19
+
+### Added
+
+- fix compilation errors and add comprehensive test suite
+- refactor vx-core architecture with closed-loop toolchain design
+- complete vx project modular refactoring
+- [**breaking**] remove vx-shim and improve GitHub API handling
+- optimize core logic with shimexe-core integration and progress bars
+
+### Fixed
+
+- resolve coverage testing compilation errors and warnings
+- resolve Linux musl cross-compilation OpenSSL issues
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/crates/vx-cli/Cargo.toml
+++ b/crates/vx-cli/Cargo.toml
@@ -13,13 +13,13 @@ rust-version.workspace = true
 
 
 [dependencies]
-vx-core = { version = "0.2.6", path = "../vx-core" }
-vx-plugin = { version = "0.2.6", path = "../vx-plugin" }
-vx-tool-node = { version = "0.2.6", path = "../vx-tools/vx-tool-node" }
-vx-tool-go = { version = "0.2.6", path = "../vx-tools/vx-tool-go" }
-vx-tool-rust = { version = "0.2.6", path = "../vx-tools/vx-tool-rust" }
-vx-tool-uv = { version = "0.2.6", path = "../vx-tools/vx-tool-uv" }
-vx-tool-npm = { version = "0.2.6", path = "../vx-tools/vx-tool-npm" }
+vx-core = { version = "0.3.0", path = "../vx-core" }
+vx-plugin = { version = "0.3.0", path = "../vx-plugin" }
+vx-tool-node = { version = "0.3.0", path = "../vx-tools/vx-tool-node" }
+vx-tool-go = { version = "0.3.0", path = "../vx-tools/vx-tool-go" }
+vx-tool-rust = { version = "0.3.0", path = "../vx-tools/vx-tool-rust" }
+vx-tool-uv = { version = "0.3.0", path = "../vx-tools/vx-tool-uv" }
+vx-tool-npm = { version = "0.3.0", path = "../vx-tools/vx-tool-npm" }
 clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
@@ -47,4 +47,4 @@ test-case = { workspace = true }
 pretty_assertions = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-vx-version = { version = "0.2.0", path = "../vx-version" }
+vx-version = { version = "0.2.1", path = "../vx-version" }

--- a/crates/vx-config/CHANGELOG.md
+++ b/crates/vx-config/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/crates/vx-core/CHANGELOG.md
+++ b/crates/vx-core/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.3.0](https://github.com/loonghao/vx/compare/vx-core-v0.2.6...vx-core-v0.3.0) - 2025-06-19
+
+### Added
+
+- refactor vx-core architecture with closed-loop toolchain design
+- complete vx project modular refactoring
+- [**breaking**] remove vx-shim and improve GitHub API handling
+- optimize core logic with shimexe-core integration and progress bars
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/crates/vx-dependency/CHANGELOG.md
+++ b/crates/vx-dependency/CHANGELOG.md
@@ -6,14 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-node-v0.2.6...vx-tool-node-v0.3.0) - 2025-06-19
+## [0.3.0](https://github.com/loonghao/vx/compare/vx-dependency-v0.2.6...vx-dependency-v0.3.0) - 2025-06-19
 
 ### Added
 
-- fix compilation errors and add comprehensive test suite
 - refactor vx-core architecture with closed-loop toolchain design
-- complete vx project modular refactoring
-# Changelog
 
-All notable changes to this project will be documented in this file.
+### Fixed
 
+- resolve import errors and clippy warnings in tool packages

--- a/crates/vx-installer/CHANGELOG.md
+++ b/crates/vx-installer/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/crates/vx-plugin/CHANGELOG.md
+++ b/crates/vx-plugin/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/crates/vx-plugin/Cargo.toml
+++ b/crates/vx-plugin/Cargo.toml
@@ -29,7 +29,7 @@ which = { workspace = true }
 dirs = { workspace = true }
 
 # Internal dependencies
-vx-config = { version = "0.2.6", path = "../vx-config" }
+vx-config = { version = "0.3.0", path = "../vx-config" }
 
 # Optional dependencies for features
 mockall = { workspace = true, optional = true }

--- a/crates/vx-tool-standard/CHANGELOG.md
+++ b/crates/vx-tool-standard/CHANGELOG.md
@@ -6,14 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-node-v0.2.6...vx-tool-node-v0.3.0) - 2025-06-19
+## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-standard-v0.2.6...vx-tool-standard-v0.3.0) - 2025-06-19
 
 ### Added
 
-- fix compilation errors and add comprehensive test suite
 - refactor vx-core architecture with closed-loop toolchain design
-- complete vx project modular refactoring
-# Changelog
-
-All notable changes to this project will be documented in this file.
-

--- a/crates/vx-tools/vx-tool-bun/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-bun/CHANGELOG.md
@@ -6,14 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-node-v0.2.6...vx-tool-node-v0.3.0) - 2025-06-19
+## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-bun-v0.2.6...vx-tool-bun-v0.3.0) - 2025-06-19
 
 ### Added
 
-- fix compilation errors and add comprehensive test suite
 - refactor vx-core architecture with closed-loop toolchain design
-- complete vx project modular refactoring
-# Changelog
 
-All notable changes to this project will be documented in this file.
+### Fixed
 
+- resolve import errors and clippy warnings in tool packages

--- a/crates/vx-tools/vx-tool-bun/Cargo.toml
+++ b/crates/vx-tools/vx-tool-bun/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.6", path = "../../vx-core" }
-vx-plugin = { version = "0.2.6", path = "../../vx-plugin" }
+vx-core = { version = "0.3.0", path = "../../vx-core" }
+vx-plugin = { version = "0.3.0", path = "../../vx-plugin" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-go/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-go/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-go-v0.2.6...vx-tool-go-v0.3.0) - 2025-06-19
+
+### Added
+
+- fix compilation errors and add comprehensive test suite
+- refactor vx-core architecture with closed-loop toolchain design
+- complete vx project modular refactoring
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/crates/vx-tools/vx-tool-go/Cargo.toml
+++ b/crates/vx-tools/vx-tool-go/Cargo.toml
@@ -12,11 +12,11 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.6", path = "../../vx-core" }
-vx-installer = { version = "0.2.6", path = "../../vx-installer" }
+vx-core = { version = "0.3.0", path = "../../vx-core" }
+vx-installer = { version = "0.3.0", path = "../../vx-installer" }
 vx-tool-standard = { path = "../../vx-tool-standard" }
-vx-plugin = { version = "0.2.6", path = "../../vx-plugin" }
-vx-version = { version = "0.2.0", path = "../../vx-version" }
+vx-plugin = { version = "0.3.0", path = "../../vx-plugin" }
+vx-version = { version = "0.2.1", path = "../../vx-version" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-node/Cargo.toml
+++ b/crates/vx-tools/vx-tool-node/Cargo.toml
@@ -12,12 +12,12 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.6", path = "../../vx-core" }
-vx-installer = { version = "0.2.6", path = "../../vx-installer" }
+vx-core = { version = "0.3.0", path = "../../vx-core" }
+vx-installer = { version = "0.3.0", path = "../../vx-installer" }
 vx-tool-standard = { path = "../../vx-tool-standard" }
-vx-plugin = { version = "0.2.6", path = "../../vx-plugin" }
-vx-version = { version = "0.2.0", path = "../../vx-version" }
-vx-tool-npm = { version = "0.2.6", path = "../vx-tool-npm" }
+vx-plugin = { version = "0.3.0", path = "../../vx-plugin" }
+vx-version = { version = "0.2.1", path = "../../vx-version" }
+vx-tool-npm = { version = "0.3.0", path = "../vx-tool-npm" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-npm/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-npm/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-npm-v0.2.6...vx-tool-npm-v0.3.0) - 2025-06-19
+
+### Added
+
+- refactor vx-core architecture with closed-loop toolchain design
+
+### Fixed
+
+- resolve lifetime errors in progress reporter and test issues
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/crates/vx-tools/vx-tool-npm/Cargo.toml
+++ b/crates/vx-tools/vx-tool-npm/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.6", path = "../../vx-core" }
-vx-plugin = { version = "0.2.6", path = "../../vx-plugin" }
+vx-core = { version = "0.3.0", path = "../../vx-core" }
+vx-plugin = { version = "0.3.0", path = "../../vx-plugin" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-pnpm/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-pnpm/CHANGELOG.md
@@ -6,14 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-node-v0.2.6...vx-tool-node-v0.3.0) - 2025-06-19
+## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-pnpm-v0.2.6...vx-tool-pnpm-v0.3.0) - 2025-06-19
 
 ### Added
 
 - fix compilation errors and add comprehensive test suite
 - refactor vx-core architecture with closed-loop toolchain design
-- complete vx project modular refactoring
-# Changelog
-
-All notable changes to this project will be documented in this file.
-

--- a/crates/vx-tools/vx-tool-pnpm/Cargo.toml
+++ b/crates/vx-tools/vx-tool-pnpm/Cargo.toml
@@ -12,10 +12,10 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.6", path = "../../vx-core" }
-vx-installer = { version = "0.2.6", path = "../../vx-installer" }
+vx-core = { version = "0.3.0", path = "../../vx-core" }
+vx-installer = { version = "0.3.0", path = "../../vx-installer" }
 vx-tool-standard = { path = "../../vx-tool-standard" }
-vx-plugin = { version = "0.2.6", path = "../../vx-plugin" }
+vx-plugin = { version = "0.3.0", path = "../../vx-plugin" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-rust/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-rust/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-rust-v0.2.6...vx-tool-rust-v0.3.0) - 2025-06-19
+
+### Added
+
+- fix compilation errors and add comprehensive test suite
+- refactor vx-core architecture with closed-loop toolchain design
+- complete vx project modular refactoring
+
+### Fixed
+
+- resolve import errors and clippy warnings in tool packages
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/crates/vx-tools/vx-tool-rust/Cargo.toml
+++ b/crates/vx-tools/vx-tool-rust/Cargo.toml
@@ -12,11 +12,11 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.6", path = "../../vx-core" }
-vx-plugin = { version = "0.2.6", path = "../../vx-plugin" }
-vx-version = { version = "0.2.0", path = "../../vx-version" }
+vx-core = { version = "0.3.0", path = "../../vx-core" }
+vx-plugin = { version = "0.3.0", path = "../../vx-plugin" }
+vx-version = { version = "0.2.1", path = "../../vx-version" }
 vx-tool-standard = { path = "../../vx-tool-standard" }
-vx-installer = { version = "0.2.6", path = "../../vx-installer" }
+vx-installer = { version = "0.3.0", path = "../../vx-installer" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-uv/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-uv/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-uv-v0.2.6...vx-tool-uv-v0.3.0) - 2025-06-19
+
+### Added
+
+- fix compilation errors and add comprehensive test suite
+- refactor vx-core architecture with closed-loop toolchain design
+- complete vx project modular refactoring
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/crates/vx-tools/vx-tool-uv/Cargo.toml
+++ b/crates/vx-tools/vx-tool-uv/Cargo.toml
@@ -12,10 +12,10 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.6", path = "../../vx-core" }
-vx-installer = { version = "0.2.6", path = "../../vx-installer" }
-vx-plugin = { version = "0.2.6", path = "../../vx-plugin" }
-vx-version = { version = "0.2.0", path = "../../vx-version" }
+vx-core = { version = "0.3.0", path = "../../vx-core" }
+vx-installer = { version = "0.3.0", path = "../../vx-installer" }
+vx-plugin = { version = "0.3.0", path = "../../vx-plugin" }
+vx-version = { version = "0.2.1", path = "../../vx-version" }
 vx-tool-standard = { path = "../../vx-tool-standard" }
 anyhow = { workspace = true }
 which = "8.0"

--- a/crates/vx-tools/vx-tool-yarn/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-yarn/CHANGELOG.md
@@ -6,14 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-node-v0.2.6...vx-tool-node-v0.3.0) - 2025-06-19
+## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-yarn-v0.2.6...vx-tool-yarn-v0.3.0) - 2025-06-19
 
 ### Added
 
-- fix compilation errors and add comprehensive test suite
 - refactor vx-core architecture with closed-loop toolchain design
-- complete vx project modular refactoring
-# Changelog
 
-All notable changes to this project will be documented in this file.
+### Fixed
 
+- resolve import errors and clippy warnings in tool packages

--- a/crates/vx-tools/vx-tool-yarn/Cargo.toml
+++ b/crates/vx-tools/vx-tool-yarn/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.2.6", path = "../../vx-core" }
-vx-plugin = { version = "0.2.6", path = "../../vx-plugin" }
+vx-core = { version = "0.3.0", path = "../../vx-core" }
+vx-plugin = { version = "0.3.0", path = "../../vx-plugin" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-version/CHANGELOG.md
+++ b/crates/vx-version/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [0.2.1](https://github.com/loonghao/vx/compare/vx-version-v0.2.0...vx-version-v0.2.1) - 2025-06-19
+
+### Other
+
+- updated the following local packages: vx-plugin

--- a/crates/vx-version/Cargo.toml
+++ b/crates/vx-version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vx-version"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 description = "Version management and parsing utilities for the vx universal tool manager"
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [dependencies]
 # Core dependencies
-vx-plugin = { version = "0.2.6", path = "../vx-plugin" }
+vx-plugin = { version = "0.3.0", path = "../vx-plugin" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 async-trait = "0.1"


### PR DESCRIPTION



## 🤖 New release

* `vx-config`: 0.2.6 -> 0.3.0
* `vx-plugin`: 0.2.6 -> 0.3.0
* `vx-installer`: 0.2.6 -> 0.3.0
* `vx-core`: 0.2.6 -> 0.3.0 (⚠ API breaking changes)
* `vx-tool-standard`: 0.2.6 -> 0.3.0
* `vx-tool-go`: 0.2.6 -> 0.3.0 (✓ API compatible changes)
* `vx-tool-npm`: 0.2.6 -> 0.3.0
* `vx-tool-node`: 0.2.6 -> 0.3.0 (✓ API compatible changes)
* `vx-tool-rust`: 0.2.6 -> 0.3.0 (✓ API compatible changes)
* `vx-tool-uv`: 0.2.6 -> 0.3.0 (✓ API compatible changes)
* `vx-cli`: 0.2.6 -> 0.3.0 (✓ API compatible changes)
* `vx-dependency`: 0.2.6 -> 0.3.0
* `vx-tool-pnpm`: 0.2.6 -> 0.3.0
* `vx-tool-yarn`: 0.2.6 -> 0.3.0
* `vx-tool-bun`: 0.2.6 -> 0.3.0
* `vx`: 0.2.6 -> 0.3.0 (✓ API compatible changes)
* `vx-version`: 0.2.0 -> 0.2.1

### ⚠ `vx-core` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type VxError is no longer UnwindSafe, in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:16
  type VxError is no longer RefUnwindSafe, in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:16

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field VxConfig.install_dir in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:237
  field VxConfig.cache_dir in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:239
  field VxConfig.platform in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:241
  field Version.version in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:77
  field Version.prerelease in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:79
  field Version.metadata in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:81
  field InstallConfig.tool in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:125
  field InstallConfig.platform in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:129
  field InstallConfig.method in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:135

--- failure declarative_macro_missing: macro_rules declaration removed or renamed ---

Description:
A `macro_rules!` declarative macro cannot be invoked by its prior name. The macro may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/reference/macros-by-example.html#path-based-scope
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/declarative_macro_missing.ron

Failed in:
  macro tool_not_found, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:245
  macro version_not_found, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:263
  macro tool_not_installed, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:254

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type Platform no longer derives Eq, in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:41
  type Platform no longer derives Hash, in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:41
  type VxError no longer derives Clone, in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:16

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_missing.ron

Failed in:
  enum vx_core::installer::InstallMethod, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:67
  enum vx_core::package_manager::Ecosystem, previously in file /tmp/.tmprscCMO/vx-core/src/package_manager.rs:67
  enum vx_core::Ecosystem, previously in file /tmp/.tmprscCMO/vx-core/src/package_manager.rs:67
  enum vx_core::config::UpdateFrequency, previously in file /tmp/.tmprscCMO/vx-core/src/config.rs:108
  enum vx_core::installer::ArchiveFormat, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:86
  enum vx_core::package_manager::SystemType, previously in file /tmp/.tmprscCMO/vx-core/src/package_manager.rs:85
  enum vx_core::config_figment::ProjectType, previously in file /tmp/.tmprscCMO/vx-core/src/config_figment.rs:94
  enum vx_core::ProjectType, previously in file /tmp/.tmprscCMO/vx-core/src/config_figment.rs:94
  enum vx_core::package_manager::LinuxDistro, previously in file /tmp/.tmprscCMO/vx-core/src/package_manager.rs:94
  enum vx_core::platform::Architecture, previously in file /tmp/.tmprscCMO/vx-core/src/platform.rs:17
  enum vx_core::Architecture, previously in file /tmp/.tmprscCMO/vx-core/src/platform.rs:17
  enum vx_core::installer::InstallStage, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:107
  enum vx_core::InstallStage, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:107
  enum vx_core::error::VxError, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:12
  enum vx_core::package_manager::IsolationLevel, previously in file /tmp/.tmprscCMO/vx-core/src/package_manager.rs:120
  enum vx_core::platform::OperatingSystem, previously in file /tmp/.tmprscCMO/vx-core/src/platform.rs:7
  enum vx_core::OperatingSystem, previously in file /tmp/.tmprscCMO/vx-core/src/platform.rs:7

--- failure enum_struct_variant_changed_kind: An enum struct variant changed kind ---

Description:
A pub enum's struct variant with at least one pub field has changed to a different kind of enum variant, breaking access to its pub fields.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_struct_variant_changed_kind.ron

Failed in:
  variant VxError::Other in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:36

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field tool of variant VxError::ToolNotFound in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:18
  field tool of variant VxError::VersionNotFound in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:21
  field tool of variant VxError::InstallationFailed in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:24
  field reason of variant VxError::InstallationFailed in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:24

--- failure enum_struct_variant_field_missing: pub enum struct variant's field removed or renamed ---

Description:
A publicly-visible enum has a struct variant whose field is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_struct_variant_field_missing.ron

Failed in:
  field tool_name of variant VxError::ToolNotFound, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:14
  field tool_name of variant VxError::VersionNotFound, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:20
  field tool_name of variant VxError::InstallationFailed, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:24
  field version of variant VxError::InstallationFailed, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:25
  field message of variant VxError::InstallationFailed, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:26

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant VxError:ExecutionFailed in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:27
  variant VxError:Io in /tmp/.tmpFa9Hke/vx/crates/vx-core/src/core.rs:33

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_missing.ron

Failed in:
  variant VxError::ToolNotInstalled, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:17
  variant VxError::VersionAlreadyInstalled, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:30
  variant VxError::VersionNotInstalled, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:33
  variant VxError::DownloadUrlNotFound, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:36
  variant VxError::DownloadFailed, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:39
  variant VxError::ConfigurationError, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:42
  variant VxError::ExecutableNotFound, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:45
  variant VxError::IoError, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:54
  variant VxError::NetworkError, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:57
  variant VxError::ParseError, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:60
  variant VxError::PluginError, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:63
  variant VxError::PackageManagerError, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:69
  variant VxError::PermissionError, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:72
  variant VxError::ChecksumError, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:75
  variant VxError::UnsupportedOperation, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:78
  variant VxError::ShimNotFound, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:81

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_missing.ron

Failed in:
  function vx_core::install_configs::supports_auto_install, previously in file /tmp/.tmprscCMO/vx-core/src/install_configs.rs:203
  function vx_core::supports_auto_install, previously in file /tmp/.tmprscCMO/vx-core/src/install_configs.rs:203
  function vx_core::version::version_utils::sort_versions_desc, previously in file /tmp/.tmprscCMO/vx-core/src/version.rs:113
  function vx_core::http::get_http_client, previously in file /tmp/.tmprscCMO/vx-core/src/http.rs:12
  function vx_core::get_http_client, previously in file /tmp/.tmprscCMO/vx-core/src/http.rs:12
  function vx_core::install_configs::get_available_install_methods, previously in file /tmp/.tmprscCMO/vx-core/src/install_configs.rs:162
  function vx_core::version::version_utils::take_latest, previously in file /tmp/.tmprscCMO/vx-core/src/version.rs:128
  function vx_core::install_configs::get_manual_install_instructions, previously in file /tmp/.tmprscCMO/vx-core/src/install_configs.rs:208
  function vx_core::get_manual_install_instructions, previously in file /tmp/.tmprscCMO/vx-core/src/install_configs.rs:208
  function vx_core::version::version_utils::filter_stable_only, previously in file /tmp/.tmprscCMO/vx-core/src/version.rs:123
  function vx_core::install_configs::get_install_config, previously in file /tmp/.tmprscCMO/vx-core/src/install_configs.rs:7
  function vx_core::get_install_config, previously in file /tmp/.tmprscCMO/vx-core/src/install_configs.rs:7

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  Version::parse, previously in file /tmp/.tmprscCMO/vx-core/src/version_manager.rs:17
  Version::as_string, previously in file /tmp/.tmprscCMO/vx-core/src/version_manager.rs:46
  Platform::current_os, previously in file /tmp/.tmprscCMO/vx-core/src/platform.rs:42
  Platform::current_arch, previously in file /tmp/.tmprscCMO/vx-core/src/platform.rs:57
  Platform::node_platform_string, previously in file /tmp/.tmprscCMO/vx-core/src/platform.rs:72
  Platform::go_platform_string, previously in file /tmp/.tmprscCMO/vx-core/src/platform.rs:91
  Platform::archive_extension, previously in file /tmp/.tmprscCMO/vx-core/src/platform.rs:112
  Platform::executable_extension, previously in file /tmp/.tmprscCMO/vx-core/src/platform.rs:120
  InstallConfig::new, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:127
  InstallConfig::with_method, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:141
  InstallConfig::with_download_url, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:147
  InstallConfig::with_force, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:153
  InstallConfig::with_metadata, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:159

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/module_missing.ron

Failed in:
  mod vx_core::venv, previously in file /tmp/.tmprscCMO/vx-core/src/venv.rs:1
  mod vx_core::installer, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:1
  mod vx_core::proxy, previously in file /tmp/.tmprscCMO/vx-core/src/proxy.rs:1
  mod vx_core::version::version_utils, previously in file /tmp/.tmprscCMO/vx-core/src/version.rs:109
  mod vx_core::environment, previously in file /tmp/.tmprscCMO/vx-core/src/environment.rs:1
  mod vx_core::error, previously in file /tmp/.tmprscCMO/vx-core/src/error.rs:1
  mod vx_core::version_parser, previously in file /tmp/.tmprscCMO/vx-core/src/version_parser.rs:1
  mod vx_core::version_manager, previously in file /tmp/.tmprscCMO/vx-core/src/version_manager.rs:1
  mod vx_core::tool, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:1
  mod vx_core::config_figment, previously in file /tmp/.tmprscCMO/vx-core/src/config_figment.rs:1
  mod vx_core::platform, previously in file /tmp/.tmprscCMO/vx-core/src/platform.rs:1
  mod vx_core::version, previously in file /tmp/.tmprscCMO/vx-core/src/version.rs:1
  mod vx_core::plugin, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:1
  mod vx_core::config, previously in file /tmp/.tmprscCMO/vx-core/src/config.rs:1
  mod vx_core::http, previously in file /tmp/.tmprscCMO/vx-core/src/http.rs:1
  mod vx_core::symlink_venv, previously in file /tmp/.tmprscCMO/vx-core/src/symlink_venv.rs:1
  mod vx_core::global_tool_manager, previously in file /tmp/.tmprscCMO/vx-core/src/global_tool_manager.rs:1
  mod vx_core::registry, previously in file /tmp/.tmprscCMO/vx-core/src/registry.rs:1
  mod vx_core::shim_integration, previously in file /tmp/.tmprscCMO/vx-core/src/shim_integration.rs:1
  mod vx_core::downloader, previously in file /tmp/.tmprscCMO/vx-core/src/downloader.rs:1
  mod vx_core::package_manager, previously in file /tmp/.tmprscCMO/vx-core/src/package_manager.rs:1
  mod vx_core::install_configs, previously in file /tmp/.tmprscCMO/vx-core/src/install_configs.rs:1
  mod vx_core::url_builder, previously in file /tmp/.tmprscCMO/vx-core/src/url_builder.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct vx_core::installer::InstallResult, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:118
  struct vx_core::environment::ToolInstallation, previously in file /tmp/.tmprscCMO/vx-core/src/environment.rs:27
  struct vx_core::ToolInstallation, previously in file /tmp/.tmprscCMO/vx-core/src/environment.rs:27
  struct vx_core::http::HttpUtils, previously in file /tmp/.tmprscCMO/vx-core/src/http.rs:23
  struct vx_core::HttpUtils, previously in file /tmp/.tmprscCMO/vx-core/src/http.rs:23
  struct vx_core::url_builder::GoUrlBuilder, previously in file /tmp/.tmprscCMO/vx-core/src/url_builder.rs:56
  struct vx_core::GoUrlBuilder, previously in file /tmp/.tmprscCMO/vx-core/src/url_builder.rs:56
  struct vx_core::config::TelemetryConfig, previously in file /tmp/.tmprscCMO/vx-core/src/config.rs:117
  struct vx_core::config::ToolConfig, previously in file /tmp/.tmprscCMO/vx-core/src/config.rs:33
  struct vx_core::ToolConfig, previously in file /tmp/.tmprscCMO/vx-core/src/config.rs:33
  struct vx_core::environment::VxEnvironment, previously in file /tmp/.tmprscCMO/vx-core/src/environment.rs:16
  struct vx_core::VxEnvironment, previously in file /tmp/.tmprscCMO/vx-core/src/environment.rs:16
  struct vx_core::venv::ProjectConfig, previously in file /tmp/.tmprscCMO/vx-core/src/venv.rs:32
  struct vx_core::ProjectConfig, previously in file /tmp/.tmprscCMO/vx-core/src/venv.rs:32
  struct vx_core::plugin::ToolMetadata, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:617
  struct vx_core::ToolMetadata, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:617
  struct vx_core::venv::VenvConfig, previously in file /tmp/.tmprscCMO/vx-core/src/venv.rs:17
  struct vx_core::VenvConfig, previously in file /tmp/.tmprscCMO/vx-core/src/venv.rs:17
  struct vx_core::tool::ToolContext, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:145
  struct vx_core::ToolContext, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:145
  struct vx_core::config::GlobalConfig, previously in file /tmp/.tmprscCMO/vx-core/src/config.rs:61
  struct vx_core::GlobalConfig, previously in file /tmp/.tmprscCMO/vx-core/src/config.rs:61
  struct vx_core::symlink_venv::SymlinkVenv, previously in file /tmp/.tmprscCMO/vx-core/src/symlink_venv.rs:14
  struct vx_core::SymlinkVenv, previously in file /tmp/.tmprscCMO/vx-core/src/symlink_venv.rs:14
  struct vx_core::plugin::StandardPlugin, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:512
  struct vx_core::StandardPlugin, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:512
  struct vx_core::environment::EnvironmentConfig, previously in file /tmp/.tmprscCMO/vx-core/src/environment.rs:44
  struct vx_core::EnvironmentConfig, previously in file /tmp/.tmprscCMO/vx-core/src/environment.rs:44
  struct vx_core::version_manager::Version, previously in file /tmp/.tmprscCMO/vx-core/src/version_manager.rs:9
  struct vx_core::url_builder::NodeUrlBuilder, previously in file /tmp/.tmprscCMO/vx-core/src/url_builder.rs:13
  struct vx_core::NodeUrlBuilder, previously in file /tmp/.tmprscCMO/vx-core/src/url_builder.rs:13
  struct vx_core::config::ProxyConfig, previously in file /tmp/.tmprscCMO/vx-core/src/config.rs:92
  struct vx_core::tool::ToolStatus, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:190
  struct vx_core::ToolStatus, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:190
  struct vx_core::installer::InstallProgress, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:99
  struct vx_core::InstallProgress, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:99
  struct vx_core::url_builder::RustUrlBuilder, previously in file /tmp/.tmprscCMO/vx-core/src/url_builder.rs:99
  struct vx_core::RustUrlBuilder, previously in file /tmp/.tmprscCMO/vx-core/src/url_builder.rs:99
  struct vx_core::version::VersionInfo, previously in file /tmp/.tmprscCMO/vx-core/src/version.rs:36
  struct vx_core::VersionInfo, previously in file /tmp/.tmprscCMO/vx-core/src/version.rs:36
  struct vx_core::config_figment::ToolConfig, previously in file /tmp/.tmprscCMO/vx-core/src/config_figment.rs:56
  struct vx_core::tool::ToolInfo, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:179
  struct vx_core::ToolInfo, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:179
  struct vx_core::config_figment::ProjectInfo, previously in file /tmp/.tmprscCMO/vx-core/src/config_figment.rs:86
  struct vx_core::ProjectInfo, previously in file /tmp/.tmprscCMO/vx-core/src/config_figment.rs:86
  struct vx_core::venv::ProjectSettings, previously in file /tmp/.tmprscCMO/vx-core/src/venv.rs:41
  struct vx_core::ProjectSettings, previously in file /tmp/.tmprscCMO/vx-core/src/venv.rs:41
  struct vx_core::config::PluginConfig, previously in file /tmp/.tmprscCMO/vx-core/src/config.rs:124
  struct vx_core::config_figment::VxConfig, previously in file /tmp/.tmprscCMO/vx-core/src/config_figment.rs:18
  struct vx_core::global_tool_manager::VenvDependency, previously in file /tmp/.tmprscCMO/vx-core/src/global_tool_manager.rs:29
  struct vx_core::VenvDependency, previously in file /tmp/.tmprscCMO/vx-core/src/global_tool_manager.rs:29
  struct vx_core::package_manager::PackageSpec, previously in file /tmp/.tmprscCMO/vx-core/src/package_manager.rs:46
  struct vx_core::PackageSpec, previously in file /tmp/.tmprscCMO/vx-core/src/package_manager.rs:46
  struct vx_core::global_tool_manager::GlobalToolInfo, previously in file /tmp/.tmprscCMO/vx-core/src/global_tool_manager.rs:14
  struct vx_core::GlobalToolInfo, previously in file /tmp/.tmprscCMO/vx-core/src/global_tool_manager.rs:14
  struct vx_core::venv::VenvManager, previously in file /tmp/.tmprscCMO/vx-core/src/venv.rs:58
  struct vx_core::VenvManager, previously in file /tmp/.tmprscCMO/vx-core/src/venv.rs:58
  struct vx_core::plugin::ConfigurableTool, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:556
  struct vx_core::ConfigurableTool, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:556
  struct vx_core::platform::Platform, previously in file /tmp/.tmprscCMO/vx-core/src/platform.rs:27
  struct vx_core::package_manager::PackageInfo, previously in file /tmp/.tmprscCMO/vx-core/src/package_manager.rs:55
  struct vx_core::PackageInfo, previously in file /tmp/.tmprscCMO/vx-core/src/package_manager.rs:55
  struct vx_core::url_builder::GenericUrlBuilder, previously in file /tmp/.tmprscCMO/vx-core/src/url_builder.rs:253
  struct vx_core::GenericUrlBuilder, previously in file /tmp/.tmprscCMO/vx-core/src/url_builder.rs:253
  struct vx_core::registry::PluginRegistry, previously in file /tmp/.tmprscCMO/vx-core/src/registry.rs:7
  struct vx_core::PluginRegistry, previously in file /tmp/.tmprscCMO/vx-core/src/registry.rs:7
  struct vx_core::config_figment::FigmentConfigManager, previously in file /tmp/.tmprscCMO/vx-core/src/config_figment.rs:150
  struct vx_core::FigmentConfigManager, previously in file /tmp/.tmprscCMO/vx-core/src/config_figment.rs:150
  struct vx_core::version_parser::NodeVersionParser, previously in file /tmp/.tmprscCMO/vx-core/src/version_parser.rs:13
  struct vx_core::NodeVersionParser, previously in file /tmp/.tmprscCMO/vx-core/src/version_parser.rs:13
  struct vx_core::downloader::ToolDownloader, previously in file /tmp/.tmprscCMO/vx-core/src/downloader.rs:8
  struct vx_core::ToolDownloader, previously in file /tmp/.tmprscCMO/vx-core/src/downloader.rs:8
  struct vx_core::installer::InstallConfig, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:39
  struct vx_core::shim_integration::VxShimManager, previously in file /tmp/.tmprscCMO/vx-core/src/shim_integration.rs:13
  struct vx_core::VxShimManager, previously in file /tmp/.tmprscCMO/vx-core/src/shim_integration.rs:13
  struct vx_core::package_manager::PackageManagerConfig, previously in file /tmp/.tmprscCMO/vx-core/src/package_manager.rs:107
  struct vx_core::version_parser::GoVersionParser, previously in file /tmp/.tmprscCMO/vx-core/src/version_parser.rs:95
  struct vx_core::GoVersionParser, previously in file /tmp/.tmprscCMO/vx-core/src/version_parser.rs:95
  struct vx_core::version_manager::VersionManager, previously in file /tmp/.tmprscCMO/vx-core/src/version_manager.rs:60
  struct vx_core::VersionManager, previously in file /tmp/.tmprscCMO/vx-core/src/version_manager.rs:60
  struct vx_core::proxy::ProxyContext, previously in file /tmp/.tmprscCMO/vx-core/src/proxy.rs:29
  struct vx_core::ProxyContext, previously in file /tmp/.tmprscCMO/vx-core/src/proxy.rs:29
  struct vx_core::version_parser::VersionParserUtils, previously in file /tmp/.tmprscCMO/vx-core/src/version_parser.rs:293
  struct vx_core::VersionParserUtils, previously in file /tmp/.tmprscCMO/vx-core/src/version_parser.rs:293
  struct vx_core::config::UpdateCheckConfig, previously in file /tmp/.tmprscCMO/vx-core/src/config.rs:100
  struct vx_core::config_figment::ConfigStatus, previously in file /tmp/.tmprscCMO/vx-core/src/config_figment.rs:105
  struct vx_core::ConfigStatus, previously in file /tmp/.tmprscCMO/vx-core/src/config_figment.rs:105
  struct vx_core::version_parser::GitHubVersionParser, previously in file /tmp/.tmprscCMO/vx-core/src/version_parser.rs:159
  struct vx_core::GitHubVersionParser, previously in file /tmp/.tmprscCMO/vx-core/src/version_parser.rs:159
  struct vx_core::config_figment::RegistryConfig, previously in file /tmp/.tmprscCMO/vx-core/src/config_figment.rs:69
  struct vx_core::tool::ToolExecutionResult, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:171
  struct vx_core::ToolExecutionResult, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:171
  struct vx_core::url_builder::UvUrlBuilder, previously in file /tmp/.tmprscCMO/vx-core/src/url_builder.rs:196
  struct vx_core::UvUrlBuilder, previously in file /tmp/.tmprscCMO/vx-core/src/url_builder.rs:196
  struct vx_core::symlink_venv::SymlinkVenvManager, previously in file /tmp/.tmprscCMO/vx-core/src/symlink_venv.rs:29
  struct vx_core::SymlinkVenvManager, previously in file /tmp/.tmprscCMO/vx-core/src/symlink_venv.rs:29
  struct vx_core::global_tool_manager::GlobalToolManager, previously in file /tmp/.tmprscCMO/vx-core/src/global_tool_manager.rs:40
  struct vx_core::GlobalToolManager, previously in file /tmp/.tmprscCMO/vx-core/src/global_tool_manager.rs:40
  struct vx_core::installer::DefaultInstaller, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:166
  struct vx_core::proxy::ToolProxy, previously in file /tmp/.tmprscCMO/vx-core/src/proxy.rs:18
  struct vx_core::ToolProxy, previously in file /tmp/.tmprscCMO/vx-core/src/proxy.rs:18
  struct vx_core::registry::ToolRegistry, previously in file /tmp/.tmprscCMO/vx-core/src/registry.rs:155
  struct vx_core::ToolRegistry, previously in file /tmp/.tmprscCMO/vx-core/src/registry.rs:155
  struct vx_core::config_figment::LayerInfo, previously in file /tmp/.tmprscCMO/vx-core/src/config_figment.rs:114
  struct vx_core::url_builder::PythonUrlBuilder, previously in file /tmp/.tmprscCMO/vx-core/src/url_builder.rs:131
  struct vx_core::PythonUrlBuilder, previously in file /tmp/.tmprscCMO/vx-core/src/url_builder.rs:131
  struct vx_core::config_figment::DefaultConfig, previously in file /tmp/.tmprscCMO/vx-core/src/config_figment.rs:29
  struct vx_core::DefaultConfig, previously in file /tmp/.tmprscCMO/vx-core/src/config_figment.rs:29

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field major of struct Version, previously in file /tmp/.tmprscCMO/vx-core/src/version_manager.rs:10
  field minor of struct Version, previously in file /tmp/.tmprscCMO/vx-core/src/version_manager.rs:11
  field patch of struct Version, previously in file /tmp/.tmprscCMO/vx-core/src/version_manager.rs:12
  field pre of struct Version, previously in file /tmp/.tmprscCMO/vx-core/src/version_manager.rs:13
  field defaults of struct VxConfig, previously in file /tmp/.tmprscCMO/vx-core/src/config_figment.rs:20
  field tool_name of struct InstallConfig, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:41
  field install_method of struct InstallConfig, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:47
  field force of struct InstallConfig, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:56
  field checksum of struct InstallConfig, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:59
  field metadata of struct InstallConfig, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:62

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_missing.ron

Failed in:
  trait vx_core::tool::AsyncTool, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:10
  trait vx_core::AsyncTool, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:10
  trait vx_core::plugin::VxPlugin, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:462
  trait vx_core::VxPlugin, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:462
  trait vx_core::config::ConfigManager, previously in file /tmp/.tmprscCMO/vx-core/src/config.rs:8
  trait vx_core::plugin::VxPackageManager, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:337
  trait vx_core::VxPackageManager, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:337
  trait vx_core::installer::Installer, previously in file /tmp/.tmprscCMO/vx-core/src/installer.rs:12
  trait vx_core::version::VersionFetcher, previously in file /tmp/.tmprscCMO/vx-core/src/version.rs:8
  trait vx_core::tool::Configuration, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:88
  trait vx_core::Configuration, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:88
  trait vx_core::tool::Plugin, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:122
  trait vx_core::Plugin, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:122
  trait vx_core::version_parser::VersionParser, previously in file /tmp/.tmprscCMO/vx-core/src/version_parser.rs:7
  trait vx_core::plugin::UrlBuilder, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:322
  trait vx_core::UrlBuilder, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:322
  trait vx_core::url_builder::UrlBuilder, previously in file /tmp/.tmprscCMO/vx-core/src/url_builder.rs:6
  trait vx_core::plugin::VxTool, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:19
  trait vx_core::VxTool, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:19
  trait vx_core::tool::Tool, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:198
  trait vx_core::Tool, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:198
  trait vx_core::tool::Environment, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:67
  trait vx_core::Environment, previously in file /tmp/.tmprscCMO/vx-core/src/tool.rs:67
  trait vx_core::plugin::VersionParser, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:328
  trait vx_core::VersionParser, previously in file /tmp/.tmprscCMO/vx-core/src/plugin.rs:328
  trait vx_core::package_manager::PackageManager, previously in file /tmp/.tmprscCMO/vx-core/src/package_manager.rs:9
```

<details><summary><i><b>Changelog</b></i></summary><p>




## `vx-core`

<blockquote>

## [0.3.0](https://github.com/loonghao/vx/compare/vx-core-v0.2.6...vx-core-v0.3.0) - 2025-06-19

### Added

- refactor vx-core architecture with closed-loop toolchain design
- complete vx project modular refactoring
- [**breaking**] remove vx-shim and improve GitHub API handling
- optimize core logic with shimexe-core integration and progress bars
</blockquote>

## `vx-tool-standard`

<blockquote>

## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-standard-v0.2.6...vx-tool-standard-v0.3.0) - 2025-06-19

### Added

- refactor vx-core architecture with closed-loop toolchain design
</blockquote>

## `vx-tool-go`

<blockquote>

## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-go-v0.2.6...vx-tool-go-v0.3.0) - 2025-06-19

### Added

- fix compilation errors and add comprehensive test suite
- refactor vx-core architecture with closed-loop toolchain design
- complete vx project modular refactoring
</blockquote>

## `vx-tool-npm`

<blockquote>

## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-npm-v0.2.6...vx-tool-npm-v0.3.0) - 2025-06-19

### Added

- refactor vx-core architecture with closed-loop toolchain design

### Fixed

- resolve lifetime errors in progress reporter and test issues
</blockquote>

## `vx-tool-node`

<blockquote>

## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-node-v0.2.6...vx-tool-node-v0.3.0) - 2025-06-19

### Added

- fix compilation errors and add comprehensive test suite
- refactor vx-core architecture with closed-loop toolchain design
- complete vx project modular refactoring
</blockquote>

## `vx-tool-rust`

<blockquote>

## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-rust-v0.2.6...vx-tool-rust-v0.3.0) - 2025-06-19

### Added

- fix compilation errors and add comprehensive test suite
- refactor vx-core architecture with closed-loop toolchain design
- complete vx project modular refactoring

### Fixed

- resolve import errors and clippy warnings in tool packages
</blockquote>

## `vx-tool-uv`

<blockquote>

## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-uv-v0.2.6...vx-tool-uv-v0.3.0) - 2025-06-19

### Added

- fix compilation errors and add comprehensive test suite
- refactor vx-core architecture with closed-loop toolchain design
- complete vx project modular refactoring
</blockquote>

## `vx-cli`

<blockquote>

## [0.3.0](https://github.com/loonghao/vx/compare/vx-cli-v0.2.6...vx-cli-v0.3.0) - 2025-06-19

### Added

- fix compilation errors and add comprehensive test suite
- refactor vx-core architecture with closed-loop toolchain design
- complete vx project modular refactoring
- [**breaking**] remove vx-shim and improve GitHub API handling
- optimize core logic with shimexe-core integration and progress bars

### Fixed

- resolve coverage testing compilation errors and warnings
- resolve Linux musl cross-compilation OpenSSL issues
</blockquote>

## `vx-dependency`

<blockquote>

## [0.3.0](https://github.com/loonghao/vx/compare/vx-dependency-v0.2.6...vx-dependency-v0.3.0) - 2025-06-19

### Added

- refactor vx-core architecture with closed-loop toolchain design

### Fixed

- resolve import errors and clippy warnings in tool packages
</blockquote>

## `vx-tool-pnpm`

<blockquote>

## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-pnpm-v0.2.6...vx-tool-pnpm-v0.3.0) - 2025-06-19

### Added

- fix compilation errors and add comprehensive test suite
- refactor vx-core architecture with closed-loop toolchain design
</blockquote>

## `vx-tool-yarn`

<blockquote>

## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-yarn-v0.2.6...vx-tool-yarn-v0.3.0) - 2025-06-19

### Added

- refactor vx-core architecture with closed-loop toolchain design

### Fixed

- resolve import errors and clippy warnings in tool packages
</blockquote>

## `vx-tool-bun`

<blockquote>

## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-bun-v0.2.6...vx-tool-bun-v0.3.0) - 2025-06-19

### Added

- refactor vx-core architecture with closed-loop toolchain design

### Fixed

- resolve import errors and clippy warnings in tool packages
</blockquote>


## `vx-version`

<blockquote>

## [0.2.1](https://github.com/loonghao/vx/compare/vx-version-v0.2.0...vx-version-v0.2.1) - 2025-06-19

### Other

- updated the following local packages: vx-plugin
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).