### PR TITLE
fix(ci): remove --locked flag from release build to handle crates.io index updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
         with:
           command: build
           target: ${{ matrix.platform.target }}
-          args: "--locked --release --bin vx"
+          args: "--release --bin vx"
           strip: true
 
       - name: Publish artifacts and release


### PR DESCRIPTION
## Summary

Remove `--locked` flag from the release build command to handle crates.io index updates.

## Problem

When building older tags, the `Cargo.lock` file may become out of sync with the current crates.io index, causing the build to fail with:

```
error: the lock file needs to be updated but --locked was passed to prevent this
```

## Solution

Remove the `--locked` flag from the release build command. This allows Cargo to update the lock file if needed during the build process.

## Changes

- Remove `--locked` flag from `houseabsolute/actions-rust-cross` build args in `release.yml`