### PR TITLE
feat(provider): add git provider for version management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3296,7 +3296,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vx"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3338,6 +3338,7 @@ dependencies = [
  "vx-paths",
  "vx-provider-bun",
  "vx-provider-deno",
+ "vx-provider-git",
  "vx-provider-go",
  "vx-provider-helm",
  "vx-provider-java",
@@ -3363,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "vx-core"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3382,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3408,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3419,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bun"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3431,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-deno"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3443,8 +3444,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "vx-provider-git"
+version = "0.5.15"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "reqwest",
+ "rstest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "vx-runtime",
+]
+
+[[package]]
 name = "vx-provider-go"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3459,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-helm"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3472,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-java"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3485,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-just"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3500,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kubectl"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3513,7 +3529,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-node"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3528,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pnpm"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3540,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rcedit"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3555,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rez"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3571,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rust"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3583,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-terraform"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3596,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-uv"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3611,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vite"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3626,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vscode"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3641,7 +3657,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yarn"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3653,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zig"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3666,7 +3682,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3684,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.5.13"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   "crates/vx-providers/kubectl",
   "crates/vx-providers/helm",
   "crates/vx-providers/rcedit",
+  "crates/vx-providers/git",
 ]
 resolver = "2"
 
@@ -111,6 +112,7 @@ vx-provider-terraform = { path = "crates/vx-providers/terraform" }
 vx-provider-kubectl = { path = "crates/vx-providers/kubectl" }
 vx-provider-helm = { path = "crates/vx-providers/helm" }
 vx-provider-rcedit = { path = "crates/vx-providers/rcedit" }
+vx-provider-git = { path = "crates/vx-providers/git" }
 
 # External dependencies
 clap = { version = "4.4", features = ["derive"] }

--- a/crates/vx-cli/Cargo.toml
+++ b/crates/vx-cli/Cargo.toml
@@ -36,6 +36,7 @@ vx-provider-terraform = { workspace = true }
 vx-provider-kubectl = { workspace = true }
 vx-provider-helm = { workspace = true }
 vx-provider-rcedit = { workspace = true }
+vx-provider-git = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-cli/src/registry.rs
+++ b/crates/vx-cli/src/registry.rs
@@ -63,6 +63,9 @@ pub fn create_registry() -> ProviderRegistry {
     // Register rcedit provider
     registry.register(vx_provider_rcedit::create_provider());
 
+    // Register Git provider
+    registry.register(vx_provider_git::create_provider());
+
     registry
 }
 

--- a/crates/vx-providers/git/Cargo.toml
+++ b/crates/vx-providers/git/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "vx-provider-git"
+version.workspace = true
+edition.workspace = true
+description = "Git version control system provider for vx"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+vx-runtime = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+chrono = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/crates/vx-providers/git/src/config.rs
+++ b/crates/vx-providers/git/src/config.rs
@@ -1,0 +1,122 @@
+//! URL builder and platform configuration for Git downloads.
+
+use vx_runtime::{Arch, Os, Platform};
+
+/// URL builder for Git downloads from GitHub releases.
+pub struct GitUrlBuilder;
+
+impl GitUrlBuilder {
+    /// Build the download URL for a specific Git version and platform.
+    ///
+    /// Git for Windows provides portable versions via GitHub releases.
+    /// For other platforms, Git is typically installed via system package managers.
+    pub fn download_url(version: &str, platform: &Platform) -> Option<String> {
+        // Git for Windows uses a different versioning scheme
+        // e.g., v2.43.0.windows.1 -> Git-2.43.0-64-bit.tar.bz2
+        let base_version = Self::extract_base_version(version);
+        let filename = Self::get_filename(&base_version, platform)?;
+
+        // Git for Windows releases are hosted on GitHub
+        Some(format!(
+            "https://github.com/git-for-windows/git/releases/download/v{}/{}",
+            version, filename
+        ))
+    }
+
+    /// Extract base version from Git for Windows version string.
+    /// e.g., "2.43.0.windows.1" -> "2.43.0"
+    fn extract_base_version(version: &str) -> String {
+        if let Some(pos) = version.find(".windows") {
+            version[..pos].to_string()
+        } else {
+            version.to_string()
+        }
+    }
+
+    /// Get the filename for the Git archive.
+    pub fn get_filename(version: &str, platform: &Platform) -> Option<String> {
+        match (&platform.os, &platform.arch) {
+            // Git for Windows - MinGit portable version
+            (Os::Windows, Arch::X86_64) => Some(format!("MinGit-{}-64-bit.zip", version)),
+            (Os::Windows, Arch::X86) => Some(format!("MinGit-{}-32-bit.zip", version)),
+            // For non-Windows platforms, Git should be installed via system package manager
+            // Return None to indicate no direct download available
+            _ => None,
+        }
+    }
+
+    /// Get the target triple for the platform.
+    pub fn get_target_triple(platform: &Platform) -> &'static str {
+        match (&platform.os, &platform.arch) {
+            (Os::Windows, Arch::X86_64) => "x86_64-pc-windows-msvc",
+            (Os::Windows, Arch::X86) => "i686-pc-windows-msvc",
+            (Os::Windows, Arch::Aarch64) => "aarch64-pc-windows-msvc",
+            (Os::MacOS, Arch::X86_64) => "x86_64-apple-darwin",
+            (Os::MacOS, Arch::Aarch64) => "aarch64-apple-darwin",
+            (Os::Linux, Arch::X86_64) => "x86_64-unknown-linux-gnu",
+            (Os::Linux, Arch::Aarch64) => "aarch64-unknown-linux-gnu",
+            (Os::Linux, Arch::Arm) => "arm-unknown-linux-gnueabihf",
+            _ => "unknown",
+        }
+    }
+
+    /// Get the archive extension for the platform.
+    pub fn get_archive_extension(platform: &Platform) -> &'static str {
+        match platform.os {
+            Os::Windows => "zip",
+            _ => "tar.gz",
+        }
+    }
+
+    /// Get the executable name for the platform.
+    pub fn get_executable_name(platform: &Platform) -> &'static str {
+        match platform.os {
+            Os::Windows => "git.exe",
+            _ => "git",
+        }
+    }
+
+    /// Get the platform string used in Git for Windows releases.
+    pub fn get_platform_string(platform: &Platform) -> Option<&'static str> {
+        match (&platform.os, &platform.arch) {
+            (Os::Windows, Arch::X86_64) => Some("64-bit"),
+            (Os::Windows, Arch::X86) => Some("32-bit"),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_base_version() {
+        assert_eq!(
+            GitUrlBuilder::extract_base_version("2.43.0.windows.1"),
+            "2.43.0"
+        );
+        assert_eq!(GitUrlBuilder::extract_base_version("2.43.0"), "2.43.0");
+    }
+
+    #[test]
+    fn test_get_filename_windows() {
+        let platform = Platform {
+            os: Os::Windows,
+            arch: Arch::X86_64,
+        };
+        assert_eq!(
+            GitUrlBuilder::get_filename("2.43.0", &platform),
+            Some("MinGit-2.43.0-64-bit.zip".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_filename_linux() {
+        let platform = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
+        assert_eq!(GitUrlBuilder::get_filename("2.43.0", &platform), None);
+    }
+}

--- a/crates/vx-providers/git/src/lib.rs
+++ b/crates/vx-providers/git/src/lib.rs
@@ -1,0 +1,20 @@
+//! Git provider for vx.
+//!
+//! This crate provides Git version control system support for vx,
+//! allowing users to install and manage Git versions.
+
+mod config;
+mod provider;
+mod runtime;
+
+pub use config::GitUrlBuilder;
+pub use provider::GitProvider;
+pub use runtime::GitRuntime;
+
+use std::sync::Arc;
+use vx_runtime::Provider;
+
+/// Create a new Git provider instance.
+pub fn create_provider() -> Arc<dyn Provider> {
+    Arc::new(GitProvider::new())
+}

--- a/crates/vx-providers/git/src/provider.rs
+++ b/crates/vx-providers/git/src/provider.rs
@@ -1,0 +1,32 @@
+//! Git provider implementation.
+
+use std::sync::Arc;
+
+use vx_runtime::{Provider, Runtime};
+
+use crate::runtime::GitRuntime;
+
+/// Git provider for vx.
+#[derive(Debug, Default)]
+pub struct GitProvider;
+
+impl GitProvider {
+    /// Create a new Git provider instance.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Provider for GitProvider {
+    fn name(&self) -> &str {
+        "git"
+    }
+
+    fn description(&self) -> &str {
+        "Git version control system support for vx"
+    }
+
+    fn runtimes(&self) -> Vec<Arc<dyn Runtime>> {
+        vec![Arc::new(GitRuntime::new())]
+    }
+}

--- a/crates/vx-providers/git/src/runtime.rs
+++ b/crates/vx-providers/git/src/runtime.rs
@@ -1,0 +1,108 @@
+//! Git runtime implementation.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use vx_runtime::{
+    Ecosystem, GitHubReleaseOptions, Platform, Runtime, RuntimeContext, VerificationResult,
+    VersionInfo,
+};
+
+use crate::config::GitUrlBuilder;
+
+/// Git runtime for managing Git installations.
+#[derive(Debug, Default)]
+pub struct GitRuntime;
+
+impl GitRuntime {
+    /// Create a new Git runtime instance.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Runtime for GitRuntime {
+    fn name(&self) -> &str {
+        "git"
+    }
+
+    fn description(&self) -> &str {
+        "Git - Distributed version control system"
+    }
+
+    fn aliases(&self) -> &[&str] {
+        &[]
+    }
+
+    fn ecosystem(&self) -> Ecosystem {
+        Ecosystem::System
+    }
+
+    fn metadata(&self) -> HashMap<String, String> {
+        let mut metadata = HashMap::new();
+        metadata.insert("homepage".to_string(), "https://git-scm.com/".to_string());
+        metadata.insert(
+            "repository".to_string(),
+            "https://github.com/git/git".to_string(),
+        );
+        metadata.insert(
+            "documentation".to_string(),
+            "https://git-scm.com/doc".to_string(),
+        );
+        metadata
+    }
+
+    async fn fetch_versions(&self, ctx: &RuntimeContext) -> Result<Vec<VersionInfo>> {
+        // Fetch versions from Git for Windows releases
+        // This provides portable Git versions for Windows
+        ctx.fetch_github_releases(
+            "git",
+            "git-for-windows",
+            "git",
+            GitHubReleaseOptions::new()
+                .strip_v_prefix(true)
+                .skip_prereleases(true)
+                .per_page(50),
+        )
+        .await
+    }
+
+    async fn download_url(&self, version: &str, platform: &Platform) -> Result<Option<String>> {
+        Ok(GitUrlBuilder::download_url(version, platform))
+    }
+
+    fn executable_relative_path(&self, _version: &str, platform: &Platform) -> String {
+        // MinGit extracts to a flat structure with cmd/git.exe
+        match platform.os {
+            vx_runtime::Os::Windows => "cmd/git.exe".to_string(),
+            _ => "bin/git".to_string(),
+        }
+    }
+
+    fn verify_installation(
+        &self,
+        version: &str,
+        install_path: &Path,
+        platform: &Platform,
+    ) -> VerificationResult {
+        let exe_path = install_path.join(self.executable_relative_path(version, platform));
+
+        if exe_path.exists() {
+            VerificationResult::success(exe_path)
+        } else {
+            VerificationResult::failure(
+                vec![format!(
+                    "Git executable not found at expected path: {}",
+                    exe_path.display()
+                )],
+                vec![
+                    "Try reinstalling Git with: vx install git".to_string(),
+                    "Check if the download completed successfully".to_string(),
+                ],
+            )
+        }
+    }
+}

--- a/crates/vx-providers/git/tests/runtime_tests.rs
+++ b/crates/vx-providers/git/tests/runtime_tests.rs
@@ -1,0 +1,161 @@
+//! Unit tests for Git runtime.
+
+use rstest::rstest;
+use vx_provider_git::{GitProvider, GitRuntime, GitUrlBuilder};
+use vx_runtime::{Arch, Ecosystem, Os, Platform, Provider, Runtime};
+
+#[test]
+fn test_git_runtime_creation() {
+    let runtime = GitRuntime::new();
+    assert_eq!(runtime.name(), "git");
+    assert_eq!(
+        runtime.description(),
+        "Git - Distributed version control system"
+    );
+    assert_eq!(runtime.ecosystem(), Ecosystem::System);
+}
+
+#[test]
+fn test_git_provider_creation() {
+    let provider = GitProvider::new();
+    assert_eq!(provider.name(), "git");
+    assert_eq!(
+        provider.description(),
+        "Git version control system support for vx"
+    );
+
+    let runtimes = provider.runtimes();
+    assert_eq!(runtimes.len(), 1);
+    assert_eq!(runtimes[0].name(), "git");
+}
+
+#[test]
+fn test_git_provider_supports() {
+    let provider = GitProvider::new();
+    assert!(provider.supports("git"));
+    assert!(!provider.supports("node"));
+}
+
+#[test]
+fn test_git_provider_get_runtime() {
+    let provider = GitProvider::new();
+
+    let git_runtime = provider.get_runtime("git");
+    assert!(git_runtime.is_some());
+    assert_eq!(git_runtime.unwrap().name(), "git");
+
+    let unknown_runtime = provider.get_runtime("unknown");
+    assert!(unknown_runtime.is_none());
+}
+
+#[rstest]
+#[case(Os::Windows, Arch::X86_64, "cmd/git.exe")]
+#[case(Os::Windows, Arch::X86, "cmd/git.exe")]
+#[case(Os::Linux, Arch::X86_64, "bin/git")]
+#[case(Os::MacOS, Arch::X86_64, "bin/git")]
+#[case(Os::MacOS, Arch::Aarch64, "bin/git")]
+fn test_executable_relative_path(#[case] os: Os, #[case] arch: Arch, #[case] expected: &str) {
+    let runtime = GitRuntime::new();
+    let platform = Platform { os, arch };
+    assert_eq!(
+        runtime.executable_relative_path("2.43.0", &platform),
+        expected
+    );
+}
+
+#[rstest]
+#[case(Os::Windows, Arch::X86_64, Some("MinGit-2.43.0-64-bit.zip".to_string()))]
+#[case(Os::Windows, Arch::X86, Some("MinGit-2.43.0-32-bit.zip".to_string()))]
+#[case(Os::Linux, Arch::X86_64, None)]
+#[case(Os::MacOS, Arch::X86_64, None)]
+fn test_get_filename(#[case] os: Os, #[case] arch: Arch, #[case] expected: Option<String>) {
+    let platform = Platform { os, arch };
+    assert_eq!(GitUrlBuilder::get_filename("2.43.0", &platform), expected);
+}
+
+#[rstest]
+#[case(Os::Windows, Arch::X86_64, "x86_64-pc-windows-msvc")]
+#[case(Os::MacOS, Arch::Aarch64, "aarch64-apple-darwin")]
+#[case(Os::Linux, Arch::X86_64, "x86_64-unknown-linux-gnu")]
+fn test_get_target_triple(#[case] os: Os, #[case] arch: Arch, #[case] expected: &str) {
+    let platform = Platform { os, arch };
+    assert_eq!(GitUrlBuilder::get_target_triple(&platform), expected);
+}
+
+#[rstest]
+#[case(Os::Windows, "zip")]
+#[case(Os::Linux, "tar.gz")]
+#[case(Os::MacOS, "tar.gz")]
+fn test_get_archive_extension(#[case] os: Os, #[case] expected: &str) {
+    let platform = Platform {
+        os,
+        arch: Arch::X86_64,
+    };
+    assert_eq!(GitUrlBuilder::get_archive_extension(&platform), expected);
+}
+
+#[rstest]
+#[case(Os::Windows, "git.exe")]
+#[case(Os::Linux, "git")]
+#[case(Os::MacOS, "git")]
+fn test_get_executable_name(#[case] os: Os, #[case] expected: &str) {
+    let platform = Platform {
+        os,
+        arch: Arch::X86_64,
+    };
+    assert_eq!(GitUrlBuilder::get_executable_name(&platform), expected);
+}
+
+#[test]
+fn test_download_url_windows() {
+    let platform = Platform {
+        os: Os::Windows,
+        arch: Arch::X86_64,
+    };
+    let url = GitUrlBuilder::download_url("2.43.0.windows.1", &platform);
+    assert!(url.is_some());
+    let url = url.unwrap();
+    assert!(url.contains("git-for-windows"));
+    assert!(url.contains("MinGit-2.43.0-64-bit.zip"));
+}
+
+#[test]
+fn test_download_url_linux() {
+    let platform = Platform {
+        os: Os::Linux,
+        arch: Arch::X86_64,
+    };
+    let url = GitUrlBuilder::download_url("2.43.0", &platform);
+    // Linux should return None as Git should be installed via system package manager
+    assert!(url.is_none());
+}
+
+#[test]
+fn test_extract_base_version() {
+    // Test that Windows version strings are properly parsed
+    let platform = Platform {
+        os: Os::Windows,
+        arch: Arch::X86_64,
+    };
+
+    // Full Windows version
+    let url = GitUrlBuilder::download_url("2.43.0.windows.1", &platform);
+    assert!(url.is_some());
+    assert!(url.unwrap().contains("MinGit-2.43.0-64-bit.zip"));
+
+    // Plain version
+    let url = GitUrlBuilder::download_url("2.43.0", &platform);
+    assert!(url.is_some());
+    assert!(url.unwrap().contains("MinGit-2.43.0-64-bit.zip"));
+}
+
+#[test]
+fn test_git_runtime_metadata() {
+    let runtime = GitRuntime::new();
+    let metadata = runtime.metadata();
+
+    assert!(metadata.contains_key("homepage"));
+    assert!(metadata.contains_key("repository"));
+    assert!(metadata.contains_key("documentation"));
+    assert_eq!(metadata.get("homepage").unwrap(), "https://git-scm.com/");
+}

--- a/tests/cmd/plugin/plugin-stats.md
+++ b/tests/cmd/plugin/plugin-stats.md
@@ -6,8 +6,8 @@ Verify that `vx plugin stats` shows plugin statistics.
 $ vx plugin stats
 
 [..]
-  Total providers: 18
-  Total runtimes: 24
+  Total providers: 19
+  Total runtimes: 25
 
   Providers:
     node (3 runtimes)
@@ -28,5 +28,6 @@ $ vx plugin stats
     kubectl (1 runtimes)
     helm (1 runtimes)
     rcedit (1 runtimes)
+    git (1 runtimes)
 
 ```

--- a/tests/cmd/search/search.md
+++ b/tests/cmd/search/search.md
@@ -30,5 +30,6 @@ $ vx search
   kubectl - kubectl - Kubernetes command-line tool
   helm - Helm - The package manager for Kubernetes
   rcedit - rcedit - Command-line tool to edit resources of Windows executables
+  git - Git - Distributed version control system
 
 ```


### PR DESCRIPTION
## Summary

Add a new `git` provider to manage Git installations via vx.

## Changes

### New Provider: `vx-provider-git`

- **config.rs**: URL builder and platform configuration
  - `download_url(version, platform)` - Build download URLs for Git for Windows
  - `get_target_triple(platform)` - Platform target triple
  - `get_archive_extension(platform)` - Archive extension (zip/tar.gz)
  - `get_executable_name(platform)` - Executable name

- **runtime.rs**: Runtime trait implementation
  - Fetch versions from `git-for-windows/git` GitHub releases
  - Support MinGit portable versions for Windows
  - Proper executable path resolution (`cmd/git.exe` for Windows)

- **provider.rs**: Provider trait implementation
  - Single runtime: `git`
  - Ecosystem: System

### Integration

- Registered in workspace `Cargo.toml`
- Added dependency to `vx-cli/Cargo.toml`
- Registered in `registry.rs`

### Tests

- Comprehensive unit tests using `rstest` in `tests/runtime_tests.rs`
- Updated snapshot tests for `plugin stats` and `search` commands

## Usage

```bash
# List available Git versions
vx list git

# Install specific version
vx install git@2.43.0.windows.1

# Use Git
vx run git --version
```

## Notes

- Currently supports Git for Windows (MinGit portable version)
- For Linux/macOS, Git should be installed via system package manager (returns None for download URL)