### PR TITLE
fix: use workspace dependencies for internal crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3329,7 +3329,7 @@ dependencies = [
 
 [[package]]
 name = "vx"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -3341,7 +3341,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "vx-core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3406,7 +3406,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.3.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bun"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3456,7 +3456,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-go"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3473,7 +3473,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-node"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3490,7 +3490,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pnpm"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3503,7 +3503,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rust"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-uv"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yarn"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version"
-version = "0.2.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ name = "config_management_demo"
 path = "examples/config_management_demo.rs"
 
 [dependencies]
-vx-cli = { version = "0.4.0", path = "crates/vx-cli" }
+vx-cli = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
 
@@ -57,7 +57,7 @@ tempfile = { workspace = true }
 # trycmd for CLI snapshot testing
 trycmd = { workspace = true }
 # Test dependencies for integration tests
-vx-core = { version = "0.4.0", path = "crates/vx-core" }
+vx-core = { workspace = true }
 
 
 [workspace.package]
@@ -76,6 +76,23 @@ rust-version = "1.80.0"
 
 
 [workspace.dependencies]
+# Internal crates
+vx-core = { path = "crates/vx-core" }
+vx-runtime = { path = "crates/vx-runtime" }
+vx-resolver = { path = "crates/vx-resolver" }
+vx-paths = { path = "crates/vx-paths" }
+vx-installer = { path = "crates/vx-installer" }
+vx-version = { path = "crates/vx-version" }
+vx-cli = { path = "crates/vx-cli" }
+vx-provider-node = { path = "crates/vx-providers/node" }
+vx-provider-go = { path = "crates/vx-providers/go" }
+vx-provider-uv = { path = "crates/vx-providers/uv" }
+vx-provider-pnpm = { path = "crates/vx-providers/pnpm" }
+vx-provider-yarn = { path = "crates/vx-providers/yarn" }
+vx-provider-bun = { path = "crates/vx-providers/bun" }
+vx-provider-rust = { path = "crates/vx-providers/rust" }
+
+# External dependencies
 clap = { version = "4.4", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"

--- a/crates/vx-cli/Cargo.toml
+++ b/crates/vx-cli/Cargo.toml
@@ -13,18 +13,18 @@ rust-version.workspace = true
 
 
 [dependencies]
-vx-core = { version = "0.4.0", path = "../vx-core" }
-vx-paths = { version = "0.3.1", path = "../vx-paths" }
-vx-resolver = { version = "0.4.0", path = "../vx-resolver" }
-vx-runtime = { version = "0.4.0", path = "../vx-runtime" }
+vx-core = { workspace = true }
+vx-paths = { workspace = true }
+vx-resolver = { workspace = true }
+vx-runtime = { workspace = true }
 # Providers
-vx-provider-node = { version = "0.4.0", path = "../vx-providers/node" }
-vx-provider-go = { version = "0.4.0", path = "../vx-providers/go" }
-vx-provider-rust = { version = "0.4.0", path = "../vx-providers/rust" }
-vx-provider-uv = { version = "0.4.0", path = "../vx-providers/uv" }
-vx-provider-bun = { version = "0.4.0", path = "../vx-providers/bun" }
-vx-provider-pnpm = { version = "0.4.0", path = "../vx-providers/pnpm" }
-vx-provider-yarn = { version = "0.4.0", path = "../vx-providers/yarn" }
+vx-provider-node = { workspace = true }
+vx-provider-go = { workspace = true }
+vx-provider-rust = { workspace = true }
+vx-provider-uv = { workspace = true }
+vx-provider-bun = { workspace = true }
+vx-provider-pnpm = { workspace = true }
+vx-provider-yarn = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
@@ -58,5 +58,5 @@ test-case = { workspace = true }
 pretty_assertions = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-vx-version = { version = "0.2.2", path = "../vx-version" }
-vx-paths = { version = "0.3.1", path = "../vx-paths" }
+vx-version = { workspace = true }
+vx-paths = { workspace = true }

--- a/crates/vx-paths/Cargo.toml
+++ b/crates/vx-paths/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "vx-paths"
-version = "0.3.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 description = "Cross-platform path management for vx tool installations"
-license = "MIT"
-repository = "https://github.com/loonghao/vx"
-homepage = "https://github.com/loonghao/vx"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/vx-providers/bun/Cargo.toml
+++ b/crates/vx-providers/bun/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-runtime = { version = "0.4.0", path = "../../vx-runtime" }
-vx-paths = { version = "0.3.1", path = "../../vx-paths" }
+vx-runtime = { workspace = true }
+vx-paths = { workspace = true }
 serde = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/vx-providers/go/Cargo.toml
+++ b/crates/vx-providers/go/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-runtime = { version = "0.4.0", path = "../../vx-runtime" }
-vx-installer = { version = "0.4.0", path = "../../vx-installer" }
-vx-version = { version = "0.2.2", path = "../../vx-version" }
+vx-runtime = { workspace = true }
+vx-installer = { workspace = true }
+vx-version = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-providers/node/Cargo.toml
+++ b/crates/vx-providers/node/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-runtime = { version = "0.4.0", path = "../../vx-runtime" }
-vx-installer = { version = "0.4.0", path = "../../vx-installer" }
-vx-version = { version = "0.2.2", path = "../../vx-version" }
+vx-runtime = { workspace = true }
+vx-installer = { workspace = true }
+vx-version = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-providers/pnpm/Cargo.toml
+++ b/crates/vx-providers/pnpm/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-runtime = { version = "0.4.0", path = "../../vx-runtime" }
-vx-paths = { version = "0.3.1", path = "../../vx-paths" }
+vx-runtime = { workspace = true }
+vx-paths = { workspace = true }
 serde = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/vx-providers/rust/Cargo.toml
+++ b/crates/vx-providers/rust/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-runtime = { version = "0.4.0", path = "../../vx-runtime" }
-vx-paths = { version = "0.3.1", path = "../../vx-paths" }
+vx-runtime = { workspace = true }
+vx-paths = { workspace = true }
 serde = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/vx-providers/uv/Cargo.toml
+++ b/crates/vx-providers/uv/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-runtime = { version = "0.4.0", path = "../../vx-runtime" }
-vx-installer = { version = "0.4.0", path = "../../vx-installer" }
-vx-version = { version = "0.2.2", path = "../../vx-version" }
+vx-runtime = { workspace = true }
+vx-installer = { workspace = true }
+vx-version = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-providers/yarn/Cargo.toml
+++ b/crates/vx-providers/yarn/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vx-runtime = { version = "0.4.0", path = "../../vx-runtime" }
-vx-paths = { version = "0.3.1", path = "../../vx-paths" }
+vx-runtime = { workspace = true }
+vx-paths = { workspace = true }
 serde = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/vx-resolver/Cargo.toml
+++ b/crates/vx-resolver/Cargo.toml
@@ -7,8 +7,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vx-runtime = { version = "0.4.0", path = "../vx-runtime" }
-vx-paths = { version = "0.3.1", path = "../vx-paths" }
+vx-runtime = { workspace = true }
+vx-paths = { workspace = true }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/vx-version/Cargo.toml
+++ b/crates/vx-version/Cargo.toml
@@ -1,45 +1,40 @@
 [package]
 name = "vx-version"
-version = "0.2.2"
-edition = "2021"
-authors = ["Hal <hal.long@outlook.com>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
 description = "Version management and parsing utilities for the vx universal tool manager"
-license = "MIT"
-repository = "https://github.com/loonghao/vx"
-homepage = "https://github.com/loonghao/vx"
-documentation = "https://docs.rs/vx-version"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 keywords = ["version", "semver", "parsing", "management", "tools"]
 categories = ["development-tools", "parsing"]
-readme = "README.md"
 
 [dependencies]
 # Core dependencies
-vx-runtime = { version = "0.4.0", path = "../vx-runtime" }
-serde = { version = "1.0", features = ["derive"] }
-anyhow = "1.0"
-async-trait = "0.1"
+vx-runtime = { workspace = true }
+serde = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 
 # HTTP client for fetching versions - use rustls for better cross-compilation
-reqwest = { version = "0.12", features = [
-  "json",
-  "rustls-tls",
-], default-features = false }
+reqwest = { workspace = true }
 
 # JSON parsing
-serde_json = "1.0"
+serde_json = { workspace = true }
 
 # Regular expressions for version parsing
-regex = "1.0"
+regex = { workspace = true }
 
 # Command execution
-which = "8.0"
+which = { workspace = true }
 
 # Standard library collections
 indexmap = "2.0"
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["full"] }
-tempfile = "3.0"
+tokio = { workspace = true, features = ["test-util"] }
+tempfile = { workspace = true }
 
 [features]
 default = []


### PR DESCRIPTION
## Summary

Fix cargo build errors caused by version mismatch between workspace version (0.5.0) and hardcoded internal crate dependencies (0.4.0, 0.3.1, 0.2.2).

## Root Cause

When release-please updated the workspace version to 0.5.0, the internal crate dependencies still had hardcoded versions:

```
error: failed to select a version for the requirement `vx-runtime = "^0.4.0"`
candidate versions found which didn't match: 0.5.0
```

## Solution

Convert all internal crate dependencies to use workspace dependencies:

1. Added all internal crates to `[workspace.dependencies]` in root `Cargo.toml`
2. Updated all sub-crates to use `{ workspace = true }` for internal dependencies
3. Updated `vx-paths` and `vx-version` to use `version.workspace = true`

## Benefits

- **Single source of truth**: Version is only defined once in `[workspace.package]`
- **No more version mismatch**: All crates automatically use the same version
- **Easier maintenance**: No need to update versions in multiple files
- **release-please compatible**: Only needs to update one version number