### PR TITLE
fix(setup): preserve boolean values in vx.toml when using vx add

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,13 +163,16 @@ jobs:
         id: archive
         shell: bash
         run: |
-          # Use simple format: vx-{target}.{ext} (without version in filename)
-          # Version is already in the release tag, no need to duplicate
+          VERSION="${{ needs.get-tag.outputs.version }}"
+          # Use format with version: vx-{version}-{target}.{ext}
+          # Also create a symlink/copy without version for backward compatibility
           if [[ "${{ matrix.platform.os }}" == "windows-latest" ]]; then
-            echo "name=vx-${{ matrix.platform.target }}.zip" >> $GITHUB_OUTPUT
+            echo "name=vx-${VERSION}-${{ matrix.platform.target }}.zip" >> $GITHUB_OUTPUT
+            echo "name_compat=vx-${{ matrix.platform.target }}.zip" >> $GITHUB_OUTPUT
             echo "ext=zip" >> $GITHUB_OUTPUT
           else
-            echo "name=vx-${{ matrix.platform.target }}.tar.gz" >> $GITHUB_OUTPUT
+            echo "name=vx-${VERSION}-${{ matrix.platform.target }}.tar.gz" >> $GITHUB_OUTPUT
+            echo "name_compat=vx-${{ matrix.platform.target }}.tar.gz" >> $GITHUB_OUTPUT
             echo "ext=tar.gz" >> $GITHUB_OUTPUT
           fi
 
@@ -177,19 +180,28 @@ jobs:
         if: matrix.platform.os != 'windows-latest'
         run: |
           cd target/${{ matrix.platform.target }}/release
+          # Create versioned archive
           tar -czvf ../../../${{ steps.archive.outputs.name }} vx
           cd ../../..
           sha256sum ${{ steps.archive.outputs.name }} > ${{ steps.archive.outputs.name }}.sha256
+          # Create backward-compatible archive (copy without version)
+          cp ${{ steps.archive.outputs.name }} ${{ steps.archive.outputs.name_compat }}
+          sha256sum ${{ steps.archive.outputs.name_compat }} > ${{ steps.archive.outputs.name_compat }}.sha256
 
       - name: Create archive (Windows)
         if: matrix.platform.os == 'windows-latest'
         shell: pwsh
         run: |
           cd target/${{ matrix.platform.target }}/release
+          # Create versioned archive
           Compress-Archive -Path vx.exe -DestinationPath ../../../${{ steps.archive.outputs.name }}
           cd ../../..
           $hash = (Get-FileHash ${{ steps.archive.outputs.name }} -Algorithm SHA256).Hash.ToLower()
           "$hash  ${{ steps.archive.outputs.name }}" | Out-File -Encoding ASCII ${{ steps.archive.outputs.name }}.sha256
+          # Create backward-compatible archive (copy without version)
+          Copy-Item ${{ steps.archive.outputs.name }} ${{ steps.archive.outputs.name_compat }}
+          $hashCompat = (Get-FileHash ${{ steps.archive.outputs.name_compat }} -Algorithm SHA256).Hash.ToLower()
+          "$hashCompat  ${{ steps.archive.outputs.name_compat }}" | Out-File -Encoding ASCII ${{ steps.archive.outputs.name_compat }}.sha256
 
       - name: Upload artifacts to release
         uses: softprops/action-gh-release@v2
@@ -198,6 +210,8 @@ jobs:
           files: |
             ${{ steps.archive.outputs.name }}
             ${{ steps.archive.outputs.name }}.sha256
+            ${{ steps.archive.outputs.name_compat }}
+            ${{ steps.archive.outputs.name_compat }}.sha256
           fail_on_unmatched_files: true
 
   # Create GitHub Release with all artifacts

--- a/crates/vx-cli/src/commands/setup.rs
+++ b/crates/vx-cli/src/commands/setup.rs
@@ -396,7 +396,7 @@ fn write_vx_config(path: &Path, config: &VxConfig) -> Result<()> {
         let mut settings: Vec<_> = config.settings.iter().collect();
         settings.sort_by_key(|(k, _)| *k);
         for (key, value) in settings {
-            content.push_str(&format!("{} = \"{}\"\n", key, value));
+            content.push_str(&format!("{} = {}\n", key, format_toml_value(value)));
         }
         content.push('\n');
     }
@@ -424,4 +424,25 @@ fn write_vx_config(path: &Path, config: &VxConfig) -> Result<()> {
 
     fs::write(path, content)?;
     Ok(())
+}
+
+/// Format a value for TOML output, detecting booleans and numbers
+fn format_toml_value(value: &str) -> String {
+    // Check if it's a boolean
+    if value == "true" || value == "false" {
+        return value.to_string();
+    }
+
+    // Check if it's an integer
+    if value.parse::<i64>().is_ok() {
+        return value.to_string();
+    }
+
+    // Check if it's a float
+    if value.parse::<f64>().is_ok() {
+        return value.to_string();
+    }
+
+    // Otherwise, quote it as a string
+    format!("\"{}\"", value)
 }

--- a/crates/vx-cli/tests/setup_tests.rs
+++ b/crates/vx-cli/tests/setup_tests.rs
@@ -1,0 +1,222 @@
+//! Tests for setup command functionality
+//!
+//! These tests verify the vx add/rm-tool/update-tool commands
+//! correctly handle TOML value types (booleans, numbers, strings).
+
+use rstest::rstest;
+use std::fs;
+use tempfile::TempDir;
+
+#[macro_use]
+mod common;
+use common::{combined_output, is_success, run_vx_in_dir};
+
+// ============================================================================
+// TOML Value Preservation Tests
+// ============================================================================
+
+/// Test: vx add preserves boolean values (not quoted as strings)
+#[rstest]
+#[test]
+fn test_add_preserves_boolean_true() {
+    skip_if_no_vx!();
+
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+
+    // Create initial config with boolean setting
+    fs::write(
+        temp_dir.path().join("vx.toml"),
+        r#"[tools]
+python = "3.11"
+
+[settings]
+auto_install = true
+"#,
+    )
+    .expect("Failed to write vx.toml");
+
+    let output = run_vx_in_dir(temp_dir.path(), &["add", "uv", "--version", "latest"])
+        .expect("Failed to run vx add");
+
+    if is_success(&output) {
+        let content =
+            fs::read_to_string(temp_dir.path().join("vx.toml")).expect("Failed to read vx.toml");
+
+        // Boolean should NOT be quoted
+        assert!(
+            !content.contains(r#"auto_install = "true""#),
+            "Boolean true should not be quoted: {}",
+            content
+        );
+        assert!(
+            content.contains("auto_install = true"),
+            "Boolean true should be preserved: {}",
+            content
+        );
+    }
+}
+
+/// Test: vx add preserves boolean false values
+#[rstest]
+#[test]
+fn test_add_preserves_boolean_false() {
+    skip_if_no_vx!();
+
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+
+    fs::write(
+        temp_dir.path().join("vx.toml"),
+        r#"[tools]
+python = "3.11"
+
+[settings]
+parallel_install = false
+"#,
+    )
+    .expect("Failed to write vx.toml");
+
+    let output = run_vx_in_dir(temp_dir.path(), &["add", "go", "--version", "latest"])
+        .expect("Failed to run vx add");
+
+    if is_success(&output) {
+        let content =
+            fs::read_to_string(temp_dir.path().join("vx.toml")).expect("Failed to read vx.toml");
+
+        assert!(
+            !content.contains(r#"parallel_install = "false""#),
+            "Boolean false should not be quoted: {}",
+            content
+        );
+        assert!(
+            content.contains("parallel_install = false"),
+            "Boolean false should be preserved: {}",
+            content
+        );
+    }
+}
+
+/// Test: vx add preserves string values with quotes
+#[rstest]
+#[test]
+fn test_add_preserves_string_values() {
+    skip_if_no_vx!();
+
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+
+    fs::write(
+        temp_dir.path().join("vx.toml"),
+        r#"[tools]
+python = "3.11"
+
+[settings]
+cache_duration = "7d"
+"#,
+    )
+    .expect("Failed to write vx.toml");
+
+    let output = run_vx_in_dir(temp_dir.path(), &["add", "node", "--version", "20"])
+        .expect("Failed to run vx add");
+
+    if is_success(&output) {
+        let content =
+            fs::read_to_string(temp_dir.path().join("vx.toml")).expect("Failed to read vx.toml");
+
+        // String should be quoted
+        assert!(
+            content.contains(r#"cache_duration = "7d""#),
+            "String value should be quoted: {}",
+            content
+        );
+    }
+}
+
+/// Test: Config remains parseable after vx add with boolean settings
+#[rstest]
+#[test]
+fn test_config_parseable_after_add() {
+    skip_if_no_vx!();
+
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+
+    fs::write(
+        temp_dir.path().join("vx.toml"),
+        r#"[tools]
+python = "3.11"
+
+[settings]
+auto_install = true
+cache_duration = "7d"
+"#,
+    )
+    .expect("Failed to write vx.toml");
+
+    // Add a tool
+    let output = run_vx_in_dir(temp_dir.path(), &["add", "uv", "--version", "latest"])
+        .expect("Failed to run vx add");
+
+    if is_success(&output) {
+        // Verify config can still be parsed
+        let output2 = run_vx_in_dir(temp_dir.path(), &["config", "show"])
+            .expect("Failed to run vx config show");
+
+        assert!(
+            is_success(&output2),
+            "Config should be parseable after add: {}",
+            combined_output(&output2)
+        );
+    }
+}
+
+/// Test: Multiple tools can be added without corrupting boolean settings
+#[rstest]
+#[test]
+fn test_multiple_adds_preserve_settings() {
+    skip_if_no_vx!();
+
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+
+    fs::write(
+        temp_dir.path().join("vx.toml"),
+        r#"[tools]
+python = "3.11"
+
+[settings]
+auto_install = true
+parallel_install = false
+cache_duration = "7d"
+"#,
+    )
+    .expect("Failed to write vx.toml");
+
+    // Add first tool
+    let _ = run_vx_in_dir(temp_dir.path(), &["add", "uv", "--version", "latest"]);
+
+    // Add second tool
+    let _ = run_vx_in_dir(temp_dir.path(), &["add", "node", "--version", "20"]);
+
+    // Verify config is still valid
+    let output =
+        run_vx_in_dir(temp_dir.path(), &["config", "show"]).expect("Failed to run vx config show");
+
+    let combined = combined_output(&output);
+    assert!(
+        is_success(&output) || !combined.contains("invalid type"),
+        "Config should remain valid after multiple adds: {}",
+        combined
+    );
+
+    // Check the actual content
+    let content =
+        fs::read_to_string(temp_dir.path().join("vx.toml")).expect("Failed to read vx.toml");
+
+    assert!(
+        content.contains("auto_install = true"),
+        "auto_install should be preserved: {}",
+        content
+    );
+    assert!(
+        content.contains("parallel_install = false"),
+        "parallel_install should be preserved: {}",
+        content
+    );
+}

--- a/distribution.toml
+++ b/distribution.toml
@@ -55,21 +55,31 @@ sync_source = "manual"
 timeout = { connect = 15, total = 60 }
 
 # Platform-specific binary naming conventions
-# Format: vx-{target}.{ext} where target is the Rust target triple
+# New format: vx-{version}-{target}.{ext} (e.g., vx-0.5.29-x86_64-pc-windows-msvc.zip)
+# Legacy format: vx-{target}.{ext} (e.g., vx-x86_64-pc-windows-msvc.zip)
+# Both formats are available for backward compatibility
 [binaries]
 # Windows binaries
 "windows-x64" = "vx-x86_64-pc-windows-msvc.zip"
+"windows-x64-versioned" = "vx-{version}-x86_64-pc-windows-msvc.zip"
 "windows-arm64" = "vx-aarch64-pc-windows-msvc.zip"
+"windows-arm64-versioned" = "vx-{version}-aarch64-pc-windows-msvc.zip"
 
 # Linux binaries (prefer musl for static linking)
 "linux-x64" = "vx-x86_64-unknown-linux-musl.tar.gz"
+"linux-x64-versioned" = "vx-{version}-x86_64-unknown-linux-musl.tar.gz"
 "linux-x64-fallback" = "vx-x86_64-unknown-linux-gnu.tar.gz"
+"linux-x64-fallback-versioned" = "vx-{version}-x86_64-unknown-linux-gnu.tar.gz"
 "linux-arm64" = "vx-aarch64-unknown-linux-musl.tar.gz"
+"linux-arm64-versioned" = "vx-{version}-aarch64-unknown-linux-musl.tar.gz"
 "linux-arm64-fallback" = "vx-aarch64-unknown-linux-gnu.tar.gz"
+"linux-arm64-fallback-versioned" = "vx-{version}-aarch64-unknown-linux-gnu.tar.gz"
 
 # macOS binaries
 "macos-x64" = "vx-x86_64-apple-darwin.tar.gz"
+"macos-x64-versioned" = "vx-{version}-x86_64-apple-darwin.tar.gz"
 "macos-arm64" = "vx-aarch64-apple-darwin.tar.gz"
+"macos-arm64-versioned" = "vx-{version}-aarch64-apple-darwin.tar.gz"
 
 # Package manager integrations
 [package_managers.homebrew]

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -52,6 +52,15 @@ cargo install vx
 
 1. Go to the [Releases page](https://github.com/loonghao/vx/releases)
 2. Download the appropriate binary for your platform:
+
+   **With version number (recommended):**
+   - `vx-{version}-x86_64-unknown-linux-gnu.tar.gz` - Linux x64
+   - `vx-{version}-aarch64-unknown-linux-gnu.tar.gz` - Linux ARM64
+   - `vx-{version}-x86_64-apple-darwin.tar.gz` - macOS x64
+   - `vx-{version}-aarch64-apple-darwin.tar.gz` - macOS ARM64 (Apple Silicon)
+   - `vx-{version}-x86_64-pc-windows-msvc.zip` - Windows x64
+
+   **Legacy format (also available):**
    - `vx-x86_64-unknown-linux-gnu.tar.gz` - Linux x64
    - `vx-aarch64-unknown-linux-gnu.tar.gz` - Linux ARM64
    - `vx-x86_64-apple-darwin.tar.gz` - macOS x64

--- a/docs/zh/guide/installation.md
+++ b/docs/zh/guide/installation.md
@@ -52,6 +52,15 @@ cargo install vx
 
 1. 前往 [Releases 页面](https://github.com/loonghao/vx/releases)
 2. 下载适合你平台的二进制文件：
+
+   **带版本号格式（推荐）：**
+   - `vx-{version}-x86_64-unknown-linux-gnu.tar.gz` - Linux x64
+   - `vx-{version}-aarch64-unknown-linux-gnu.tar.gz` - Linux ARM64
+   - `vx-{version}-x86_64-apple-darwin.tar.gz` - macOS x64
+   - `vx-{version}-aarch64-apple-darwin.tar.gz` - macOS ARM64 (Apple Silicon)
+   - `vx-{version}-x86_64-pc-windows-msvc.zip` - Windows x64
+
+   **旧版格式（同样可用）：**
    - `vx-x86_64-unknown-linux-gnu.tar.gz` - Linux x64
    - `vx-aarch64-unknown-linux-gnu.tar.gz` - Linux ARM64
    - `vx-x86_64-apple-darwin.tar.gz` - macOS x64


### PR DESCRIPTION
## Summary

Fixes the issue where `vx add` command writes boolean values as quoted strings (e.g., `auto_install = "true"`) instead of proper TOML booleans (e.g., `auto_install = true`), causing the configuration file to become unparseable.

## Changes

### Bug Fix
- **`crates/vx-cli/src/commands/setup.rs`**: Added `format_toml_value()` helper function to detect and preserve TOML value types (booleans, integers, floats, strings)

### Release Artifacts with Version Numbers
- **`.github/workflows/release.yml`**: Build artifacts now include version number in filename (e.g., `vx-0.5.29-x86_64-pc-windows-msvc.zip`) alongside legacy format for backward compatibility
- **`distribution.toml`**: Updated binary naming documentation

### Installation Script Updates
- **`install.sh`**: Updated to try versioned archive format first, then fallback to legacy format
- **`install.ps1`**: Same update for Windows PowerShell installer

### Tests
- **`crates/vx-cli/tests/setup_tests.rs`**: New test file for TOML value preservation
- **`crates/vx-cli/tests/project_context/mod.rs`**: Additional tests for boolean settings

### Documentation
- **`docs/guide/installation.md`**: Updated with new versioned artifact naming
- **`docs/zh/guide/installation.md`**: Chinese translation updated

## Testing

All tests pass:
```
test test_config_parseable_after_add ... ok
test test_add_preserves_boolean_false ... ok
test test_add_preserves_boolean_true ... ok
test test_add_preserves_string_values ... ok
test test_multiple_adds_preserve_settings ... ok
```

## Reproduction Steps (Before Fix)

```powershell
vx add go
vx rm-tool go  # Error: invalid type: string "true", expected a boolean
```

## After Fix

Boolean values are correctly preserved as TOML booleans, and the configuration file remains parseable after any `vx add`/`vx rm-tool`/`vx update-tool` operations.