### PR TITLE
feat: add P1 providers (ninja, cmake, protoc, task, pre-commit)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3340,6 +3340,7 @@ dependencies = [
  "vx-provider-azcli",
  "vx-provider-bun",
  "vx-provider-choco",
+ "vx-provider-cmake",
  "vx-provider-deno",
  "vx-provider-docker",
  "vx-provider-gcloud",
@@ -3349,11 +3350,15 @@ dependencies = [
  "vx-provider-java",
  "vx-provider-just",
  "vx-provider-kubectl",
+ "vx-provider-ninja",
  "vx-provider-node",
  "vx-provider-pnpm",
+ "vx-provider-pre-commit",
+ "vx-provider-protoc",
  "vx-provider-rcedit",
  "vx-provider-rez",
  "vx-provider-rust",
+ "vx-provider-task",
  "vx-provider-terraform",
  "vx-provider-uv",
  "vx-provider-vite",
@@ -3467,6 +3472,21 @@ version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
+ "rstest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "vx-runtime",
+]
+
+[[package]]
+name = "vx-provider-cmake"
+version = "0.5.15"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "reqwest",
  "rstest",
  "serde",
  "serde_json",
@@ -3599,6 +3619,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "vx-provider-ninja"
+version = "0.5.15"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "reqwest",
+ "rstest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "vx-runtime",
+]
+
+[[package]]
 name = "vx-provider-node"
 version = "0.5.15"
 dependencies = [
@@ -3621,6 +3656,37 @@ dependencies = [
  "async-trait",
  "rstest",
  "serde",
+ "tokio",
+ "vx-runtime",
+]
+
+[[package]]
+name = "vx-provider-pre-commit"
+version = "0.5.15"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "reqwest",
+ "rstest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "vx-runtime",
+]
+
+[[package]]
+name = "vx-provider-protoc"
+version = "0.5.15"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "reqwest",
+ "rstest",
+ "serde",
+ "serde_json",
  "tokio",
  "vx-runtime",
 ]
@@ -3664,6 +3730,21 @@ dependencies = [
  "async-trait",
  "rstest",
  "serde",
+ "tokio",
+ "vx-runtime",
+]
+
+[[package]]
+name = "vx-provider-task"
+version = "0.5.15"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "reqwest",
+ "rstest",
+ "serde",
+ "serde_json",
  "tokio",
  "vx-runtime",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,12 @@ members = [
   "crates/vx-providers/awscli",
   "crates/vx-providers/azcli",
   "crates/vx-providers/gcloud",
+  # Build tools & Task runners (P1)
+  "crates/vx-providers/ninja",
+  "crates/vx-providers/cmake",
+  "crates/vx-providers/protoc",
+  "crates/vx-providers/task",
+  "crates/vx-providers/pre-commit",
 ]
 resolver = "2"
 
@@ -124,6 +130,11 @@ vx-provider-docker = { path = "crates/vx-providers/docker" }
 vx-provider-awscli = { path = "crates/vx-providers/awscli" }
 vx-provider-azcli = { path = "crates/vx-providers/azcli" }
 vx-provider-gcloud = { path = "crates/vx-providers/gcloud" }
+vx-provider-ninja = { path = "crates/vx-providers/ninja" }
+vx-provider-cmake = { path = "crates/vx-providers/cmake" }
+vx-provider-protoc = { path = "crates/vx-providers/protoc" }
+vx-provider-task = { path = "crates/vx-providers/task" }
+vx-provider-pre-commit = { path = "crates/vx-providers/pre-commit" }
 
 # External dependencies
 clap = { version = "4.4", features = ["derive"] }

--- a/crates/vx-cli/Cargo.toml
+++ b/crates/vx-cli/Cargo.toml
@@ -42,6 +42,11 @@ vx-provider-docker = { workspace = true }
 vx-provider-awscli = { workspace = true }
 vx-provider-azcli = { workspace = true }
 vx-provider-gcloud = { workspace = true }
+vx-provider-ninja = { workspace = true }
+vx-provider-cmake = { workspace = true }
+vx-provider-protoc = { workspace = true }
+vx-provider-task = { workspace = true }
+vx-provider-pre-commit = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-cli/src/registry.rs
+++ b/crates/vx-cli/src/registry.rs
@@ -81,6 +81,21 @@ pub fn create_registry() -> ProviderRegistry {
     // Register Google Cloud CLI provider
     registry.register(vx_provider_gcloud::create_provider());
 
+    // Register Ninja provider
+    registry.register(vx_provider_ninja::create_provider());
+
+    // Register CMake provider
+    registry.register(vx_provider_cmake::create_provider());
+
+    // Register protoc provider
+    registry.register(vx_provider_protoc::create_provider());
+
+    // Register Task (go-task) provider
+    registry.register(vx_provider_task::create_provider());
+
+    // Register pre-commit provider
+    registry.register(vx_provider_pre_commit::create_provider());
+
     registry
 }
 

--- a/crates/vx-providers/cmake/Cargo.toml
+++ b/crates/vx-providers/cmake/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "vx-provider-cmake"
+version.workspace = true
+edition.workspace = true
+description = "CMake build system provider for vx"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+vx-runtime = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+chrono = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/crates/vx-providers/cmake/src/config.rs
+++ b/crates/vx-providers/cmake/src/config.rs
@@ -1,0 +1,140 @@
+//! URL builder and platform configuration for CMake
+//!
+//! CMake releases are available at: https://github.com/Kitware/CMake/releases
+//! Download URL format varies by platform:
+//! - Windows: cmake-{version}-windows-x86_64.zip
+//! - macOS: cmake-{version}-macos-universal.tar.gz
+//! - Linux: cmake-{version}-linux-x86_64.tar.gz
+
+use vx_runtime::{Arch, Os, Platform};
+
+/// URL builder for CMake downloads
+pub struct CMakeUrlBuilder;
+
+impl CMakeUrlBuilder {
+    /// Base URL for CMake releases
+    const BASE_URL: &'static str = "https://github.com/Kitware/CMake/releases/download";
+
+    /// Build the download URL for a specific version and platform
+    pub fn download_url(version: &str, platform: &Platform) -> Option<String> {
+        let platform_suffix = Self::get_platform_suffix(platform)?;
+        let ext = Self::get_archive_extension(platform);
+        // CMake uses 'v' prefix in release tags
+        let version_tag = if version.starts_with('v') {
+            version.to_string()
+        } else {
+            format!("v{}", version)
+        };
+        // Version in filename doesn't have 'v' prefix
+        let version_num = version.trim_start_matches('v');
+        Some(format!(
+            "{}/{}/cmake-{}-{}.{}",
+            Self::BASE_URL,
+            version_tag,
+            version_num,
+            platform_suffix,
+            ext
+        ))
+    }
+
+    /// Get the platform suffix for CMake downloads
+    pub fn get_platform_suffix(platform: &Platform) -> Option<&'static str> {
+        match (&platform.os, &platform.arch) {
+            // Windows
+            (Os::Windows, Arch::X86_64) => Some("windows-x86_64"),
+            (Os::Windows, Arch::Aarch64) => Some("windows-arm64"),
+            // macOS - universal binary
+            (Os::MacOS, Arch::X86_64 | Arch::Aarch64) => Some("macos-universal"),
+            // Linux
+            (Os::Linux, Arch::X86_64) => Some("linux-x86_64"),
+            (Os::Linux, Arch::Aarch64) => Some("linux-aarch64"),
+            _ => None,
+        }
+    }
+
+    /// Get the archive extension for the platform
+    pub fn get_archive_extension(platform: &Platform) -> &'static str {
+        match platform.os {
+            Os::Windows => "zip",
+            _ => "tar.gz",
+        }
+    }
+
+    /// Get the executable name for the platform
+    pub fn get_executable_name(platform: &Platform) -> &'static str {
+        match platform.os {
+            Os::Windows => "cmake.exe",
+            _ => "cmake",
+        }
+    }
+
+    /// Get the directory name inside the archive
+    pub fn get_archive_dir_name(version: &str, platform: &Platform) -> Option<String> {
+        let platform_suffix = Self::get_platform_suffix(platform)?;
+        let version_num = version.trim_start_matches('v');
+        Some(format!("cmake-{}-{}", version_num, platform_suffix))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_download_url_linux_x64() {
+        let platform = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
+        let url = CMakeUrlBuilder::download_url("3.31.3", &platform);
+        assert_eq!(
+            url,
+            Some(
+                "https://github.com/Kitware/CMake/releases/download/v3.31.3/cmake-3.31.3-linux-x86_64.tar.gz"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_download_url_windows_x64() {
+        let platform = Platform {
+            os: Os::Windows,
+            arch: Arch::X86_64,
+        };
+        let url = CMakeUrlBuilder::download_url("3.31.3", &platform);
+        assert_eq!(
+            url,
+            Some(
+                "https://github.com/Kitware/CMake/releases/download/v3.31.3/cmake-3.31.3-windows-x86_64.zip"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_download_url_macos_arm64() {
+        let platform = Platform {
+            os: Os::MacOS,
+            arch: Arch::Aarch64,
+        };
+        let url = CMakeUrlBuilder::download_url("3.31.3", &platform);
+        assert_eq!(
+            url,
+            Some(
+                "https://github.com/Kitware/CMake/releases/download/v3.31.3/cmake-3.31.3-macos-universal.tar.gz"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_archive_dir_name() {
+        let platform = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
+        let dir = CMakeUrlBuilder::get_archive_dir_name("3.31.3", &platform);
+        assert_eq!(dir, Some("cmake-3.31.3-linux-x86_64".to_string()));
+    }
+}

--- a/crates/vx-providers/cmake/src/lib.rs
+++ b/crates/vx-providers/cmake/src/lib.rs
@@ -1,0 +1,31 @@
+//! CMake provider for vx
+//!
+//! This crate provides the CMake build system provider for vx.
+//! CMake is a cross-platform build system generator.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use vx_provider_cmake::create_provider;
+//!
+//! let provider = create_provider();
+//! assert_eq!(provider.name(), "cmake");
+//! ```
+
+mod config;
+mod provider;
+mod runtime;
+
+pub use config::CMakeUrlBuilder;
+pub use provider::CMakeProvider;
+pub use runtime::CMakeRuntime;
+
+use std::sync::Arc;
+use vx_runtime::Provider;
+
+/// Create a new CMake provider instance
+///
+/// This is the main entry point for the provider, used by the registry.
+pub fn create_provider() -> Arc<dyn Provider> {
+    Arc::new(CMakeProvider::new())
+}

--- a/crates/vx-providers/cmake/src/provider.rs
+++ b/crates/vx-providers/cmake/src/provider.rs
@@ -1,0 +1,44 @@
+//! CMake provider implementation
+//!
+//! Provides the CMake build system.
+
+use crate::runtime::CMakeRuntime;
+use std::sync::Arc;
+use vx_runtime::{Provider, Runtime};
+
+/// CMake provider
+#[derive(Debug, Default)]
+pub struct CMakeProvider;
+
+impl CMakeProvider {
+    /// Create a new CMake provider
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Provider for CMakeProvider {
+    fn name(&self) -> &str {
+        "cmake"
+    }
+
+    fn description(&self) -> &str {
+        "CMake - Cross-platform build system generator"
+    }
+
+    fn runtimes(&self) -> Vec<Arc<dyn Runtime>> {
+        vec![Arc::new(CMakeRuntime::new())]
+    }
+
+    fn supports(&self, name: &str) -> bool {
+        matches!(name, "cmake" | "ctest" | "cpack")
+    }
+
+    fn get_runtime(&self, name: &str) -> Option<Arc<dyn Runtime>> {
+        if matches!(name, "cmake" | "ctest" | "cpack") {
+            Some(Arc::new(CMakeRuntime::new()))
+        } else {
+            None
+        }
+    }
+}

--- a/crates/vx-providers/cmake/src/runtime.rs
+++ b/crates/vx-providers/cmake/src/runtime.rs
@@ -1,0 +1,111 @@
+//! CMake runtime implementation
+//!
+//! CMake is a cross-platform build system generator.
+//! https://github.com/Kitware/CMake
+
+use crate::config::CMakeUrlBuilder;
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::path::Path;
+use vx_runtime::{
+    Ecosystem, GitHubReleaseOptions, Os, Platform, Runtime, RuntimeContext, VerificationResult,
+    VersionInfo,
+};
+
+/// CMake runtime implementation
+#[derive(Debug, Clone, Default)]
+pub struct CMakeRuntime;
+
+impl CMakeRuntime {
+    /// Create a new CMake runtime
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Runtime for CMakeRuntime {
+    fn name(&self) -> &str {
+        "cmake"
+    }
+
+    fn description(&self) -> &str {
+        "CMake - Cross-platform build system generator"
+    }
+
+    fn aliases(&self) -> &[&str] {
+        &["ctest", "cpack"]
+    }
+
+    fn ecosystem(&self) -> Ecosystem {
+        Ecosystem::System
+    }
+
+    fn metadata(&self) -> HashMap<String, String> {
+        let mut meta = HashMap::new();
+        meta.insert("homepage".to_string(), "https://cmake.org/".to_string());
+        meta.insert(
+            "documentation".to_string(),
+            "https://cmake.org/documentation/".to_string(),
+        );
+        meta.insert(
+            "repository".to_string(),
+            "https://github.com/Kitware/CMake".to_string(),
+        );
+        meta.insert("category".to_string(), "build-system".to_string());
+        meta.insert("license".to_string(), "BSD-3-Clause".to_string());
+        meta
+    }
+
+    fn executable_relative_path(&self, version: &str, platform: &Platform) -> String {
+        let dir_name = CMakeUrlBuilder::get_archive_dir_name(version, platform)
+            .unwrap_or_else(|| "cmake".to_string());
+        let exe_name = CMakeUrlBuilder::get_executable_name(platform);
+
+        match &platform.os {
+            // On macOS, CMake is in CMake.app/Contents/bin/
+            Os::MacOS => format!("{}/CMake.app/Contents/bin/{}", dir_name, exe_name),
+            // On Windows and Linux, it's in bin/
+            _ => format!("{}/bin/{}", dir_name, exe_name),
+        }
+    }
+
+    async fn fetch_versions(&self, ctx: &RuntimeContext) -> Result<Vec<VersionInfo>> {
+        // CMake uses 'v' prefix in tags, strip it for version display
+        ctx.fetch_github_releases(
+            "cmake",
+            "Kitware",
+            "CMake",
+            GitHubReleaseOptions::new()
+                .strip_v_prefix(true)
+                .skip_prereleases(true),
+        )
+        .await
+    }
+
+    async fn download_url(&self, version: &str, platform: &Platform) -> Result<Option<String>> {
+        Ok(CMakeUrlBuilder::download_url(version, platform))
+    }
+
+    fn verify_installation(
+        &self,
+        version: &str,
+        install_path: &Path,
+        platform: &Platform,
+    ) -> VerificationResult {
+        let exe_path = install_path.join(self.executable_relative_path(version, platform));
+
+        if exe_path.exists() {
+            VerificationResult::success(exe_path)
+        } else {
+            VerificationResult::failure(
+                vec![format!(
+                    "CMake executable not found at expected path: {}",
+                    exe_path.display()
+                )],
+                vec!["Try reinstalling the runtime".to_string()],
+            )
+        }
+    }
+}

--- a/crates/vx-providers/ninja/Cargo.toml
+++ b/crates/vx-providers/ninja/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "vx-provider-ninja"
+version.workspace = true
+edition.workspace = true
+description = "Ninja build system provider for vx"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+vx-runtime = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+chrono = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/crates/vx-providers/ninja/src/config.rs
+++ b/crates/vx-providers/ninja/src/config.rs
@@ -1,0 +1,123 @@
+//! URL builder and platform configuration for Ninja
+//!
+//! Ninja releases are available at: https://github.com/ninja-build/ninja/releases
+//! Download URL format: https://github.com/ninja-build/ninja/releases/download/v{version}/ninja-{platform}.zip
+
+use vx_runtime::{Arch, Os, Platform};
+
+/// URL builder for Ninja downloads
+pub struct NinjaUrlBuilder;
+
+impl NinjaUrlBuilder {
+    /// Base URL for Ninja releases
+    const BASE_URL: &'static str = "https://github.com/ninja-build/ninja/releases/download";
+
+    /// Build the download URL for a specific version and platform
+    pub fn download_url(version: &str, platform: &Platform) -> Option<String> {
+        let platform_name = Self::get_platform_name(platform)?;
+        // Ninja uses 'v' prefix in release tags
+        let version_tag = if version.starts_with('v') {
+            version.to_string()
+        } else {
+            format!("v{}", version)
+        };
+        Some(format!(
+            "{}/{}/ninja-{}.zip",
+            Self::BASE_URL,
+            version_tag,
+            platform_name
+        ))
+    }
+
+    /// Get the platform name for Ninja downloads
+    pub fn get_platform_name(platform: &Platform) -> Option<&'static str> {
+        match (&platform.os, &platform.arch) {
+            // Windows - only x64
+            (Os::Windows, Arch::X86_64) => Some("win"),
+            // macOS - universal binary
+            (Os::MacOS, Arch::X86_64 | Arch::Aarch64) => Some("mac"),
+            // Linux - only x64
+            (Os::Linux, Arch::X86_64) => Some("linux"),
+            // Linux ARM64 added in recent versions
+            (Os::Linux, Arch::Aarch64) => Some("linux-aarch64"),
+            _ => None,
+        }
+    }
+
+    /// Get the executable name for the platform
+    pub fn get_executable_name(platform: &Platform) -> &'static str {
+        match platform.os {
+            Os::Windows => "ninja.exe",
+            _ => "ninja",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_download_url_linux_x64() {
+        let platform = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
+        let url = NinjaUrlBuilder::download_url("1.12.1", &platform);
+        assert_eq!(
+            url,
+            Some(
+                "https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_download_url_windows_x64() {
+        let platform = Platform {
+            os: Os::Windows,
+            arch: Arch::X86_64,
+        };
+        let url = NinjaUrlBuilder::download_url("1.12.1", &platform);
+        assert_eq!(
+            url,
+            Some(
+                "https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_download_url_macos_arm64() {
+        let platform = Platform {
+            os: Os::MacOS,
+            arch: Arch::Aarch64,
+        };
+        let url = NinjaUrlBuilder::download_url("1.12.1", &platform);
+        assert_eq!(
+            url,
+            Some(
+                "https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-mac.zip"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_download_url_with_v_prefix() {
+        let platform = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
+        let url = NinjaUrlBuilder::download_url("v1.12.1", &platform);
+        assert_eq!(
+            url,
+            Some(
+                "https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip"
+                    .to_string()
+            )
+        );
+    }
+}

--- a/crates/vx-providers/ninja/src/lib.rs
+++ b/crates/vx-providers/ninja/src/lib.rs
@@ -1,0 +1,31 @@
+//! Ninja provider for vx
+//!
+//! This crate provides the Ninja build system provider for vx.
+//! Ninja is a small build system with a focus on speed.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use vx_provider_ninja::create_provider;
+//!
+//! let provider = create_provider();
+//! assert_eq!(provider.name(), "ninja");
+//! ```
+
+mod config;
+mod provider;
+mod runtime;
+
+pub use config::NinjaUrlBuilder;
+pub use provider::NinjaProvider;
+pub use runtime::NinjaRuntime;
+
+use std::sync::Arc;
+use vx_runtime::Provider;
+
+/// Create a new Ninja provider instance
+///
+/// This is the main entry point for the provider, used by the registry.
+pub fn create_provider() -> Arc<dyn Provider> {
+    Arc::new(NinjaProvider::new())
+}

--- a/crates/vx-providers/ninja/src/provider.rs
+++ b/crates/vx-providers/ninja/src/provider.rs
@@ -1,0 +1,44 @@
+//! Ninja provider implementation
+//!
+//! Provides the Ninja build system.
+
+use crate::runtime::NinjaRuntime;
+use std::sync::Arc;
+use vx_runtime::{Provider, Runtime};
+
+/// Ninja provider
+#[derive(Debug, Default)]
+pub struct NinjaProvider;
+
+impl NinjaProvider {
+    /// Create a new Ninja provider
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Provider for NinjaProvider {
+    fn name(&self) -> &str {
+        "ninja"
+    }
+
+    fn description(&self) -> &str {
+        "Ninja - A small build system with a focus on speed"
+    }
+
+    fn runtimes(&self) -> Vec<Arc<dyn Runtime>> {
+        vec![Arc::new(NinjaRuntime::new())]
+    }
+
+    fn supports(&self, name: &str) -> bool {
+        name == "ninja"
+    }
+
+    fn get_runtime(&self, name: &str) -> Option<Arc<dyn Runtime>> {
+        if name == "ninja" {
+            Some(Arc::new(NinjaRuntime::new()))
+        } else {
+            None
+        }
+    }
+}

--- a/crates/vx-providers/pre-commit/Cargo.toml
+++ b/crates/vx-providers/pre-commit/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "vx-provider-pre-commit"
+version.workspace = true
+edition.workspace = true
+description = "pre-commit framework provider for vx"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+vx-runtime = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+chrono = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/crates/vx-providers/pre-commit/src/lib.rs
+++ b/crates/vx-providers/pre-commit/src/lib.rs
@@ -1,0 +1,29 @@
+//! pre-commit provider for vx
+//!
+//! This crate provides the pre-commit framework provider for vx.
+//! pre-commit is a framework for managing and maintaining multi-language pre-commit hooks.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use vx_provider_pre_commit::create_provider;
+//!
+//! let provider = create_provider();
+//! assert_eq!(provider.name(), "pre-commit");
+//! ```
+
+mod provider;
+mod runtime;
+
+pub use provider::PreCommitProvider;
+pub use runtime::PreCommitRuntime;
+
+use std::sync::Arc;
+use vx_runtime::Provider;
+
+/// Create a new pre-commit provider instance
+///
+/// This is the main entry point for the provider, used by the registry.
+pub fn create_provider() -> Arc<dyn Provider> {
+    Arc::new(PreCommitProvider::new())
+}

--- a/crates/vx-providers/pre-commit/src/provider.rs
+++ b/crates/vx-providers/pre-commit/src/provider.rs
@@ -1,0 +1,44 @@
+//! pre-commit provider implementation
+//!
+//! Provides the pre-commit framework.
+
+use crate::runtime::PreCommitRuntime;
+use std::sync::Arc;
+use vx_runtime::{Provider, Runtime};
+
+/// pre-commit provider
+#[derive(Debug, Default)]
+pub struct PreCommitProvider;
+
+impl PreCommitProvider {
+    /// Create a new pre-commit provider
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Provider for PreCommitProvider {
+    fn name(&self) -> &str {
+        "pre-commit"
+    }
+
+    fn description(&self) -> &str {
+        "pre-commit - A framework for managing and maintaining multi-language pre-commit hooks"
+    }
+
+    fn runtimes(&self) -> Vec<Arc<dyn Runtime>> {
+        vec![Arc::new(PreCommitRuntime::new())]
+    }
+
+    fn supports(&self, name: &str) -> bool {
+        name == "pre-commit"
+    }
+
+    fn get_runtime(&self, name: &str) -> Option<Arc<dyn Runtime>> {
+        if name == "pre-commit" {
+            Some(Arc::new(PreCommitRuntime::new()))
+        } else {
+            None
+        }
+    }
+}

--- a/crates/vx-providers/pre-commit/src/runtime.rs
+++ b/crates/vx-providers/pre-commit/src/runtime.rs
@@ -1,0 +1,177 @@
+//! pre-commit runtime implementation
+//!
+//! pre-commit is a framework for managing and maintaining multi-language pre-commit hooks.
+//! https://github.com/pre-commit/pre-commit
+//!
+//! This runtime installs pre-commit from PyPI as an isolated tool.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::path::Path;
+use vx_runtime::{
+    compare_semver, Ecosystem, InstallMethod, InstallResult, PackageRuntime, PathProvider,
+    Platform, Runtime, RuntimeContext, VerificationResult, VersionInfo,
+};
+
+/// pre-commit runtime implementation
+///
+/// pre-commit is installed as a pip package in an isolated virtual environment,
+/// similar to how pipx works.
+#[derive(Debug, Clone, Default)]
+pub struct PreCommitRuntime;
+
+impl PreCommitRuntime {
+    /// Create a new pre-commit runtime
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// pip package name for pre-commit
+    const PACKAGE_NAME: &'static str = "pre-commit";
+}
+
+#[async_trait]
+impl Runtime for PreCommitRuntime {
+    fn name(&self) -> &str {
+        "pre-commit"
+    }
+
+    fn description(&self) -> &str {
+        "pre-commit - A framework for managing and maintaining multi-language pre-commit hooks"
+    }
+
+    fn aliases(&self) -> &[&str] {
+        &[]
+    }
+
+    fn ecosystem(&self) -> Ecosystem {
+        Ecosystem::Python
+    }
+
+    fn metadata(&self) -> HashMap<String, String> {
+        let mut meta = HashMap::new();
+        meta.insert(
+            "homepage".to_string(),
+            "https://pre-commit.com/".to_string(),
+        );
+        meta.insert(
+            "documentation".to_string(),
+            "https://pre-commit.com/#intro".to_string(),
+        );
+        meta.insert(
+            "repository".to_string(),
+            "https://github.com/pre-commit/pre-commit".to_string(),
+        );
+        meta.insert("category".to_string(), "code-quality".to_string());
+        meta.insert("install_method".to_string(), "pip".to_string());
+        meta.insert("pip_package".to_string(), Self::PACKAGE_NAME.to_string());
+        meta.insert("license".to_string(), "MIT".to_string());
+        meta
+    }
+
+    fn executable_relative_path(&self, _version: &str, platform: &Platform) -> String {
+        // For pip packages, the executable is in the venv bin directory
+        if platform.is_windows() {
+            format!("venv/Scripts/{}", platform.exe_name("pre-commit"))
+        } else {
+            format!("venv/bin/{}", platform.exe_name("pre-commit"))
+        }
+    }
+
+    async fn fetch_versions(&self, ctx: &RuntimeContext) -> Result<Vec<VersionInfo>> {
+        // Fetch versions from PyPI
+        self.fetch_package_versions(ctx).await
+    }
+
+    async fn download_url(&self, _version: &str, _platform: &Platform) -> Result<Option<String>> {
+        // pip packages don't have direct download URLs
+        Ok(None)
+    }
+
+    async fn install(&self, version: &str, ctx: &RuntimeContext) -> Result<InstallResult> {
+        // Use pip package installation
+        self.install_package(version, ctx).await
+    }
+
+    async fn is_installed(&self, version: &str, ctx: &RuntimeContext) -> Result<bool> {
+        let bin_dir = ctx.paths.pip_tool_bin_dir(Self::PACKAGE_NAME, version);
+        let exe_name = if cfg!(windows) {
+            "pre-commit.exe"
+        } else {
+            "pre-commit"
+        };
+        let exe_path = bin_dir.join(exe_name);
+        Ok(exe_path.exists())
+    }
+
+    async fn installed_versions(&self, ctx: &RuntimeContext) -> Result<Vec<String>> {
+        let tool_dir = ctx.paths.pip_tool_dir(Self::PACKAGE_NAME);
+        if !ctx.fs.exists(&tool_dir) {
+            return Ok(vec![]);
+        }
+
+        let entries = ctx.fs.read_dir(&tool_dir)?;
+        let mut versions: Vec<String> = entries
+            .into_iter()
+            .filter(|p| ctx.fs.is_dir(p))
+            .filter_map(|p| p.file_name().and_then(|n| n.to_str().map(String::from)))
+            .collect();
+
+        // Sort versions (newest first) using simple semver comparison
+        versions.sort_by(|a, b| compare_semver(b, a));
+        Ok(versions)
+    }
+
+    async fn uninstall(&self, version: &str, ctx: &RuntimeContext) -> Result<()> {
+        let install_dir = ctx.paths.pip_tool_version_dir(Self::PACKAGE_NAME, version);
+        if ctx.fs.exists(&install_dir) {
+            ctx.fs.remove_dir_all(&install_dir)?;
+        }
+        Ok(())
+    }
+
+    fn verify_installation(
+        &self,
+        version: &str,
+        _install_path: &Path,
+        _platform: &Platform,
+    ) -> VerificationResult {
+        // Use package verification instead
+        let paths = vx_runtime::RealPathProvider::default();
+        let bin_dir = paths.pip_tool_bin_dir(Self::PACKAGE_NAME, version);
+        let exe_name = if cfg!(windows) {
+            "pre-commit.exe"
+        } else {
+            "pre-commit"
+        };
+        let exe_path = bin_dir.join(exe_name);
+
+        if exe_path.exists() {
+            VerificationResult::success(exe_path)
+        } else {
+            VerificationResult::failure(
+                vec![format!(
+                    "pre-commit executable not found at expected path: {}",
+                    exe_path.display()
+                )],
+                vec!["Try reinstalling with: vx install pre-commit".to_string()],
+            )
+        }
+    }
+}
+
+#[async_trait]
+impl PackageRuntime for PreCommitRuntime {
+    fn install_method(&self) -> InstallMethod {
+        InstallMethod::pip(Self::PACKAGE_NAME)
+    }
+
+    fn required_runtime(&self) -> &str {
+        "uv" // Use uv for faster Python package installation
+    }
+
+    fn required_runtime_version(&self) -> Option<&str> {
+        None
+    }
+}

--- a/crates/vx-providers/protoc/Cargo.toml
+++ b/crates/vx-providers/protoc/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "vx-provider-protoc"
+version.workspace = true
+edition.workspace = true
+description = "Protocol Buffers compiler (protoc) provider for vx"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+vx-runtime = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+chrono = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/crates/vx-providers/protoc/src/config.rs
+++ b/crates/vx-providers/protoc/src/config.rs
@@ -1,0 +1,131 @@
+//! URL builder and platform configuration for protoc
+//!
+//! protoc releases are available at: https://github.com/protocolbuffers/protobuf/releases
+//! Download URL format: protoc-{version}-{platform}.zip
+//! Examples:
+//! - protoc-29.2-win64.zip
+//! - protoc-29.2-linux-x86_64.zip
+//! - protoc-29.2-osx-universal_binary.zip
+
+use vx_runtime::{Arch, Os, Platform};
+
+/// URL builder for protoc downloads
+pub struct ProtocUrlBuilder;
+
+impl ProtocUrlBuilder {
+    /// Base URL for protoc releases
+    const BASE_URL: &'static str = "https://github.com/protocolbuffers/protobuf/releases/download";
+
+    /// Build the download URL for a specific version and platform
+    pub fn download_url(version: &str, platform: &Platform) -> Option<String> {
+        let platform_suffix = Self::get_platform_suffix(platform)?;
+        // protoc uses 'v' prefix in release tags
+        let version_tag = if version.starts_with('v') {
+            version.to_string()
+        } else {
+            format!("v{}", version)
+        };
+        // Version in filename doesn't have 'v' prefix
+        let version_num = version.trim_start_matches('v');
+        Some(format!(
+            "{}/{}/protoc-{}-{}.zip",
+            Self::BASE_URL,
+            version_tag,
+            version_num,
+            platform_suffix
+        ))
+    }
+
+    /// Get the platform suffix for protoc downloads
+    pub fn get_platform_suffix(platform: &Platform) -> Option<&'static str> {
+        match (&platform.os, &platform.arch) {
+            // Windows
+            (Os::Windows, Arch::X86_64) => Some("win64"),
+            (Os::Windows, Arch::X86) => Some("win32"),
+            // macOS - universal binary
+            (Os::MacOS, Arch::X86_64 | Arch::Aarch64) => Some("osx-universal_binary"),
+            // Linux
+            (Os::Linux, Arch::X86_64) => Some("linux-x86_64"),
+            (Os::Linux, Arch::Aarch64) => Some("linux-aarch_64"),
+            (Os::Linux, Arch::X86) => Some("linux-x86_32"),
+            _ => None,
+        }
+    }
+
+    /// Get the executable name for the platform
+    pub fn get_executable_name(platform: &Platform) -> &'static str {
+        match platform.os {
+            Os::Windows => "protoc.exe",
+            _ => "protoc",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_download_url_linux_x64() {
+        let platform = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
+        let url = ProtocUrlBuilder::download_url("29.2", &platform);
+        assert_eq!(
+            url,
+            Some(
+                "https://github.com/protocolbuffers/protobuf/releases/download/v29.2/protoc-29.2-linux-x86_64.zip"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_download_url_windows_x64() {
+        let platform = Platform {
+            os: Os::Windows,
+            arch: Arch::X86_64,
+        };
+        let url = ProtocUrlBuilder::download_url("29.2", &platform);
+        assert_eq!(
+            url,
+            Some(
+                "https://github.com/protocolbuffers/protobuf/releases/download/v29.2/protoc-29.2-win64.zip"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_download_url_macos_arm64() {
+        let platform = Platform {
+            os: Os::MacOS,
+            arch: Arch::Aarch64,
+        };
+        let url = ProtocUrlBuilder::download_url("29.2", &platform);
+        assert_eq!(
+            url,
+            Some(
+                "https://github.com/protocolbuffers/protobuf/releases/download/v29.2/protoc-29.2-osx-universal_binary.zip"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_download_url_with_v_prefix() {
+        let platform = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
+        let url = ProtocUrlBuilder::download_url("v29.2", &platform);
+        assert_eq!(
+            url,
+            Some(
+                "https://github.com/protocolbuffers/protobuf/releases/download/v29.2/protoc-29.2-linux-x86_64.zip"
+                    .to_string()
+            )
+        );
+    }
+}

--- a/crates/vx-providers/protoc/src/lib.rs
+++ b/crates/vx-providers/protoc/src/lib.rs
@@ -1,0 +1,31 @@
+//! Protoc provider for vx
+//!
+//! This crate provides the Protocol Buffers compiler (protoc) provider for vx.
+//! protoc is the compiler for Protocol Buffers, Google's data interchange format.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use vx_provider_protoc::create_provider;
+//!
+//! let provider = create_provider();
+//! assert_eq!(provider.name(), "protoc");
+//! ```
+
+mod config;
+mod provider;
+mod runtime;
+
+pub use config::ProtocUrlBuilder;
+pub use provider::ProtocProvider;
+pub use runtime::ProtocRuntime;
+
+use std::sync::Arc;
+use vx_runtime::Provider;
+
+/// Create a new protoc provider instance
+///
+/// This is the main entry point for the provider, used by the registry.
+pub fn create_provider() -> Arc<dyn Provider> {
+    Arc::new(ProtocProvider::new())
+}

--- a/crates/vx-providers/protoc/src/provider.rs
+++ b/crates/vx-providers/protoc/src/provider.rs
@@ -1,0 +1,44 @@
+//! Protoc provider implementation
+//!
+//! Provides the Protocol Buffers compiler.
+
+use crate::runtime::ProtocRuntime;
+use std::sync::Arc;
+use vx_runtime::{Provider, Runtime};
+
+/// Protoc provider
+#[derive(Debug, Default)]
+pub struct ProtocProvider;
+
+impl ProtocProvider {
+    /// Create a new protoc provider
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Provider for ProtocProvider {
+    fn name(&self) -> &str {
+        "protoc"
+    }
+
+    fn description(&self) -> &str {
+        "Protocol Buffers Compiler - Google's data interchange format"
+    }
+
+    fn runtimes(&self) -> Vec<Arc<dyn Runtime>> {
+        vec![Arc::new(ProtocRuntime::new())]
+    }
+
+    fn supports(&self, name: &str) -> bool {
+        name == "protoc" || name == "protobuf"
+    }
+
+    fn get_runtime(&self, name: &str) -> Option<Arc<dyn Runtime>> {
+        if name == "protoc" || name == "protobuf" {
+            Some(Arc::new(ProtocRuntime::new()))
+        } else {
+            None
+        }
+    }
+}

--- a/crates/vx-providers/protoc/src/runtime.rs
+++ b/crates/vx-providers/protoc/src/runtime.rs
@@ -1,0 +1,105 @@
+//! Protoc runtime implementation
+//!
+//! protoc is the Protocol Buffers compiler.
+//! https://github.com/protocolbuffers/protobuf
+
+use crate::config::ProtocUrlBuilder;
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::path::Path;
+use vx_runtime::{
+    Ecosystem, GitHubReleaseOptions, Platform, Runtime, RuntimeContext, VerificationResult,
+    VersionInfo,
+};
+
+/// Protoc runtime implementation
+#[derive(Debug, Clone, Default)]
+pub struct ProtocRuntime;
+
+impl ProtocRuntime {
+    /// Create a new protoc runtime
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Runtime for ProtocRuntime {
+    fn name(&self) -> &str {
+        "protoc"
+    }
+
+    fn description(&self) -> &str {
+        "Protocol Buffers Compiler - Google's data interchange format"
+    }
+
+    fn aliases(&self) -> &[&str] {
+        &["protobuf"]
+    }
+
+    fn ecosystem(&self) -> Ecosystem {
+        Ecosystem::System
+    }
+
+    fn metadata(&self) -> HashMap<String, String> {
+        let mut meta = HashMap::new();
+        meta.insert("homepage".to_string(), "https://protobuf.dev/".to_string());
+        meta.insert(
+            "documentation".to_string(),
+            "https://protobuf.dev/programming-guides/proto3/".to_string(),
+        );
+        meta.insert(
+            "repository".to_string(),
+            "https://github.com/protocolbuffers/protobuf".to_string(),
+        );
+        meta.insert("category".to_string(), "serialization".to_string());
+        meta.insert("license".to_string(), "BSD-3-Clause".to_string());
+        meta
+    }
+
+    fn executable_relative_path(&self, _version: &str, platform: &Platform) -> String {
+        // protoc extracts to bin/ directory
+        let exe_name = ProtocUrlBuilder::get_executable_name(platform);
+        format!("bin/{}", exe_name)
+    }
+
+    async fn fetch_versions(&self, ctx: &RuntimeContext) -> Result<Vec<VersionInfo>> {
+        // protoc uses 'v' prefix in tags, strip it for version display
+        // Filter out releases that don't have protoc binaries (e.g., language-specific releases)
+        ctx.fetch_github_releases(
+            "protoc",
+            "protocolbuffers",
+            "protobuf",
+            GitHubReleaseOptions::new()
+                .strip_v_prefix(true)
+                .skip_prereleases(true),
+        )
+        .await
+    }
+
+    async fn download_url(&self, version: &str, platform: &Platform) -> Result<Option<String>> {
+        Ok(ProtocUrlBuilder::download_url(version, platform))
+    }
+
+    fn verify_installation(
+        &self,
+        version: &str,
+        install_path: &Path,
+        platform: &Platform,
+    ) -> VerificationResult {
+        let exe_path = install_path.join(self.executable_relative_path(version, platform));
+
+        if exe_path.exists() {
+            VerificationResult::success(exe_path)
+        } else {
+            VerificationResult::failure(
+                vec![format!(
+                    "protoc executable not found at expected path: {}",
+                    exe_path.display()
+                )],
+                vec!["Try reinstalling the runtime".to_string()],
+            )
+        }
+    }
+}

--- a/crates/vx-providers/task/Cargo.toml
+++ b/crates/vx-providers/task/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "vx-provider-task"
+version.workspace = true
+edition.workspace = true
+description = "Task (go-task) runner provider for vx"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+vx-runtime = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+chrono = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/crates/vx-providers/task/src/config.rs
+++ b/crates/vx-providers/task/src/config.rs
@@ -1,0 +1,139 @@
+//! URL builder and platform configuration for Task
+//!
+//! Task releases are available at: https://github.com/go-task/task/releases
+//! Download URL format: https://github.com/go-task/task/releases/download/v{version}/task_{os}_{arch}.{ext}
+
+use vx_runtime::{Arch, Os, Platform};
+
+/// URL builder for Task downloads
+pub struct TaskUrlBuilder;
+
+impl TaskUrlBuilder {
+    /// Base URL for Task releases
+    const BASE_URL: &'static str = "https://github.com/go-task/task/releases/download";
+
+    /// Build the download URL for a specific version and platform
+    pub fn download_url(version: &str, platform: &Platform) -> Option<String> {
+        let (os_name, arch_name) = Self::get_platform_parts(platform)?;
+        let ext = Self::get_archive_extension(platform);
+        // Task uses 'v' prefix in release tags
+        let version_tag = if version.starts_with('v') {
+            version.to_string()
+        } else {
+            format!("v{}", version)
+        };
+        Some(format!(
+            "{}/{}/task_{}_{}.{}",
+            Self::BASE_URL,
+            version_tag,
+            os_name,
+            arch_name,
+            ext
+        ))
+    }
+
+    /// Get the OS and arch parts for Task downloads
+    pub fn get_platform_parts(platform: &Platform) -> Option<(&'static str, &'static str)> {
+        let os_name = match &platform.os {
+            Os::Windows => "windows",
+            Os::MacOS => "darwin",
+            Os::Linux => "linux",
+            _ => return None,
+        };
+
+        let arch_name = match &platform.arch {
+            Arch::X86_64 => "amd64",
+            Arch::Aarch64 => "arm64",
+            Arch::Arm => "arm",
+            Arch::X86 => "386",
+            _ => return None,
+        };
+
+        Some((os_name, arch_name))
+    }
+
+    /// Get the archive extension for the platform
+    pub fn get_archive_extension(platform: &Platform) -> &'static str {
+        match platform.os {
+            Os::Windows => "zip",
+            _ => "tar.gz",
+        }
+    }
+
+    /// Get the executable name for the platform
+    pub fn get_executable_name(platform: &Platform) -> &'static str {
+        match platform.os {
+            Os::Windows => "task.exe",
+            _ => "task",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_download_url_linux_x64() {
+        let platform = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
+        let url = TaskUrlBuilder::download_url("3.40.1", &platform);
+        assert_eq!(
+            url,
+            Some(
+                "https://github.com/go-task/task/releases/download/v3.40.1/task_linux_amd64.tar.gz"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_download_url_windows_x64() {
+        let platform = Platform {
+            os: Os::Windows,
+            arch: Arch::X86_64,
+        };
+        let url = TaskUrlBuilder::download_url("3.40.1", &platform);
+        assert_eq!(
+            url,
+            Some(
+                "https://github.com/go-task/task/releases/download/v3.40.1/task_windows_amd64.zip"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_download_url_macos_arm64() {
+        let platform = Platform {
+            os: Os::MacOS,
+            arch: Arch::Aarch64,
+        };
+        let url = TaskUrlBuilder::download_url("3.40.1", &platform);
+        assert_eq!(
+            url,
+            Some(
+                "https://github.com/go-task/task/releases/download/v3.40.1/task_darwin_arm64.tar.gz"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_download_url_with_v_prefix() {
+        let platform = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
+        let url = TaskUrlBuilder::download_url("v3.40.1", &platform);
+        assert_eq!(
+            url,
+            Some(
+                "https://github.com/go-task/task/releases/download/v3.40.1/task_linux_amd64.tar.gz"
+                    .to_string()
+            )
+        );
+    }
+}

--- a/crates/vx-providers/task/src/lib.rs
+++ b/crates/vx-providers/task/src/lib.rs
@@ -1,0 +1,31 @@
+//! Task provider for vx
+//!
+//! This crate provides the Task (go-task) runner provider for vx.
+//! Task is a task runner / simpler Make alternative written in Go.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use vx_provider_task::create_provider;
+//!
+//! let provider = create_provider();
+//! assert_eq!(provider.name(), "task");
+//! ```
+
+mod config;
+mod provider;
+mod runtime;
+
+pub use config::TaskUrlBuilder;
+pub use provider::TaskProvider;
+pub use runtime::TaskRuntime;
+
+use std::sync::Arc;
+use vx_runtime::Provider;
+
+/// Create a new Task provider instance
+///
+/// This is the main entry point for the provider, used by the registry.
+pub fn create_provider() -> Arc<dyn Provider> {
+    Arc::new(TaskProvider::new())
+}

--- a/crates/vx-providers/task/src/provider.rs
+++ b/crates/vx-providers/task/src/provider.rs
@@ -1,0 +1,44 @@
+//! Task provider implementation
+//!
+//! Provides the Task (go-task) runner.
+
+use crate::runtime::TaskRuntime;
+use std::sync::Arc;
+use vx_runtime::{Provider, Runtime};
+
+/// Task provider
+#[derive(Debug, Default)]
+pub struct TaskProvider;
+
+impl TaskProvider {
+    /// Create a new Task provider
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Provider for TaskProvider {
+    fn name(&self) -> &str {
+        "task"
+    }
+
+    fn description(&self) -> &str {
+        "Task - A task runner / simpler Make alternative written in Go"
+    }
+
+    fn runtimes(&self) -> Vec<Arc<dyn Runtime>> {
+        vec![Arc::new(TaskRuntime::new())]
+    }
+
+    fn supports(&self, name: &str) -> bool {
+        name == "task" || name == "go-task"
+    }
+
+    fn get_runtime(&self, name: &str) -> Option<Arc<dyn Runtime>> {
+        if name == "task" || name == "go-task" {
+            Some(Arc::new(TaskRuntime::new()))
+        } else {
+            None
+        }
+    }
+}

--- a/crates/vx-providers/task/src/runtime.rs
+++ b/crates/vx-providers/task/src/runtime.rs
@@ -1,0 +1,103 @@
+//! Task runtime implementation
+//!
+//! Task is a task runner / simpler Make alternative written in Go.
+//! https://github.com/go-task/task
+
+use crate::config::TaskUrlBuilder;
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::path::Path;
+use vx_runtime::{
+    Ecosystem, GitHubReleaseOptions, Platform, Runtime, RuntimeContext, VerificationResult,
+    VersionInfo,
+};
+
+/// Task runtime implementation
+#[derive(Debug, Clone, Default)]
+pub struct TaskRuntime;
+
+impl TaskRuntime {
+    /// Create a new Task runtime
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Runtime for TaskRuntime {
+    fn name(&self) -> &str {
+        "task"
+    }
+
+    fn description(&self) -> &str {
+        "Task - A task runner / simpler Make alternative written in Go"
+    }
+
+    fn aliases(&self) -> &[&str] {
+        &["go-task"]
+    }
+
+    fn ecosystem(&self) -> Ecosystem {
+        Ecosystem::System
+    }
+
+    fn metadata(&self) -> HashMap<String, String> {
+        let mut meta = HashMap::new();
+        meta.insert("homepage".to_string(), "https://taskfile.dev/".to_string());
+        meta.insert(
+            "documentation".to_string(),
+            "https://taskfile.dev/usage/".to_string(),
+        );
+        meta.insert(
+            "repository".to_string(),
+            "https://github.com/go-task/task".to_string(),
+        );
+        meta.insert("category".to_string(), "task-runner".to_string());
+        meta
+    }
+
+    fn executable_relative_path(&self, _version: &str, platform: &Platform) -> String {
+        // Task extracts directly without subdirectory
+        TaskUrlBuilder::get_executable_name(platform).to_string()
+    }
+
+    async fn fetch_versions(&self, ctx: &RuntimeContext) -> Result<Vec<VersionInfo>> {
+        // Task uses 'v' prefix in tags, strip it for version display
+        ctx.fetch_github_releases(
+            "task",
+            "go-task",
+            "task",
+            GitHubReleaseOptions::new()
+                .strip_v_prefix(true)
+                .skip_prereleases(true),
+        )
+        .await
+    }
+
+    async fn download_url(&self, version: &str, platform: &Platform) -> Result<Option<String>> {
+        Ok(TaskUrlBuilder::download_url(version, platform))
+    }
+
+    fn verify_installation(
+        &self,
+        _version: &str,
+        install_path: &Path,
+        platform: &Platform,
+    ) -> VerificationResult {
+        let exe_name = TaskUrlBuilder::get_executable_name(platform);
+        let exe_path = install_path.join(exe_name);
+
+        if exe_path.exists() {
+            VerificationResult::success(exe_path)
+        } else {
+            VerificationResult::failure(
+                vec![format!(
+                    "Task executable not found at expected path: {}",
+                    exe_path.display()
+                )],
+                vec!["Try reinstalling the runtime".to_string()],
+            )
+        }
+    }
+}

--- a/tests/cmd/plugin/plugin-stats.md
+++ b/tests/cmd/plugin/plugin-stats.md
@@ -6,8 +6,8 @@ Verify that `vx plugin stats` shows plugin statistics.
 $ vx plugin stats
 
 [..]
-  Total providers: 24
-  Total runtimes: 30
+  Total providers: 29
+  Total runtimes: 35
 
   Providers:
     node (3 runtimes)
@@ -34,5 +34,10 @@ $ vx plugin stats
     awscli (1 runtimes)
     azcli (1 runtimes)
     gcloud (1 runtimes)
+    ninja (1 runtimes)
+    cmake (1 runtimes)
+    protoc (1 runtimes)
+    task (1 runtimes)
+    pre-commit (1 runtimes)
 
 ```

--- a/tests/cmd/search/search.md
+++ b/tests/cmd/search/search.md
@@ -36,5 +36,10 @@ $ vx search
   aws - AWS CLI v2 - Amazon Web Services command-line interface
   az - Azure CLI - Microsoft Azure command-line interface
   gcloud - Google Cloud CLI - Google Cloud Platform command-line interface
+  ninja - Ninja - A small build system with a focus on speed
+  cmake - CMake - Cross-platform build system generator
+  protoc - Protocol Buffers Compiler - Google's data interchange format
+  task - Task - A task runner / simpler Make alternative written in Go
+  pre-commit - pre-commit - A framework for managing and maintaining multi-language pre-commit hooks
 
 ```


### PR DESCRIPTION
## Summary

This PR implements 5 P1 priority providers as part of the 2025 AI-Era Toolchain Roadmap.

## Issues Closed

- Closes #250 - [P1] Add CMake provider for C/C++ build support
- Closes #251 - [P1] Add Ninja build system provider
- Closes #252 - [P1] Add Protocol Buffers (protoc) provider
- Closes #255 - [P1] Add Task runner provider (go-task)
- Closes #257 - [P1] Add pre-commit provider for code quality

## New Providers

| Provider | Type | Description |
|----------|------|-------------|
| **ninja** | GitHub Release | Small build system with a focus on speed |
| **cmake** | GitHub Release | Cross-platform build system generator |
| **protoc** | GitHub Release | Protocol Buffers compiler |
| **task** | GitHub Release | Task runner / simpler Make alternative (go-task) |
| **pre-commit** | PyPI Package | Framework for managing pre-commit hooks |

## Implementation Details

Each provider includes:
- `config.rs` - URL builder with platform detection and unit tests
- `provider.rs` - Provider trait implementation
- `runtime.rs` - Runtime trait implementation with version fetching

### Platform Support

All providers support:
- Windows (x86_64)
- macOS (x86_64, aarch64)
- Linux (x86_64, aarch64)

### Special Notes

- **pre-commit** is Python-based and uses `uv` for installation (similar to `rez` provider)
- **cmake** on macOS extracts to `CMake.app/Contents/bin/`
- **protoc** extracts to `bin/` subdirectory

## Testing

- [x] `cargo check` passes
- [x] `cargo test` passes (16 unit tests for URL builders)
- [x] `cargo clippy` passes
- [x] `cargo fmt` applied
- [x] All providers searchable via `vx search`

## Related

- Part of #258 - [Tracking] 2025 AI-Era Toolchain Roadmap