### PR TITLE
fix(ci): change release-please type from rust to simple

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "rust",
+  "release-type": "simple",
   "include-v-in-tag": true,
   "separate-pull-requests": false,
   "pull-request-title-pattern": "chore(release): ${component} ${version}",
@@ -9,7 +9,7 @@
       "package-name": "vx",
       "component": "vx",
       "changelog-path": "CHANGELOG.md",
-      "release-type": "rust",
+      "release-type": "simple",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [


### PR DESCRIPTION
## Summary

Fix release-please error: `value at path package.version is not tagged`

## Root Cause

The `rust` release type causes release-please to automatically scan all workspace member crates' `Cargo.toml` files. Some crates (`vx-paths`, `vx-version`) have hardcoded versions instead of using `version.workspace = true`, causing the version tag detection to fail.

## Solution

Change `release-type` from `rust` to `simple`. This tells release-please to only update the files explicitly listed in `extra-files` (root `Cargo.toml` with the `x-release-please-version` tag), rather than scanning all workspace members.

## Changes

- Changed `release-type` from `rust` to `simple` at both root and package level