### PR TITLE
fix(ci): add pull-request-title-pattern to release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "release-type": "rust",
   "include-v-in-tag": true,
   "separate-pull-requests": false,
+  "pull-request-title-pattern": "chore(release): ${component} ${version}",
   "packages": {
     ".": {
       "package-name": "vx",


### PR DESCRIPTION
## Summary

Fix release-please warnings about missing `pullRequestTitlePattern` placeholders:

```
⚠ pullRequestTitlePattern miss the part of '${scope}'
⚠ pullRequestTitlePattern miss the part of '${component}'
⚠ pullRequestTitlePattern miss the part of '${version}'
```

## Changes

Added `pull-request-title-pattern` configuration to `release-please-config.json`:

```json
"pull-request-title-pattern": "chore(release): ${component} ${version}"
```

This will generate PR titles like: `chore(release): vx v0.5.0`