### PR TITLE
fix: add vx managed tools bin directory to PATH in GitHub Action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3296,7 +3296,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vx"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "vx-core"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-awscli"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-azcli"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bun"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-choco"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cmake"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-deno"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-docker"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gcloud"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-git"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3553,7 +3553,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-go"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-helm"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3581,7 +3581,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-java"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-just"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kubectl"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ninja"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-node"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ollama"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pnpm"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pre-commit"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-protoc"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rcedit"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rez"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rust"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-spack"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-task"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-terraform"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-uv"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vite"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vscode"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yarn"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3852,7 +3852,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zig"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,13 @@ runs:
         echo "$INSTALL_DIR" >> $GITHUB_PATH
         export PATH="$INSTALL_DIR:$PATH"
 
+        # Add vx managed tools bin directory to PATH
+        # This allows tools installed by vx (like uv, node, etc.) to be found
+        VX_BIN_DIR="$HOME/.vx/bin"
+        mkdir -p "$VX_BIN_DIR"
+        echo "$VX_BIN_DIR" >> $GITHUB_PATH
+        export PATH="$VX_BIN_DIR:$PATH"
+
         # Skip download if already cached
         if [ -f "$INSTALL_DIR/vx" ]; then
           echo "vx already installed (from cache)"
@@ -186,6 +193,13 @@ runs:
         # Add to PATH immediately for current step and subsequent steps
         $InstallDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         $env:PATH = "$InstallDir;$env:PATH"
+
+        # Add vx managed tools bin directory to PATH
+        # This allows tools installed by vx (like uv, node, etc.) to be found
+        $VxBinDir = "$env:USERPROFILE\.vx\bin"
+        New-Item -ItemType Directory -Path $VxBinDir -Force | Out-Null
+        $VxBinDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        $env:PATH = "$VxBinDir;$env:PATH"
 
         $vxPath = "$InstallDir\vx.exe"
 
@@ -308,6 +322,9 @@ runs:
           fi
         fi
 
+        # Add vx managed tools to PATH
+        export PATH="$HOME/.vx/bin:$PATH"
+
         VERSION=$(vx --version | head -1 | awk '{print $2}')
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "vx version: $VERSION"
@@ -330,6 +347,9 @@ runs:
             export PATH="$HOME/.local/bin:$PATH"
           fi
         fi
+
+        # Add vx managed tools to PATH
+        export PATH="$HOME/.vx/bin:$PATH"
 
         echo "Pre-installing tools: ${{ inputs.tools }}"
         for tool in ${{ inputs.tools }}; do


### PR DESCRIPTION
## Summary

This PR fixes the `uv: not found` error in GitHub Actions when running `vx run <script>` after `vx setup`.

## Problem

When using the vx GitHub Action, the following workflow fails:

```yaml
- name: Setup vx
  uses: loonghao/vx@vx-v0.5.17
- name: Setup development environment
  run: vx setup
- name: Run tests
  run: vx run test  # Fails with "sh: 1: uv: not found"
```

The error occurs because:
1. `vx setup` installs tools (like `uv`) to `~/.vx/store/<tool>/<version>/`
2. On Linux/macOS, `uv` extracts to a subdirectory like `uv-x86_64-unknown-linux-gnu/`
3. `vx run test` executes a script that calls `uv` directly, but `uv` is not in PATH
4. The `get_tool_bin_path` function didn't check for tool-specific subdirectories

## Solution

### 1. GitHub Action (`action.yml`)
- Add `~/.vx/bin` to `GITHUB_PATH` in both Unix and Windows install steps
- This ensures vx-managed tools are available in subsequent workflow steps

### 2. Tool bin path resolution (`dev.rs`)
- Improve `get_tool_bin_path` to find executables in tool-specific subdirectories
- Check for `tool-*` pattern directories (e.g., `uv-x86_64-unknown-linux-gnu/`)
- Verify the directory actually contains the expected executable before returning

## Testing

- [x] All existing tests pass (`cargo test --package vx-cli`)
- [x] Pre-commit hooks pass

## Related Issue

Fixes the setup failure in:
- https://github.com/loonghao/shotgrid-mcp-server/actions/runs/20514841312/job/58940811872