### PR TITLE
fix(ci): add x-release-please-version tag to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ vx-core = { version = "0.4.0", path = "crates/vx-core" }
 
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.1"                                                # x-release-please-version
 edition = "2021"
 description = "Universal Development Tool Manager"
 license = "MIT"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,11 +12,7 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [
-        {
-          "type": "toml",
-          "path": "Cargo.toml",
-          "jsonpath": "$.workspace.package.version"
-        }
+        "Cargo.toml"
       ]
     }
   },


### PR DESCRIPTION
## Summary

Fix release-please CI failure: `value at path package.version is not tagged`

## Changes

1. **`Cargo.toml`**: Added `# x-release-please-version` comment tag after `version = "0.4.1"` to allow release-please to identify and update the version number

2. **`release-please-config.json`**: Simplified `extra-files` configuration by removing `jsonpath` since the comment tag approach doesn't require it

## Related Issue

Fixes release-please workflow failure