### PR TITLE
fix: simplify release asset naming and fix installer download URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,11 +163,13 @@ jobs:
         id: archive
         shell: bash
         run: |
+          # Use simple format: vx-{target}.{ext} (without version in filename)
+          # Version is already in the release tag, no need to duplicate
           if [[ "${{ matrix.platform.os }}" == "windows-latest" ]]; then
-            echo "name=vx-${{ needs.get-tag.outputs.tag_name }}-${{ matrix.platform.target }}.zip" >> $GITHUB_OUTPUT
+            echo "name=vx-${{ matrix.platform.target }}.zip" >> $GITHUB_OUTPUT
             echo "ext=zip" >> $GITHUB_OUTPUT
           else
-            echo "name=vx-${{ needs.get-tag.outputs.tag_name }}-${{ matrix.platform.target }}.tar.gz" >> $GITHUB_OUTPUT
+            echo "name=vx-${{ matrix.platform.target }}.tar.gz" >> $GITHUB_OUTPUT
             echo "ext=tar.gz" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## Summary

Fix the installation script download failures caused by incorrect release asset naming and URL construction.

## Problems Fixed

1. **Duplicate 'vx-' prefix in asset names**: Release assets were named `vx-vx-v0.5.7-x86_64-pc-windows-msvc.zip` instead of `vx-x86_64-pc-windows-msvc.zip`

2. **Incorrect tag format in download URLs**: Installer scripts used `v0.5.7` format but actual tags are `vx-v0.5.7`

3. **CDN fallbacks don't work**: jsDelivr/Fastly CDN don't support GitHub Release assets, only repository files

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Simplify asset naming to `vx-{target}.{ext}` (without version in filename) |
| `install.ps1` | Use full tag name format, remove CDN fallbacks, support multiple version input formats |
| `install.sh` | Same changes as install.ps1 |

## After This Fix

- Asset name: `vx-x86_64-pc-windows-msvc.zip`
- Download URL: `https://github.com/loonghao/vx/releases/download/vx-v0.5.8/vx-x86_64-pc-windows-msvc.zip`

## Testing

After merging and releasing, test with:
```powershell
irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex
```

```bash
curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
```
