### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.0](https://github.com/loonghao/vx/compare/v0.3.0...v0.4.0) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
+
 ## [0.3.0](https://github.com/loonghao/vx/compare/v0.2.6...v0.3.0) - 2025-06-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "vx"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -2514,7 +2514,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "vx-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2592,7 +2592,7 @@ dependencies = [
 
 [[package]]
 name = "vx-dependency"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "vx-plugin"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-bun"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-go"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-node"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-npm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-pnpm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-rust"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-standard"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-uv"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "vx-tool-yarn"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2797,7 +2797,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ name = "config_management_demo"
 path = "examples/config_management_demo.rs"
 
 [dependencies]
-vx-cli = { version = "0.3.0", path = "crates/vx-cli" }
+vx-cli = { version = "0.4.0", path = "crates/vx-cli" }
 tokio = { workspace = true }
 anyhow = { workspace = true }
 
@@ -57,19 +57,19 @@ anyhow = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 # Test dependencies for integration tests
-vx-core = { version = "0.3.0", path = "crates/vx-core" }
-vx-tool-node = { version = "0.3.0", path = "crates/vx-tools/vx-tool-node" }
-vx-tool-go = { version = "0.3.0", path = "crates/vx-tools/vx-tool-go" }
-vx-tool-rust = { version = "0.3.0", path = "crates/vx-tools/vx-tool-rust" }
-vx-tool-uv = { version = "0.3.0", path = "crates/vx-tools/vx-tool-uv" }
-vx-tool-npm = { version = "0.3.0", path = "crates/vx-tools/vx-tool-npm" }
-vx-tool-pnpm = { version = "0.3.0", path = "crates/vx-tools/vx-tool-pnpm" }
-vx-tool-yarn = { version = "0.3.0", path = "crates/vx-tools/vx-tool-yarn" }
-vx-tool-bun = { version = "0.3.0", path = "crates/vx-tools/vx-tool-bun" }
+vx-core = { version = "0.4.0", path = "crates/vx-core" }
+vx-tool-node = { version = "0.4.0", path = "crates/vx-tools/vx-tool-node" }
+vx-tool-go = { version = "0.4.0", path = "crates/vx-tools/vx-tool-go" }
+vx-tool-rust = { version = "0.4.0", path = "crates/vx-tools/vx-tool-rust" }
+vx-tool-uv = { version = "0.4.0", path = "crates/vx-tools/vx-tool-uv" }
+vx-tool-npm = { version = "0.4.0", path = "crates/vx-tools/vx-tool-npm" }
+vx-tool-pnpm = { version = "0.4.0", path = "crates/vx-tools/vx-tool-pnpm" }
+vx-tool-yarn = { version = "0.4.0", path = "crates/vx-tools/vx-tool-yarn" }
+vx-tool-bun = { version = "0.4.0", path = "crates/vx-tools/vx-tool-bun" }
 
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Universal Development Tool Manager"
 license = "MIT"

--- a/crates/vx-cli/CHANGELOG.md
+++ b/crates/vx-cli/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.0](https://github.com/loonghao/vx/compare/vx-cli-v0.3.0...vx-cli-v0.4.0) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
+
 ## [0.3.0](https://github.com/loonghao/vx/compare/vx-cli-v0.2.6...vx-cli-v0.3.0) - 2025-06-19
 
 ### Added

--- a/crates/vx-cli/Cargo.toml
+++ b/crates/vx-cli/Cargo.toml
@@ -13,14 +13,14 @@ rust-version.workspace = true
 
 
 [dependencies]
-vx-core = { version = "0.3.0", path = "../vx-core" }
-vx-plugin = { version = "0.3.0", path = "../vx-plugin" }
-vx-paths = { version = "0.3.0", path = "../vx-paths" }
-vx-tool-node = { version = "0.3.0", path = "../vx-tools/vx-tool-node" }
-vx-tool-go = { version = "0.3.0", path = "../vx-tools/vx-tool-go" }
-vx-tool-rust = { version = "0.3.0", path = "../vx-tools/vx-tool-rust" }
-vx-tool-uv = { version = "0.3.0", path = "../vx-tools/vx-tool-uv" }
-vx-tool-npm = { version = "0.3.0", path = "../vx-tools/vx-tool-npm" }
+vx-core = { version = "0.4.0", path = "../vx-core" }
+vx-plugin = { version = "0.4.0", path = "../vx-plugin" }
+vx-paths = { version = "0.3.1", path = "../vx-paths" }
+vx-tool-node = { version = "0.4.0", path = "../vx-tools/vx-tool-node" }
+vx-tool-go = { version = "0.4.0", path = "../vx-tools/vx-tool-go" }
+vx-tool-rust = { version = "0.4.0", path = "../vx-tools/vx-tool-rust" }
+vx-tool-uv = { version = "0.4.0", path = "../vx-tools/vx-tool-uv" }
+vx-tool-npm = { version = "0.4.0", path = "../vx-tools/vx-tool-npm" }
 clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
@@ -52,4 +52,4 @@ test-case = { workspace = true }
 pretty_assertions = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-vx-version = { version = "0.2.1", path = "../vx-version" }
+vx-version = { version = "0.2.2", path = "../vx-version" }

--- a/crates/vx-config/CHANGELOG.md
+++ b/crates/vx-config/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.4.0](https://github.com/loonghao/vx/compare/vx-config-v0.3.0...vx-config-v0.4.0) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
 ## [Unreleased]
 
 ## [0.3.0] - 2025-01-19

--- a/crates/vx-core/CHANGELOG.md
+++ b/crates/vx-core/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.0](https://github.com/loonghao/vx/compare/vx-core-v0.3.0...vx-core-v0.4.0) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
+
 ## [0.3.0](https://github.com/loonghao/vx/compare/vx-core-v0.2.6...vx-core-v0.3.0) - 2025-06-19
 
 ### Added

--- a/crates/vx-dependency/CHANGELOG.md
+++ b/crates/vx-dependency/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.4.0](https://github.com/loonghao/vx/compare/vx-dependency-v0.3.0...vx-dependency-v0.4.0) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
 ## [Unreleased]
 
 ## [0.3.0] - 2025-06-19

--- a/crates/vx-installer/CHANGELOG.md
+++ b/crates/vx-installer/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.4.0](https://github.com/loonghao/vx/compare/vx-installer-v0.3.0...vx-installer-v0.4.0) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
 ## [Unreleased]
 
 ## [0.3.0] - 2025-01-19

--- a/crates/vx-paths/CHANGELOG.md
+++ b/crates/vx-paths/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.3.1](https://github.com/loonghao/vx/compare/vx-paths-v0.3.0...vx-paths-v0.3.1) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
 ## [Unreleased]
 
 ## [0.3.0] - 2025-01-19

--- a/crates/vx-paths/Cargo.toml
+++ b/crates/vx-paths/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vx-paths"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Cross-platform path management for vx tool installations"
 license = "MIT"

--- a/crates/vx-plugin/CHANGELOG.md
+++ b/crates/vx-plugin/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.4.0](https://github.com/loonghao/vx/compare/vx-plugin-v0.3.0...vx-plugin-v0.4.0) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
 ## [Unreleased]
 
 ## [0.3.0] - 2025-01-19

--- a/crates/vx-plugin/Cargo.toml
+++ b/crates/vx-plugin/Cargo.toml
@@ -29,8 +29,8 @@ which = { workspace = true }
 dirs = { workspace = true }
 
 # Internal dependencies
-vx-config = { version = "0.3.0", path = "../vx-config" }
-vx-paths = { version = "0.3.0", path = "../vx-paths" }
+vx-config = { version = "0.4.0", path = "../vx-config" }
+vx-paths = { version = "0.3.1", path = "../vx-paths" }
 
 # Optional dependencies for features
 mockall = { workspace = true, optional = true }

--- a/crates/vx-tool-standard/CHANGELOG.md
+++ b/crates/vx-tool-standard/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-standard-v0.3.0...vx-tool-standard-v0.4.0) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
+
 ## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-standard-v0.2.6...vx-tool-standard-v0.3.0) - 2025-06-19
 
 ### Added

--- a/crates/vx-tool-standard/Cargo.toml
+++ b/crates/vx-tool-standard/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.3.0", path = "../vx-core" }
-vx-installer = { version = "0.3.0", path = "../vx-installer" }
+vx-core = { version = "0.4.0", path = "../vx-core" }
+vx-installer = { version = "0.4.0", path = "../vx-installer" }
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/crates/vx-tools/vx-tool-bun/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-bun/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-bun-v0.3.0...vx-tool-bun-v0.4.0) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
 <<<<<<< HEAD
 
 ## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-bun-v0.2.6...vx-tool-bun-v0.3.0) - 2025-06-19

--- a/crates/vx-tools/vx-tool-bun/Cargo.toml
+++ b/crates/vx-tools/vx-tool-bun/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.3.0", path = "../../vx-core" }
-vx-plugin = { version = "0.3.0", path = "../../vx-plugin" }
+vx-core = { version = "0.4.0", path = "../../vx-core" }
+vx-plugin = { version = "0.4.0", path = "../../vx-plugin" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-go/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-go/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-go-v0.3.0...vx-tool-go-v0.4.0) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
 <<<<<<< HEAD
 
 ## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-go-v0.2.6...vx-tool-go-v0.3.0) - 2025-06-19

--- a/crates/vx-tools/vx-tool-go/Cargo.toml
+++ b/crates/vx-tools/vx-tool-go/Cargo.toml
@@ -12,11 +12,11 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.3.0", path = "../../vx-core" }
-vx-installer = { version = "0.3.0", path = "../../vx-installer" }
-vx-tool-standard = { version = "0.3.0", path = "../../vx-tool-standard" }
-vx-plugin = { version = "0.3.0", path = "../../vx-plugin" }
-vx-version = { version = "0.2.1", path = "../../vx-version" }
+vx-core = { version = "0.4.0", path = "../../vx-core" }
+vx-installer = { version = "0.4.0", path = "../../vx-installer" }
+vx-tool-standard = { version = "0.4.0", path = "../../vx-tool-standard" }
+vx-plugin = { version = "0.4.0", path = "../../vx-plugin" }
+vx-version = { version = "0.2.2", path = "../../vx-version" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-node/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-node/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-node-v0.3.0...vx-tool-node-v0.4.0) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
 ## [Unreleased]
 
 ## [0.3.0] - 2025-06-19

--- a/crates/vx-tools/vx-tool-node/Cargo.toml
+++ b/crates/vx-tools/vx-tool-node/Cargo.toml
@@ -12,12 +12,12 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.3.0", path = "../../vx-core" }
-vx-installer = { version = "0.3.0", path = "../../vx-installer" }
-vx-tool-standard = { version = "0.3.0", path = "../../vx-tool-standard" }
-vx-plugin = { version = "0.3.0", path = "../../vx-plugin" }
-vx-version = { version = "0.2.1", path = "../../vx-version" }
-vx-tool-npm = { version = "0.3.0", path = "../vx-tool-npm" }
+vx-core = { version = "0.4.0", path = "../../vx-core" }
+vx-installer = { version = "0.4.0", path = "../../vx-installer" }
+vx-tool-standard = { version = "0.4.0", path = "../../vx-tool-standard" }
+vx-plugin = { version = "0.4.0", path = "../../vx-plugin" }
+vx-version = { version = "0.2.2", path = "../../vx-version" }
+vx-tool-npm = { version = "0.4.0", path = "../vx-tool-npm" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-npm/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-npm/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-npm-v0.3.0...vx-tool-npm-v0.4.0) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
 <<<<<<< HEAD
 
 ## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-npm-v0.2.6...vx-tool-npm-v0.3.0) - 2025-06-19

--- a/crates/vx-tools/vx-tool-npm/Cargo.toml
+++ b/crates/vx-tools/vx-tool-npm/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.3.0", path = "../../vx-core" }
-vx-plugin = { version = "0.3.0", path = "../../vx-plugin" }
+vx-core = { version = "0.4.0", path = "../../vx-core" }
+vx-plugin = { version = "0.4.0", path = "../../vx-plugin" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-pnpm/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-pnpm/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-pnpm-v0.3.0...vx-tool-pnpm-v0.4.0) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
 <<<<<<< HEAD
 
 ## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-pnpm-v0.2.6...vx-tool-pnpm-v0.3.0) - 2025-06-19

--- a/crates/vx-tools/vx-tool-pnpm/Cargo.toml
+++ b/crates/vx-tools/vx-tool-pnpm/Cargo.toml
@@ -12,10 +12,10 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.3.0", path = "../../vx-core" }
-vx-installer = { version = "0.3.0", path = "../../vx-installer" }
-vx-tool-standard = { version = "0.3.0", path = "../../vx-tool-standard" }
-vx-plugin = { version = "0.3.0", path = "../../vx-plugin" }
+vx-core = { version = "0.4.0", path = "../../vx-core" }
+vx-installer = { version = "0.4.0", path = "../../vx-installer" }
+vx-tool-standard = { version = "0.4.0", path = "../../vx-tool-standard" }
+vx-plugin = { version = "0.4.0", path = "../../vx-plugin" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-rust/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-rust/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-rust-v0.3.0...vx-tool-rust-v0.4.0) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
 <<<<<<< HEAD
 
 ## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-rust-v0.2.6...vx-tool-rust-v0.3.0) - 2025-06-19

--- a/crates/vx-tools/vx-tool-rust/Cargo.toml
+++ b/crates/vx-tools/vx-tool-rust/Cargo.toml
@@ -12,11 +12,11 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.3.0", path = "../../vx-core" }
-vx-plugin = { version = "0.3.0", path = "../../vx-plugin" }
-vx-version = { version = "0.2.1", path = "../../vx-version" }
-vx-tool-standard = { version = "0.3.0", path = "../../vx-tool-standard" }
-vx-installer = { version = "0.3.0", path = "../../vx-installer" }
+vx-core = { version = "0.4.0", path = "../../vx-core" }
+vx-plugin = { version = "0.4.0", path = "../../vx-plugin" }
+vx-version = { version = "0.2.2", path = "../../vx-version" }
+vx-tool-standard = { version = "0.4.0", path = "../../vx-tool-standard" }
+vx-installer = { version = "0.4.0", path = "../../vx-installer" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-tools/vx-tool-uv/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-uv/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-uv-v0.3.0...vx-tool-uv-v0.4.0) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
 <<<<<<< HEAD
 
 ## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-uv-v0.2.6...vx-tool-uv-v0.3.0) - 2025-06-19

--- a/crates/vx-tools/vx-tool-uv/Cargo.toml
+++ b/crates/vx-tools/vx-tool-uv/Cargo.toml
@@ -12,11 +12,11 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.3.0", path = "../../vx-core" }
-vx-installer = { version = "0.3.0", path = "../../vx-installer" }
-vx-plugin = { version = "0.3.0", path = "../../vx-plugin" }
-vx-version = { version = "0.2.1", path = "../../vx-version" }
-vx-tool-standard = { version = "0.3.0", path = "../../vx-tool-standard" }
+vx-core = { version = "0.4.0", path = "../../vx-core" }
+vx-installer = { version = "0.4.0", path = "../../vx-installer" }
+vx-plugin = { version = "0.4.0", path = "../../vx-plugin" }
+vx-version = { version = "0.2.2", path = "../../vx-version" }
+vx-tool-standard = { version = "0.4.0", path = "../../vx-tool-standard" }
 anyhow = { workspace = true }
 which = "8.0"
 async-trait = { workspace = true }

--- a/crates/vx-tools/vx-tool-yarn/CHANGELOG.md
+++ b/crates/vx-tools/vx-tool-yarn/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-yarn-v0.3.0...vx-tool-yarn-v0.4.0) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
 <<<<<<< HEAD
 
 ## [0.3.0](https://github.com/loonghao/vx/compare/vx-tool-yarn-v0.2.6...vx-tool-yarn-v0.3.0) - 2025-06-19

--- a/crates/vx-tools/vx-tool-yarn/Cargo.toml
+++ b/crates/vx-tools/vx-tool-yarn/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-core = { version = "0.3.0", path = "../../vx-core" }
-vx-plugin = { version = "0.3.0", path = "../../vx-plugin" }
+vx-core = { version = "0.4.0", path = "../../vx-core" }
+vx-plugin = { version = "0.4.0", path = "../../vx-plugin" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-version/CHANGELOG.md
+++ b/crates/vx-version/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.2.2](https://github.com/loonghao/vx/compare/vx-version-v0.2.1...vx-version-v0.2.2) - 2025-06-19
+
+### Added
+
+- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
 <<<<<<< HEAD
 
 ## [0.2.1](https://github.com/loonghao/vx/compare/vx-version-v0.2.0...vx-version-v0.2.1) - 2025-06-19

--- a/crates/vx-version/Cargo.toml
+++ b/crates/vx-version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vx-version"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 description = "Version management and parsing utilities for the vx universal tool manager"
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [dependencies]
 # Core dependencies
-vx-plugin = { version = "0.3.0", path = "../vx-plugin" }
+vx-plugin = { version = "0.4.0", path = "../vx-plugin" }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 async-trait = "0.1"


### PR DESCRIPTION



## 🤖 New release

* `vx-config`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `vx-paths`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `vx-plugin`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `vx-installer`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `vx-version`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `vx-core`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `vx-dependency`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `vx-tool-standard`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `vx-tool-go`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `vx-tool-npm`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `vx-tool-node`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `vx-tool-rust`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `vx-tool-uv`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `vx-cli`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `vx-tool-pnpm`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `vx-tool-yarn`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `vx-tool-bun`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `vx`: 0.3.0 -> 0.4.0 (✓ API compatible changes)

### ⚠ `vx-cli` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field token of variant Commands::SelfUpdate in /tmp/.tmp36K71z/vx/crates/vx-cli/src/cli.rs:88
  field prerelease of variant Commands::SelfUpdate in /tmp/.tmp36K71z/vx/crates/vx-cli/src/cli.rs:91
  field force of variant Commands::SelfUpdate in /tmp/.tmp36K71z/vx/crates/vx-cli/src/cli.rs:94

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_parameter_count_changed.ron

Failed in:
  vx_cli::commands::self_update::handle now takes 4 parameters instead of 2, in /tmp/.tmp36K71z/vx/crates/vx-cli/src/commands/self_update.rs:29
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `vx-config`

<blockquote>

## [0.4.0](https://github.com/loonghao/vx/compare/vx-config-v0.3.0...vx-config-v0.4.0) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
</blockquote>

## `vx-paths`

<blockquote>

## [0.3.1](https://github.com/loonghao/vx/compare/vx-paths-v0.3.0...vx-paths-v0.3.1) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
</blockquote>

## `vx-plugin`

<blockquote>

## [0.4.0](https://github.com/loonghao/vx/compare/vx-plugin-v0.3.0...vx-plugin-v0.4.0) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
</blockquote>

## `vx-installer`

<blockquote>

## [0.4.0](https://github.com/loonghao/vx/compare/vx-installer-v0.3.0...vx-installer-v0.4.0) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
</blockquote>

## `vx-version`

<blockquote>

## [0.2.2](https://github.com/loonghao/vx/compare/vx-version-v0.2.1...vx-version-v0.2.2) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
<<<<<<< HEAD
</blockquote>

## `vx-core`

<blockquote>

## [0.4.0](https://github.com/loonghao/vx/compare/vx-core-v0.3.0...vx-core-v0.4.0) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
</blockquote>

## `vx-dependency`

<blockquote>

## [0.4.0](https://github.com/loonghao/vx/compare/vx-dependency-v0.3.0...vx-dependency-v0.4.0) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
</blockquote>

## `vx-tool-standard`

<blockquote>

## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-standard-v0.3.0...vx-tool-standard-v0.4.0) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
</blockquote>

## `vx-tool-go`

<blockquote>

## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-go-v0.3.0...vx-tool-go-v0.4.0) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
<<<<<<< HEAD
</blockquote>

## `vx-tool-npm`

<blockquote>

## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-npm-v0.3.0...vx-tool-npm-v0.4.0) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
<<<<<<< HEAD
</blockquote>

## `vx-tool-node`

<blockquote>

## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-node-v0.3.0...vx-tool-node-v0.4.0) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
</blockquote>

## `vx-tool-rust`

<blockquote>

## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-rust-v0.3.0...vx-tool-rust-v0.4.0) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
<<<<<<< HEAD
</blockquote>

## `vx-tool-uv`

<blockquote>

## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-uv-v0.3.0...vx-tool-uv-v0.4.0) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
<<<<<<< HEAD
</blockquote>

## `vx-cli`

<blockquote>

## [0.4.0](https://github.com/loonghao/vx/compare/vx-cli-v0.3.0...vx-cli-v0.4.0) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
</blockquote>

## `vx-tool-pnpm`

<blockquote>

## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-pnpm-v0.3.0...vx-tool-pnpm-v0.4.0) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
<<<<<<< HEAD
</blockquote>

## `vx-tool-yarn`

<blockquote>

## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-yarn-v0.3.0...vx-tool-yarn-v0.4.0) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
<<<<<<< HEAD
</blockquote>

## `vx-tool-bun`

<blockquote>

## [0.4.0](https://github.com/loonghao/vx/compare/vx-tool-bun-v0.3.0...vx-tool-bun-v0.4.0) - 2025-06-19

### Added

- implement unified path management and complete crate documentation ([#112](https://github.com/loonghao/vx/pull/112))
<<<<<<< HEAD
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).