### PR TITLE
feat: add just command runner provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3347,7 +3347,7 @@ dependencies = [
 
 [[package]]
 name = "vx"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -3359,7 +3359,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3390,6 +3390,7 @@ dependencies = [
  "vx-paths",
  "vx-provider-bun",
  "vx-provider-go",
+ "vx-provider-just",
  "vx-provider-node",
  "vx-provider-pnpm",
  "vx-provider-rust",
@@ -3406,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "vx-core"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3425,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3451,7 +3452,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3462,7 +3463,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bun"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3475,7 +3476,24 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-go"
-version = "0.5.7"
+version = "0.5.8"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "reqwest",
+ "rstest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "vx-installer",
+ "vx-runtime",
+ "vx-version",
+]
+
+[[package]]
+name = "vx-provider-just"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3492,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-node"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3509,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pnpm"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3522,7 +3540,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rust"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3535,7 +3553,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-uv"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3552,7 +3570,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vscode"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3569,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yarn"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3582,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3600,7 +3618,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3626,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "crates/vx-providers/bun",
   "crates/vx-providers/rust",
   "crates/vx-providers/vscode",
+  "crates/vx-providers/just",
 ]
 resolver = "2"
 
@@ -93,6 +94,7 @@ vx-provider-yarn = { path = "crates/vx-providers/yarn" }
 vx-provider-bun = { path = "crates/vx-providers/bun" }
 vx-provider-rust = { path = "crates/vx-providers/rust" }
 vx-provider-vscode = { path = "crates/vx-providers/vscode" }
+vx-provider-just = { path = "crates/vx-providers/just" }
 
 # External dependencies
 clap = { version = "4.4", features = ["derive"] }

--- a/crates/vx-cli/Cargo.toml
+++ b/crates/vx-cli/Cargo.toml
@@ -26,6 +26,7 @@ vx-provider-bun = { workspace = true }
 vx-provider-pnpm = { workspace = true }
 vx-provider-yarn = { workspace = true }
 vx-provider-vscode = { workspace = true }
+vx-provider-just = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-cli/src/registry.rs
+++ b/crates/vx-cli/src/registry.rs
@@ -33,6 +33,9 @@ pub fn create_registry() -> ProviderRegistry {
     // Register VSCode provider
     registry.register(vx_provider_vscode::create_provider());
 
+    // Register Just provider
+    registry.register(vx_provider_just::create_provider());
+
     registry
 }
 

--- a/crates/vx-providers/just/Cargo.toml
+++ b/crates/vx-providers/just/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "vx-provider-just"
+version.workspace = true
+edition.workspace = true
+description = "Just command runner provider for vx"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+vx-runtime = { workspace = true }
+vx-installer = { workspace = true }
+vx-version = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+chrono = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/crates/vx-providers/just/src/config.rs
+++ b/crates/vx-providers/just/src/config.rs
@@ -1,0 +1,114 @@
+//! URL builder and platform configuration for Just
+//!
+//! Just releases are available at: https://github.com/casey/just/releases
+//! Download URL format: https://github.com/casey/just/releases/download/{version}/just-{version}-{target}.{ext}
+
+use vx_runtime::{Arch, Os, Platform};
+
+/// URL builder for Just downloads
+pub struct JustUrlBuilder;
+
+impl JustUrlBuilder {
+    /// Base URL for Just releases
+    const BASE_URL: &'static str = "https://github.com/casey/just/releases/download";
+
+    /// Build the download URL for a specific version and platform
+    pub fn download_url(version: &str, platform: &Platform) -> Option<String> {
+        let target = Self::get_target_triple(platform)?;
+        let ext = Self::get_archive_extension(platform);
+        Some(format!(
+            "{}/{}/just-{}-{}.{}",
+            Self::BASE_URL,
+            version,
+            version,
+            target,
+            ext
+        ))
+    }
+
+    /// Get the target triple for the platform
+    pub fn get_target_triple(platform: &Platform) -> Option<String> {
+        match (&platform.os, &platform.arch) {
+            // Windows
+            (Os::Windows, Arch::X86_64) => Some("x86_64-pc-windows-msvc".to_string()),
+            (Os::Windows, Arch::Aarch64) => Some("aarch64-pc-windows-msvc".to_string()),
+
+            // macOS
+            (Os::MacOS, Arch::X86_64) => Some("x86_64-apple-darwin".to_string()),
+            (Os::MacOS, Arch::Aarch64) => Some("aarch64-apple-darwin".to_string()),
+
+            // Linux (using musl for better compatibility)
+            (Os::Linux, Arch::X86_64) => Some("x86_64-unknown-linux-musl".to_string()),
+            (Os::Linux, Arch::Aarch64) => Some("aarch64-unknown-linux-musl".to_string()),
+            (Os::Linux, Arch::Arm) => Some("arm-unknown-linux-musleabihf".to_string()),
+
+            _ => None,
+        }
+    }
+
+    /// Get the archive extension for the platform
+    pub fn get_archive_extension(platform: &Platform) -> &'static str {
+        match platform.os {
+            Os::Windows => "zip",
+            _ => "tar.gz",
+        }
+    }
+
+    /// Get the executable name for the platform
+    pub fn get_executable_name(platform: &Platform) -> &'static str {
+        match platform.os {
+            Os::Windows => "just.exe",
+            _ => "just",
+        }
+    }
+
+    /// Get the archive directory name (Just extracts directly, no subdirectory)
+    pub fn get_archive_dir_name(_version: &str, _platform: &Platform) -> String {
+        // Just archives extract files directly without a subdirectory
+        String::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_download_url_linux_x64() {
+        let platform = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
+        let url = JustUrlBuilder::download_url("1.45.0", &platform);
+        assert_eq!(
+            url,
+            Some("https://github.com/casey/just/releases/download/1.45.0/just-1.45.0-x86_64-unknown-linux-musl.tar.gz".to_string())
+        );
+    }
+
+    #[test]
+    fn test_download_url_windows_x64() {
+        let platform = Platform {
+            os: Os::Windows,
+            arch: Arch::X86_64,
+        };
+        let url = JustUrlBuilder::download_url("1.45.0", &platform);
+        assert_eq!(
+            url,
+            Some("https://github.com/casey/just/releases/download/1.45.0/just-1.45.0-x86_64-pc-windows-msvc.zip".to_string())
+        );
+    }
+
+    #[test]
+    fn test_download_url_macos_arm64() {
+        let platform = Platform {
+            os: Os::MacOS,
+            arch: Arch::Aarch64,
+        };
+        let url = JustUrlBuilder::download_url("1.45.0", &platform);
+        assert_eq!(
+            url,
+            Some("https://github.com/casey/just/releases/download/1.45.0/just-1.45.0-aarch64-apple-darwin.tar.gz".to_string())
+        );
+    }
+}

--- a/crates/vx-providers/just/src/lib.rs
+++ b/crates/vx-providers/just/src/lib.rs
@@ -1,0 +1,31 @@
+//! Just provider for vx
+//!
+//! This crate provides the Just command runner provider for vx.
+//! Just is a handy way to save and run project-specific commands.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use vx_provider_just::create_provider;
+//!
+//! let provider = create_provider();
+//! assert_eq!(provider.name(), "just");
+//! ```
+
+mod config;
+mod provider;
+mod runtime;
+
+pub use config::JustUrlBuilder;
+pub use provider::JustProvider;
+pub use runtime::JustRuntime;
+
+use std::sync::Arc;
+use vx_runtime::Provider;
+
+/// Create a new Just provider instance
+///
+/// This is the main entry point for the provider, used by the registry.
+pub fn create_provider() -> Arc<dyn Provider> {
+    Arc::new(JustProvider::new())
+}

--- a/crates/vx-providers/just/src/provider.rs
+++ b/crates/vx-providers/just/src/provider.rs
@@ -1,0 +1,44 @@
+//! Just provider implementation
+//!
+//! Provides the Just command runner.
+
+use crate::runtime::JustRuntime;
+use std::sync::Arc;
+use vx_runtime::{Provider, Runtime};
+
+/// Just provider
+#[derive(Debug, Default)]
+pub struct JustProvider;
+
+impl JustProvider {
+    /// Create a new Just provider
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Provider for JustProvider {
+    fn name(&self) -> &str {
+        "just"
+    }
+
+    fn description(&self) -> &str {
+        "Just - A handy way to save and run project-specific commands"
+    }
+
+    fn runtimes(&self) -> Vec<Arc<dyn Runtime>> {
+        vec![Arc::new(JustRuntime::new())]
+    }
+
+    fn supports(&self, name: &str) -> bool {
+        name == "just"
+    }
+
+    fn get_runtime(&self, name: &str) -> Option<Arc<dyn Runtime>> {
+        if name == "just" {
+            Some(Arc::new(JustRuntime::new()))
+        } else {
+            None
+        }
+    }
+}

--- a/crates/vx-providers/just/src/runtime.rs
+++ b/crates/vx-providers/just/src/runtime.rs
@@ -1,0 +1,140 @@
+//! Just runtime implementation
+//!
+//! Just is a handy way to save and run project-specific commands.
+//! https://github.com/casey/just
+
+use crate::config::JustUrlBuilder;
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::path::Path;
+use vx_runtime::{Ecosystem, Platform, Runtime, RuntimeContext, VerificationResult, VersionInfo};
+
+/// Just runtime implementation
+#[derive(Debug, Clone, Default)]
+pub struct JustRuntime;
+
+impl JustRuntime {
+    /// Create a new Just runtime
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Runtime for JustRuntime {
+    fn name(&self) -> &str {
+        "just"
+    }
+
+    fn description(&self) -> &str {
+        "Just - A handy way to save and run project-specific commands"
+    }
+
+    fn aliases(&self) -> &[&str] {
+        &[]
+    }
+
+    fn ecosystem(&self) -> Ecosystem {
+        Ecosystem::System
+    }
+
+    fn metadata(&self) -> HashMap<String, String> {
+        let mut meta = HashMap::new();
+        meta.insert(
+            "homepage".to_string(),
+            "https://github.com/casey/just".to_string(),
+        );
+        meta.insert(
+            "documentation".to_string(),
+            "https://just.systems/man/en/".to_string(),
+        );
+        meta.insert("category".to_string(), "command-runner".to_string());
+        meta
+    }
+
+    fn executable_relative_path(&self, _version: &str, platform: &Platform) -> String {
+        // Just extracts directly without subdirectory
+        JustUrlBuilder::get_executable_name(platform).to_string()
+    }
+
+    async fn fetch_versions(&self, ctx: &RuntimeContext) -> Result<Vec<VersionInfo>> {
+        let url = "https://api.github.com/repos/casey/just/releases";
+        let response = ctx.http.get_json_value(url).await?;
+
+        let mut versions = Vec::new();
+
+        if let Some(releases) = response.as_array() {
+            for release in releases {
+                // Skip drafts and prereleases
+                if release
+                    .get("draft")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+                if release
+                    .get("prerelease")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+
+                // Get tag name (version)
+                let tag_name = match release.get("tag_name").and_then(|v| v.as_str()) {
+                    Some(tag) => tag,
+                    None => continue,
+                };
+
+                // Just uses plain version numbers without 'v' prefix
+                let version = tag_name.to_string();
+
+                // Get published date
+                let published_at = release
+                    .get("published_at")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+
+                let mut version_info = VersionInfo::new(version)
+                    .with_lts(false)
+                    .with_prerelease(false);
+
+                if let Some(date) = published_at {
+                    version_info = version_info.with_release_date(date);
+                }
+
+                versions.push(version_info);
+            }
+        }
+
+        Ok(versions)
+    }
+
+    async fn download_url(&self, version: &str, platform: &Platform) -> Result<Option<String>> {
+        Ok(JustUrlBuilder::download_url(version, platform))
+    }
+
+    fn verify_installation(
+        &self,
+        _version: &str,
+        install_path: &Path,
+        platform: &Platform,
+    ) -> VerificationResult {
+        let exe_name = JustUrlBuilder::get_executable_name(platform);
+        let exe_path = install_path.join(exe_name);
+
+        if exe_path.exists() {
+            VerificationResult::success(exe_path)
+        } else {
+            VerificationResult::failure(
+                vec![format!(
+                    "Just executable not found at expected path: {}",
+                    exe_path.display()
+                )],
+                vec!["Try reinstalling the runtime".to_string()],
+            )
+        }
+    }
+}

--- a/crates/vx-providers/just/tests/runtime_tests.rs
+++ b/crates/vx-providers/just/tests/runtime_tests.rs
@@ -1,0 +1,135 @@
+//! Tests for Just runtime
+
+use rstest::rstest;
+use vx_provider_just::{JustProvider, JustRuntime, JustUrlBuilder};
+use vx_runtime::{Arch, Ecosystem, Os, Platform, Provider, Runtime};
+
+#[test]
+fn test_runtime_name() {
+    let runtime = JustRuntime::new();
+    assert_eq!(runtime.name(), "just");
+}
+
+#[test]
+fn test_runtime_description() {
+    let runtime = JustRuntime::new();
+    assert!(runtime.description().contains("Just"));
+}
+
+#[test]
+fn test_runtime_ecosystem() {
+    let runtime = JustRuntime::new();
+    assert_eq!(runtime.ecosystem(), Ecosystem::System);
+}
+
+#[test]
+fn test_runtime_metadata() {
+    let runtime = JustRuntime::new();
+    let meta = runtime.metadata();
+    assert!(meta.contains_key("homepage"));
+    assert!(meta.get("homepage").unwrap().contains("casey/just"));
+}
+
+#[test]
+fn test_provider_name() {
+    let provider = JustProvider::new();
+    assert_eq!(provider.name(), "just");
+}
+
+#[test]
+fn test_provider_supports() {
+    let provider = JustProvider::new();
+    assert!(provider.supports("just"));
+    assert!(!provider.supports("make"));
+}
+
+#[test]
+fn test_provider_runtimes() {
+    let provider = JustProvider::new();
+    let runtimes = provider.runtimes();
+    assert_eq!(runtimes.len(), 1);
+    assert_eq!(runtimes[0].name(), "just");
+}
+
+#[test]
+fn test_provider_get_runtime() {
+    let provider = JustProvider::new();
+    assert!(provider.get_runtime("just").is_some());
+    assert!(provider.get_runtime("make").is_none());
+}
+
+#[rstest]
+#[case(Os::Linux, Arch::X86_64, "x86_64-unknown-linux-musl")]
+#[case(Os::Linux, Arch::Aarch64, "aarch64-unknown-linux-musl")]
+#[case(Os::MacOS, Arch::X86_64, "x86_64-apple-darwin")]
+#[case(Os::MacOS, Arch::Aarch64, "aarch64-apple-darwin")]
+#[case(Os::Windows, Arch::X86_64, "x86_64-pc-windows-msvc")]
+#[case(Os::Windows, Arch::Aarch64, "aarch64-pc-windows-msvc")]
+#[case(Os::Linux, Arch::Arm, "arm-unknown-linux-musleabihf")]
+fn test_target_triple(#[case] os: Os, #[case] arch: Arch, #[case] expected: &str) {
+    let platform = Platform { os, arch };
+    let triple = JustUrlBuilder::get_target_triple(&platform);
+    assert_eq!(triple, Some(expected.to_string()));
+}
+
+#[rstest]
+#[case(Os::Windows, "zip")]
+#[case(Os::Linux, "tar.gz")]
+#[case(Os::MacOS, "tar.gz")]
+fn test_archive_extension(#[case] os: Os, #[case] expected: &str) {
+    let platform = Platform {
+        os,
+        arch: Arch::X86_64,
+    };
+    let ext = JustUrlBuilder::get_archive_extension(&platform);
+    assert_eq!(ext, expected);
+}
+
+#[rstest]
+#[case(Os::Windows, "just.exe")]
+#[case(Os::Linux, "just")]
+#[case(Os::MacOS, "just")]
+fn test_executable_name(#[case] os: Os, #[case] expected: &str) {
+    let platform = Platform {
+        os,
+        arch: Arch::X86_64,
+    };
+    let name = JustUrlBuilder::get_executable_name(&platform);
+    assert_eq!(name, expected);
+}
+
+#[test]
+fn test_download_url_format() {
+    let platform = Platform {
+        os: Os::Linux,
+        arch: Arch::X86_64,
+    };
+    let url = JustUrlBuilder::download_url("1.45.0", &platform).unwrap();
+    assert!(url.contains("github.com/casey/just"));
+    assert!(url.contains("1.45.0"));
+    assert!(url.contains("x86_64-unknown-linux-musl"));
+    assert!(url.ends_with(".tar.gz"));
+}
+
+#[test]
+fn test_executable_relative_path() {
+    let runtime = JustRuntime::new();
+
+    let linux_platform = Platform {
+        os: Os::Linux,
+        arch: Arch::X86_64,
+    };
+    assert_eq!(
+        runtime.executable_relative_path("1.45.0", &linux_platform),
+        "just"
+    );
+
+    let windows_platform = Platform {
+        os: Os::Windows,
+        arch: Arch::X86_64,
+    };
+    assert_eq!(
+        runtime.executable_relative_path("1.45.0", &windows_platform),
+        "just.exe"
+    );
+}

--- a/tests/cmd/plugin/plugin-stats.md
+++ b/tests/cmd/plugin/plugin-stats.md
@@ -6,8 +6,8 @@ Verify that `vx plugin stats` shows plugin statistics.
 $ vx plugin stats
 
 [..]
-  Total providers: 8
-  Total runtimes: 14
+  Total providers: 9
+  Total runtimes: 15
 
   Providers:
     node (3 runtimes)
@@ -18,5 +18,6 @@ $ vx plugin stats
     pnpm (1 runtimes)
     yarn (1 runtimes)
     vscode (1 runtimes)
+    just (1 runtimes)
 
 ```

--- a/tests/cmd/search/search.md
+++ b/tests/cmd/search/search.md
@@ -20,5 +20,6 @@ $ vx search
   pnpm - Fast, disk space efficient package manager
   yarn - Fast, reliable, and secure dependency management
   code - Visual Studio Code - Code editing. Redefined.
+  just - Just - A handy way to save and run project-specific commands
 
 ```


### PR DESCRIPTION
## Summary

Add a new provider for [Just](https://github.com/casey/just) - a handy way to save and run project-specific commands (similar to make).

## Changes

- Add \x-provider-just\ crate with full provider implementation
- Support for multiple platforms:
  - Windows (x86_64, aarch64)
  - macOS (x86_64, aarch64)  
  - Linux (x86_64, aarch64, arm)
- Fetch versions from GitHub Releases API
- Register provider in \x-cli\ registry

## Files Added

- \crates/vx-providers/just/Cargo.toml\
- \crates/vx-providers/just/src/lib.rs\
- \crates/vx-providers/just/src/provider.rs\
- \crates/vx-providers/just/src/runtime.rs\
- \crates/vx-providers/just/src/config.rs\
- \crates/vx-providers/just/tests/runtime_tests.rs\

## Testing

- 23 unit tests added and passing
- All pre-commit hooks pass (cargo fmt, clippy, check)