### PR TITLE
feat(vite): add Vite provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3395,6 +3395,7 @@ dependencies = [
  "vx-provider-pnpm",
  "vx-provider-rust",
  "vx-provider-uv",
+ "vx-provider-vite",
  "vx-provider-vscode",
  "vx-provider-yarn",
  "vx-resolver",
@@ -3553,6 +3554,23 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-uv"
+version = "0.5.8"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "reqwest",
+ "rstest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "vx-installer",
+ "vx-runtime",
+ "vx-version",
+]
+
+[[package]]
+name = "vx-provider-vite"
 version = "0.5.8"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "crates/vx-providers/rust",
   "crates/vx-providers/vscode",
   "crates/vx-providers/just",
+  "crates/vx-providers/vite",
 ]
 resolver = "2"
 
@@ -95,6 +96,7 @@ vx-provider-bun = { path = "crates/vx-providers/bun" }
 vx-provider-rust = { path = "crates/vx-providers/rust" }
 vx-provider-vscode = { path = "crates/vx-providers/vscode" }
 vx-provider-just = { path = "crates/vx-providers/just" }
+vx-provider-vite = { path = "crates/vx-providers/vite" }
 
 # External dependencies
 clap = { version = "4.4", features = ["derive"] }

--- a/crates/vx-cli/Cargo.toml
+++ b/crates/vx-cli/Cargo.toml
@@ -27,6 +27,7 @@ vx-provider-pnpm = { workspace = true }
 vx-provider-yarn = { workspace = true }
 vx-provider-vscode = { workspace = true }
 vx-provider-just = { workspace = true }
+vx-provider-vite = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-cli/src/registry.rs
+++ b/crates/vx-cli/src/registry.rs
@@ -36,6 +36,9 @@ pub fn create_registry() -> ProviderRegistry {
     // Register Just provider
     registry.register(vx_provider_just::create_provider());
 
+    // Register Vite provider
+    registry.register(vx_provider_vite::create_provider());
+
     registry
 }
 

--- a/crates/vx-providers/vite/Cargo.toml
+++ b/crates/vx-providers/vite/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "vx-provider-vite"
+version.workspace = true
+edition.workspace = true
+description = "Vite provider for vx"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+vx-runtime = { workspace = true }
+vx-installer = { workspace = true }
+vx-version = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+chrono = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/crates/vx-providers/vite/src/config.rs
+++ b/crates/vx-providers/vite/src/config.rs
@@ -1,0 +1,63 @@
+//! URL builder and platform configuration for Vite
+//!
+//! Vite standalone releases are available at:
+//! <https://github.com/nicholasruunu/vite-standalone/releases>
+
+use vx_runtime::{Arch, Os, Platform};
+
+/// URL builder for Vite downloads
+pub struct ViteUrlBuilder;
+
+impl ViteUrlBuilder {
+    /// Base URL for Vite standalone releases
+    const BASE_URL: &'static str =
+        "https://github.com/nicholasruunu/vite-standalone/releases/download";
+
+    /// Build the download URL for a specific version and platform
+    pub fn download_url(version: &str, platform: &Platform) -> Option<String> {
+        let target = Self::get_target_triple(platform)?;
+        let ext = Self::get_archive_extension(platform);
+        Some(format!(
+            "{}/v{}/vite-{}.{}",
+            Self::BASE_URL,
+            version,
+            target,
+            ext
+        ))
+    }
+
+    /// Get the target triple for the platform
+    pub fn get_target_triple(platform: &Platform) -> Option<String> {
+        match (&platform.os, &platform.arch) {
+            // Windows
+            (Os::Windows, Arch::X86_64) => Some("x86_64-pc-windows-msvc".to_string()),
+            (Os::Windows, Arch::Aarch64) => Some("aarch64-pc-windows-msvc".to_string()),
+
+            // macOS
+            (Os::MacOS, Arch::X86_64) => Some("x86_64-apple-darwin".to_string()),
+            (Os::MacOS, Arch::Aarch64) => Some("aarch64-apple-darwin".to_string()),
+
+            // Linux
+            (Os::Linux, Arch::X86_64) => Some("x86_64-unknown-linux-musl".to_string()),
+            (Os::Linux, Arch::Aarch64) => Some("aarch64-unknown-linux-musl".to_string()),
+
+            _ => None,
+        }
+    }
+
+    /// Get the archive extension for the platform
+    pub fn get_archive_extension(platform: &Platform) -> &'static str {
+        match platform.os {
+            Os::Windows => "zip",
+            _ => "tar.gz",
+        }
+    }
+
+    /// Get the executable name for the platform
+    pub fn get_executable_name(platform: &Platform) -> &'static str {
+        match platform.os {
+            Os::Windows => "vite.exe",
+            _ => "vite",
+        }
+    }
+}

--- a/crates/vx-providers/vite/src/lib.rs
+++ b/crates/vx-providers/vite/src/lib.rs
@@ -1,0 +1,32 @@
+//! Vite provider for vx
+//!
+//! This crate provides the Vite frontend build tool provider for vx.
+//! Vite is a next-generation frontend build tool that significantly improves
+//! the frontend development experience.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use vx_provider_vite::create_provider;
+//!
+//! let provider = create_provider();
+//! assert_eq!(provider.name(), "vite");
+//! ```
+
+mod config;
+mod provider;
+mod runtime;
+
+pub use config::ViteUrlBuilder;
+pub use provider::ViteProvider;
+pub use runtime::ViteRuntime;
+
+use std::sync::Arc;
+use vx_runtime::Provider;
+
+/// Create a new Vite provider instance
+///
+/// This is the main entry point for the provider, used by the registry.
+pub fn create_provider() -> Arc<dyn Provider> {
+    Arc::new(ViteProvider::new())
+}

--- a/crates/vx-providers/vite/src/provider.rs
+++ b/crates/vx-providers/vite/src/provider.rs
@@ -1,0 +1,44 @@
+//! Vite provider implementation
+//!
+//! Provides the Vite frontend build tool.
+
+use crate::runtime::ViteRuntime;
+use std::sync::Arc;
+use vx_runtime::{Provider, Runtime};
+
+/// Vite provider
+#[derive(Debug, Default)]
+pub struct ViteProvider;
+
+impl ViteProvider {
+    /// Create a new Vite provider
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Provider for ViteProvider {
+    fn name(&self) -> &str {
+        "vite"
+    }
+
+    fn description(&self) -> &str {
+        "Vite - Next Generation Frontend Tooling"
+    }
+
+    fn runtimes(&self) -> Vec<Arc<dyn Runtime>> {
+        vec![Arc::new(ViteRuntime::new())]
+    }
+
+    fn supports(&self, name: &str) -> bool {
+        name == "vite"
+    }
+
+    fn get_runtime(&self, name: &str) -> Option<Arc<dyn Runtime>> {
+        if name == "vite" {
+            Some(Arc::new(ViteRuntime::new()))
+        } else {
+            None
+        }
+    }
+}

--- a/crates/vx-providers/vite/src/runtime.rs
+++ b/crates/vx-providers/vite/src/runtime.rs
@@ -1,0 +1,131 @@
+//! Vite runtime implementation
+//!
+//! Vite is a next-generation frontend build tool that significantly improves
+//! the frontend development experience.
+//! <https://github.com/nicholasruunu/vite-standalone>
+
+use crate::config::ViteUrlBuilder;
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::path::Path;
+use vx_runtime::{Ecosystem, Platform, Runtime, RuntimeContext, VerificationResult, VersionInfo};
+
+/// Vite runtime implementation
+#[derive(Debug, Clone, Default)]
+pub struct ViteRuntime;
+
+impl ViteRuntime {
+    /// Create a new Vite runtime
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Runtime for ViteRuntime {
+    fn name(&self) -> &str {
+        "vite"
+    }
+
+    fn description(&self) -> &str {
+        "Vite - Next Generation Frontend Tooling"
+    }
+
+    fn aliases(&self) -> &[&str] {
+        &[]
+    }
+
+    fn ecosystem(&self) -> Ecosystem {
+        Ecosystem::NodeJs
+    }
+
+    fn metadata(&self) -> HashMap<String, String> {
+        let mut meta = HashMap::new();
+        meta.insert("homepage".to_string(), "https://vitejs.dev/".to_string());
+        meta.insert(
+            "documentation".to_string(),
+            "https://vitejs.dev/guide/".to_string(),
+        );
+        meta.insert("category".to_string(), "build-tool".to_string());
+        meta
+    }
+
+    fn executable_relative_path(&self, _version: &str, platform: &Platform) -> String {
+        ViteUrlBuilder::get_executable_name(platform).to_string()
+    }
+
+    async fn fetch_versions(&self, ctx: &RuntimeContext) -> Result<Vec<VersionInfo>> {
+        let url = "https://api.github.com/repos/nicholasruunu/vite-standalone/releases";
+        let response = ctx.http.get_json_value(url).await?;
+
+        let mut versions = Vec::new();
+
+        if let Some(releases) = response.as_array() {
+            for release in releases {
+                if release
+                    .get("draft")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+
+                let is_prerelease = release
+                    .get("prerelease")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+
+                let tag_name = match release.get("tag_name").and_then(|v| v.as_str()) {
+                    Some(tag) => tag,
+                    None => continue,
+                };
+
+                let version = tag_name.strip_prefix('v').unwrap_or(tag_name).to_string();
+
+                let published_at = release
+                    .get("published_at")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+
+                let mut version_info = VersionInfo::new(version)
+                    .with_lts(false)
+                    .with_prerelease(is_prerelease);
+
+                if let Some(date) = published_at {
+                    version_info = version_info.with_release_date(date);
+                }
+
+                versions.push(version_info);
+            }
+        }
+
+        Ok(versions)
+    }
+
+    async fn download_url(&self, version: &str, platform: &Platform) -> Result<Option<String>> {
+        Ok(ViteUrlBuilder::download_url(version, platform))
+    }
+
+    fn verify_installation(
+        &self,
+        _version: &str,
+        install_path: &Path,
+        platform: &Platform,
+    ) -> VerificationResult {
+        let exe_name = ViteUrlBuilder::get_executable_name(platform);
+        let exe_path = install_path.join(exe_name);
+
+        if exe_path.exists() {
+            VerificationResult::success(exe_path)
+        } else {
+            VerificationResult::failure(
+                vec![format!(
+                    "Vite executable not found at expected path: {}",
+                    exe_path.display()
+                )],
+                vec!["Try reinstalling the runtime".to_string()],
+            )
+        }
+    }
+}

--- a/crates/vx-providers/vite/tests/runtime_tests.rs
+++ b/crates/vx-providers/vite/tests/runtime_tests.rs
@@ -1,0 +1,139 @@
+//! Tests for Vite runtime
+
+use rstest::rstest;
+use vx_provider_vite::{ViteProvider, ViteRuntime, ViteUrlBuilder};
+use vx_runtime::{Arch, Ecosystem, Os, Platform, Provider, Runtime};
+
+#[test]
+fn test_runtime_name() {
+    let runtime = ViteRuntime::new();
+    assert_eq!(runtime.name(), "vite");
+}
+
+#[test]
+fn test_runtime_description() {
+    let runtime = ViteRuntime::new();
+    assert!(runtime.description().contains("Vite"));
+}
+
+#[test]
+fn test_runtime_ecosystem() {
+    let runtime = ViteRuntime::new();
+    assert_eq!(runtime.ecosystem(), Ecosystem::NodeJs);
+}
+
+#[test]
+fn test_runtime_metadata() {
+    let runtime = ViteRuntime::new();
+    let meta = runtime.metadata();
+    assert!(meta.contains_key("homepage"));
+    assert!(meta.get("homepage").unwrap().contains("vitejs"));
+}
+
+#[test]
+fn test_provider_name() {
+    let provider = ViteProvider::new();
+    assert_eq!(provider.name(), "vite");
+}
+
+#[test]
+fn test_provider_supports() {
+    let provider = ViteProvider::new();
+    assert!(provider.supports("vite"));
+    assert!(!provider.supports("webpack"));
+}
+
+#[test]
+fn test_provider_runtimes() {
+    let provider = ViteProvider::new();
+    let runtimes = provider.runtimes();
+    assert_eq!(runtimes.len(), 1);
+    assert_eq!(runtimes[0].name(), "vite");
+}
+
+#[test]
+fn test_provider_get_runtime() {
+    let provider = ViteProvider::new();
+    assert!(provider.get_runtime("vite").is_some());
+    assert!(provider.get_runtime("webpack").is_none());
+}
+
+#[rstest]
+#[case(Os::Linux, Arch::X86_64, "x86_64-unknown-linux-musl")]
+#[case(Os::Linux, Arch::Aarch64, "aarch64-unknown-linux-musl")]
+#[case(Os::MacOS, Arch::X86_64, "x86_64-apple-darwin")]
+#[case(Os::MacOS, Arch::Aarch64, "aarch64-apple-darwin")]
+#[case(Os::Windows, Arch::X86_64, "x86_64-pc-windows-msvc")]
+#[case(Os::Windows, Arch::Aarch64, "aarch64-pc-windows-msvc")]
+fn test_target_triple(#[case] os: Os, #[case] arch: Arch, #[case] expected: &str) {
+    let platform = Platform { os, arch };
+    let triple = ViteUrlBuilder::get_target_triple(&platform);
+    assert_eq!(triple, Some(expected.to_string()));
+}
+
+#[rstest]
+#[case(Os::Windows, "zip")]
+#[case(Os::Linux, "tar.gz")]
+#[case(Os::MacOS, "tar.gz")]
+fn test_archive_extension(#[case] os: Os, #[case] expected: &str) {
+    let platform = Platform {
+        os,
+        arch: Arch::X86_64,
+    };
+    let ext = ViteUrlBuilder::get_archive_extension(&platform);
+    assert_eq!(ext, expected);
+}
+
+#[rstest]
+#[case(Os::Windows, "vite.exe")]
+#[case(Os::Linux, "vite")]
+#[case(Os::MacOS, "vite")]
+fn test_executable_name(#[case] os: Os, #[case] expected: &str) {
+    let platform = Platform {
+        os,
+        arch: Arch::X86_64,
+    };
+    let name = ViteUrlBuilder::get_executable_name(&platform);
+    assert_eq!(name, expected);
+}
+
+#[test]
+fn test_download_url_linux_x64() {
+    let platform = Platform {
+        os: Os::Linux,
+        arch: Arch::X86_64,
+    };
+    let url = ViteUrlBuilder::download_url("6.0.0", &platform);
+    assert!(url.is_some());
+    let url = url.unwrap();
+    assert!(url.contains("vite-standalone"));
+    assert!(url.contains("v6.0.0"));
+    assert!(url.contains("x86_64-unknown-linux-musl"));
+    assert!(url.ends_with(".tar.gz"));
+}
+
+#[test]
+fn test_download_url_windows_x64() {
+    let platform = Platform {
+        os: Os::Windows,
+        arch: Arch::X86_64,
+    };
+    let url = ViteUrlBuilder::download_url("6.0.0", &platform);
+    assert!(url.is_some());
+    let url = url.unwrap();
+    assert!(url.contains("vite-standalone"));
+    assert!(url.ends_with(".zip"));
+}
+
+#[test]
+fn test_download_url_macos_arm64() {
+    let platform = Platform {
+        os: Os::MacOS,
+        arch: Arch::Aarch64,
+    };
+    let url = ViteUrlBuilder::download_url("6.0.0", &platform);
+    assert!(url.is_some());
+    let url = url.unwrap();
+    assert!(url.contains("aarch64-apple-darwin"));
+    assert!(url.ends_with(".tar.gz"));
+}

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,36 +1,48 @@
 ## Summary
 
-Fix the installation script download failures caused by incorrect release asset naming and URL construction.
-
-## Problems Fixed
-
-1. **Duplicate 'vx-' prefix in asset names**: Release assets were named `vx-vx-v0.5.7-x86_64-pc-windows-msvc.zip` instead of `vx-x86_64-pc-windows-msvc.zip`
-
-2. **Incorrect tag format in download URLs**: Installer scripts used `v0.5.7` format but actual tags are `vx-v0.5.7`
-
-3. **CDN fallbacks don't work**: jsDelivr/Fastly CDN don't support GitHub Release assets, only repository files
+Add a new VSCode provider to enable installation and management of Visual Studio Code through vx.
 
 ## Changes
 
-| File | Change |
-|------|--------|
-| `.github/workflows/release.yml` | Simplify asset naming to `vx-{target}.{ext}` (without version in filename) |
-| `install.ps1` | Use full tag name format, remove CDN fallbacks, support multiple version input formats |
-| `install.sh` | Same changes as install.ps1 |
+### New Files
 
-## After This Fix
+- `crates/vx-providers/vscode/` - New VSCode provider crate
+  - `src/provider.rs` - Provider metadata implementation
+  - `src/runtime.rs` - Runtime implementation with version fetching
+  - `src/config.rs` - URL builder for download URLs
+  - `tests/runtime_tests.rs` - 21 unit tests
 
-- Asset name: `vx-x86_64-pc-windows-msvc.zip`
-- Download URL: `https://github.com/loonghao/vx/releases/download/vx-v0.5.8/vx-x86_64-pc-windows-msvc.zip`
+### Modified Files
+
+- `crates/vx-runtime/src/impls.rs` - Enhanced extract functions with:
+  - URL fragment hints (`#.zip`) for file type detection
+  - Magic bytes detection (ZIP, GZIP) for archives without extensions
+- `crates/vx-cli/src/registry.rs` - Register VSCode provider
+- Updated snapshot tests for new provider count
+
+## Features
+
+- **Runtime names**: `code`, `vscode`, `vs-code`, `visual-studio-code`
+- **Version source**: Official VSCode SHA API with GitHub releases fallback
+- **Platform support**: Windows, macOS, Linux (x64, arm64)
+- **Archive handling**: Automatic ZIP extraction with magic bytes detection
 
 ## Testing
 
-After merging and releasing, test with:
-
-```powershell
-irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex
-```
-
 ```bash
-curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
+# Install VSCode
+vx install code 1.107.1
+
+# List installed versions
+vx list code
+
+# Locate executable
+vx where code
 ```
+
+## Checklist
+
+- [x] Code compiles without errors
+- [x] All 21 unit tests pass
+- [x] Integration tests pass
+- [x] Manual testing verified

--- a/tests/cmd/plugin/plugin-stats.md
+++ b/tests/cmd/plugin/plugin-stats.md
@@ -6,8 +6,8 @@ Verify that `vx plugin stats` shows plugin statistics.
 $ vx plugin stats
 
 [..]
-  Total providers: 9
-  Total runtimes: 15
+  Total providers: 10
+  Total runtimes: 16
 
   Providers:
     node (3 runtimes)
@@ -19,5 +19,6 @@ $ vx plugin stats
     yarn (1 runtimes)
     vscode (1 runtimes)
     just (1 runtimes)
+    vite (1 runtimes)
 
 ```

--- a/tests/cmd/search/search.md
+++ b/tests/cmd/search/search.md
@@ -21,5 +21,6 @@ $ vx search
   yarn - Fast, reliable, and secure dependency management
   code - Visual Studio Code - Code editing. Redefined.
   just - Just - A handy way to save and run project-specific commands
+  vite - Vite - Next Generation Frontend Tooling
 
 ```


### PR DESCRIPTION
## Summary

Add a new provider for [Vite](https://vitejs.dev/) - a next-generation frontend build tool that significantly improves the frontend development experience.

## Changes

- Add `vx-provider-vite` crate with full provider implementation
- Support for multiple platforms:
  - Windows (x86_64, aarch64)
  - macOS (x86_64, aarch64)
  - Linux (x86_64, aarch64)
- Fetch versions from [vite-standalone](https://github.com/nicholasruunu/vite-standalone) GitHub Releases API
- Register provider in `vx-cli` registry
- Update snapshot tests

## Files Added

- `crates/vx-providers/vite/Cargo.toml`
- `crates/vx-providers/vite/src/lib.rs`
- `crates/vx-providers/vite/src/provider.rs`
- `crates/vx-providers/vite/src/runtime.rs`
- `crates/vx-providers/vite/src/config.rs`
- `crates/vx-providers/vite/tests/runtime_tests.rs`

## Testing

- 23 unit tests added and passing
- All pre-commit hooks pass (cargo fmt, clippy, check)
- `cargo check` and `cargo test -p vx-provider-vite` pass
