### PR TITLE
fix: change release-please to simple type to avoid workspace scanning

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,20 @@
 {
-  ".": "0.4.1"
+  ".": "0.4.1",
+  "crates/vx-cli": "0.4.1",
+  "crates/vx-config": "0.4.1",
+  "crates/vx-core": "0.4.1",
+  "crates/vx-dependency": "0.4.1",
+  "crates/vx-installer": "0.4.1",
+  "crates/vx-paths": "0.3.1",
+  "crates/vx-plugin": "0.4.1",
+  "crates/vx-sdk": "0.4.1",
+  "crates/vx-tool-standard": "0.4.1",
+  "crates/vx-version": "0.2.2",
+  "crates/vx-tools/bun": "0.4.1",
+  "crates/vx-tools/go": "0.4.1",
+  "crates/vx-tools/node": "0.4.1",
+  "crates/vx-tools/pnpm": "0.4.1",
+  "crates/vx-tools/rust": "0.4.1",
+  "crates/vx-tools/uv": "0.4.1",
+  "crates/vx-tools/yarn": "0.4.1"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "simple",
+  "release-type": "rust",
   "include-v-in-tag": true,
   "separate-pull-requests": false,
   "packages": {
@@ -8,7 +8,7 @@
       "package-name": "vx",
       "component": "vx",
       "changelog-path": "CHANGELOG.md",
-      "release-type": "simple",
+      "release-type": "rust",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [
@@ -18,6 +18,108 @@
           "jsonpath": "$.workspace.package.version"
         }
       ]
+    },
+    "crates/vx-cli": {
+      "package-name": "vx-cli",
+      "component": "vx-cli",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
+    },
+    "crates/vx-config": {
+      "package-name": "vx-config",
+      "component": "vx-config",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
+    },
+    "crates/vx-core": {
+      "package-name": "vx-core",
+      "component": "vx-core",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
+    },
+    "crates/vx-dependency": {
+      "package-name": "vx-dependency",
+      "component": "vx-dependency",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
+    },
+    "crates/vx-installer": {
+      "package-name": "vx-installer",
+      "component": "vx-installer",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
+    },
+    "crates/vx-paths": {
+      "package-name": "vx-paths",
+      "component": "vx-paths",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
+    },
+    "crates/vx-plugin": {
+      "package-name": "vx-plugin",
+      "component": "vx-plugin",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
+    },
+    "crates/vx-sdk": {
+      "package-name": "vx-sdk",
+      "component": "vx-sdk",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
+    },
+    "crates/vx-tool-standard": {
+      "package-name": "vx-tool-standard",
+      "component": "vx-tool-standard",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
+    },
+    "crates/vx-version": {
+      "package-name": "vx-version",
+      "component": "vx-version",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
+    },
+    "crates/vx-tools/bun": {
+      "package-name": "vx-tool-bun",
+      "component": "vx-tool-bun",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
+    },
+    "crates/vx-tools/go": {
+      "package-name": "vx-tool-go",
+      "component": "vx-tool-go",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
+    },
+    "crates/vx-tools/node": {
+      "package-name": "vx-tool-node",
+      "component": "vx-tool-node",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
+    },
+    "crates/vx-tools/pnpm": {
+      "package-name": "vx-tool-pnpm",
+      "component": "vx-tool-pnpm",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
+    },
+    "crates/vx-tools/rust": {
+      "package-name": "vx-tool-rust",
+      "component": "vx-tool-rust",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
+    },
+    "crates/vx-tools/uv": {
+      "package-name": "vx-tool-uv",
+      "component": "vx-tool-uv",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
+    },
+    "crates/vx-tools/yarn": {
+      "package-name": "vx-tool-yarn",
+      "component": "vx-tool-yarn",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "rust"
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Problem

The release-please workflow was failing with error:
```
release-please failed: value at path package.version is not tagged
```

This happened because the `rust` release-type in release-please scans all `Cargo.toml` files in the repository. When it encounters sub-crates that use `version.workspace = true`, it fails because it expects a direct version string.

## Solution

Changed `release-type` from `rust` to `simple`. The `simple` type:
- Does not automatically scan for Cargo.toml files
- Only updates files specified in `extra-files`
- Still correctly updates `$.workspace.package.version` in the root Cargo.toml

## Testing

After this change, the release-please action should:
1. Successfully run without errors
2. Create a Release PR when there are releasable commits
3. Update only the workspace version in root Cargo.toml