### PR TITLE
fix(ci): escape changelog content with toJSON() in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
           action-gh-release-parameters: |
             {
               "tag_name": "${{ needs.get-tag.outputs.tag_name }}",
-              "body": "${{ steps.changelog_reader.outputs.changes }}",
+              "body": ${{ toJSON(steps.changelog_reader.outputs.changes) }},
               "prerelease": false,
               "draft": false
             }


### PR DESCRIPTION
Fix action-gh-release-parameters JSON parsing error by using toJSON() to properly escape changelog content with special characters.