### PR TITLE
fix(ci): correct release asset naming in Docker and package manager workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -77,17 +77,26 @@ jobs:
           VERSION="${{ needs.check-release.outputs.version }}"
 
           # Determine architecture
+          # Note: We use gnu instead of musl because musl builds are not available
           if [[ "${{ matrix.platform }}" == "linux/amd64" ]]; then
-            ARCH="x86_64-unknown-linux-musl"
+            ARCH="x86_64-unknown-linux-gnu"
           else
-            ARCH="aarch64-unknown-linux-musl"
+            ARCH="aarch64-unknown-linux-gnu"
           fi
 
-          # Download binary
-          DOWNLOAD_URL="https://github.com/loonghao/vx/releases/download/${VERSION}/vx-${ARCH}.tar.gz"
-          echo "Downloading from: $DOWNLOAD_URL"
+          # Try versioned format first, then fall back to non-versioned format
+          VERSION_NUM=$(echo "${VERSION}" | sed -E 's/^(vx-)?v//')
+          DOWNLOAD_URL_VERSIONED="https://github.com/loonghao/vx/releases/download/${VERSION}/vx-${VERSION_NUM}-${ARCH}.tar.gz"
+          DOWNLOAD_URL_COMPAT="https://github.com/loonghao/vx/releases/download/${VERSION}/vx-${ARCH}.tar.gz"
 
-          curl -fsSL "$DOWNLOAD_URL" -o vx.tar.gz
+          echo "Trying versioned URL: $DOWNLOAD_URL_VERSIONED"
+          if curl -fsSL "$DOWNLOAD_URL_VERSIONED" -o vx.tar.gz 2>/dev/null; then
+            echo "Downloaded from versioned URL"
+          else
+            echo "Versioned URL failed, trying compatible URL: $DOWNLOAD_URL_COMPAT"
+            curl -fsSL "$DOWNLOAD_URL_COMPAT" -o vx.tar.gz
+          fi
+
           tar -xzf vx.tar.gz
           chmod +x vx
 

--- a/.github/workflows/package-managers.yml
+++ b/.github/workflows/package-managers.yml
@@ -118,8 +118,9 @@ jobs:
           identifier: loonghao.vx
           # release-tag must match the GitHub release tag (with 'v' prefix)
           release-tag: ${{ needs.check-release.outputs.version }}
-          # Only match Windows installer files (.exe, .msi, .zip)
-          installers-regex: '\.(exe|msi|zip)$'
+          # Only match Windows MSVC zip files (exclude sha256 files and non-Windows builds)
+          # Matches: vx-0.6.2-x86_64-pc-windows-msvc.zip, vx-x86_64-pc-windows-msvc.zip
+          installers-regex: 'windows-msvc\.zip$'
           max-versions-to-keep: 5
           token: ${{ secrets.WINGET_TOKEN }}
 
@@ -135,35 +136,48 @@ jobs:
 
       - name: Download Windows binary from release
         run: |
-          # Download pre-built binary from GitHub Release (built by tag-release-assets.yml)
+          # Download pre-built binary from GitHub Release (built by release.yml)
           $version = "${{ needs.check-release.outputs.version }}"
-          $downloadUrl = "https://github.com/loonghao/vx/releases/download/$version/vx-windows-x64.zip"
-          Write-Host "Downloading pre-built binary from: $downloadUrl"
+          # Extract version number: vx-v0.6.2 -> 0.6.2, v0.6.2 -> 0.6.2
+          $versionNum = $version -replace '^(vx-)?v', ''
+
+          # Try versioned format first, then fall back to non-versioned format
+          $downloadUrlVersioned = "https://github.com/loonghao/vx/releases/download/$version/vx-$versionNum-x86_64-pc-windows-msvc.zip"
+          $downloadUrlCompat = "https://github.com/loonghao/vx/releases/download/$version/vx-x86_64-pc-windows-msvc.zip"
+
+          Write-Host "Trying versioned URL: $downloadUrlVersioned"
 
           try {
-            # Download the zip file
-            Invoke-WebRequest -Uri $downloadUrl -OutFile "vx-windows-x64.zip" -ErrorAction Stop
-            Write-Host "Downloaded zip size: $((Get-Item vx-windows-x64.zip).Length) bytes"
-
-            # Extract the exe from zip
-            Expand-Archive -Path "vx-windows-x64.zip" -DestinationPath "." -Force
-
-            # Find the vx.exe file (it might be in a subdirectory)
-            $exeFile = Get-ChildItem -Recurse -Name "vx.exe" | Select-Object -First 1
-            if ($exeFile) {
-              Copy-Item $exeFile "vx.exe"
-              Write-Host "Extracted vx.exe size: $((Get-Item vx.exe).Length) bytes"
-            } else {
-              Write-Host "vx.exe not found in the zip file"
-              Write-Host "Contents of zip:"
-              Get-ChildItem -Recurse | ForEach-Object { Write-Host "  - $($_.FullName)" }
+            Invoke-WebRequest -Uri $downloadUrlVersioned -OutFile "vx-windows.zip" -ErrorAction Stop
+            Write-Host "Downloaded from versioned URL"
+          } catch {
+            Write-Host "Versioned URL failed, trying compatible URL: $downloadUrlCompat"
+            try {
+              Invoke-WebRequest -Uri $downloadUrlCompat -OutFile "vx-windows.zip" -ErrorAction Stop
+              Write-Host "Downloaded from compatible URL"
+            } catch {
+              Write-Host "Failed to download binary from both URLs"
+              Write-Host "Available releases:"
+              $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/loonghao/vx/releases"
+              $releases | ForEach-Object { Write-Host "  - $($_.tag_name)" }
               exit 1
             }
-          } catch {
-            Write-Host "Failed to download or extract binary: $_"
-            Write-Host "Available releases:"
-            $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/loonghao/vx/releases"
-            $releases | ForEach-Object { Write-Host "  - $($_.tag_name)" }
+          }
+
+          Write-Host "Downloaded zip size: $((Get-Item vx-windows.zip).Length) bytes"
+
+          # Extract the exe from zip
+          Expand-Archive -Path "vx-windows.zip" -DestinationPath "." -Force
+
+          # Find the vx.exe file (it might be in a subdirectory)
+          $exeFile = Get-ChildItem -Recurse -Name "vx.exe" | Select-Object -First 1
+          if ($exeFile) {
+            Copy-Item $exeFile "vx.exe"
+            Write-Host "Extracted vx.exe size: $((Get-Item vx.exe).Length) bytes"
+          } else {
+            Write-Host "vx.exe not found in the zip file"
+            Write-Host "Contents of zip:"
+            Get-ChildItem -Recurse | ForEach-Object { Write-Host "  - $($_.FullName)" }
             exit 1
           }
 


### PR DESCRIPTION
## Summary

Fix CI workflow failures caused by incorrect release asset naming conventions.

## Issues Fixed

### 1. Docker Publish Workflow (`docker-publish.yml`)
- **Problem**: Tried to download `vx-x86_64-unknown-linux-musl.tar.gz` which doesn't exist
- **Solution**: Changed to use `gnu` builds instead of `musl` (musl builds are not available)
- Added fallback logic to try versioned format first, then non-versioned format

### 2. Chocolatey Workflow (`package-managers.yml`)
- **Problem**: Tried to download `vx-windows-x64.zip` which doesn't exist
- **Solution**: Updated to use correct naming format `vx-{version}-x86_64-pc-windows-msvc.zip`
- Added fallback logic to try versioned format first, then non-versioned format

### 3. WinGet Workflow (`package-managers.yml`)
- **Problem**: `installers-regex` was too broad, matching non-Windows files
- **Solution**: Changed regex from `\.(exe|msi|zip)$` to `windows-msvc\.zip$` to only match Windows MSVC builds

## Release Asset Naming Convention

The release workflow produces assets in two formats:
- **Versioned**: `vx-{version}-{target}.{ext}` (e.g., `vx-0.6.2-x86_64-pc-windows-msvc.zip`)
- **Compatible**: `vx-{target}.{ext}` (e.g., `vx-x86_64-pc-windows-msvc.zip`)

All workflows now try the versioned format first, then fall back to the compatible format.

## Testing

These changes can be verified by:
1. Triggering the Docker Publish workflow manually
2. Triggering the Package Managers workflow manually
3. Creating a new release and verifying all workflows succeed