### PR TITLE
docs: complete RFC-0028 remaining tasks - Yarn 2.x+ corepack support

### DIFF
--- a/docs/tools/nodejs.md
+++ b/docs/tools/nodejs.md
@@ -10,7 +10,7 @@ vx provides comprehensive support for the Node.js ecosystem.
 | `npm` | Node.js package manager |
 | `npx` | Node.js package runner |
 | `pnpm` | Fast, disk space efficient package manager |
-| `yarn` | JavaScript package manager |
+| `yarn` | JavaScript package manager (all versions) |
 | `bun` | All-in-one JavaScript runtime |
 
 ## Node.js
@@ -75,14 +75,28 @@ vx pnpm add react
 
 ## Yarn
 
-vx supports Yarn 1.x (Classic). For Yarn 2.x+ (Berry), please use corepack which is bundled with Node.js.
+vx provides seamless support for **all Yarn versions** - both Yarn 1.x (Classic) and Yarn 2.x+ (Berry/Modern).
+
+### Yarn Version Support
+
+| Version | Type | Installation Method |
+|---------|------|---------------------|
+| 1.x | Classic | Direct download from GitHub releases |
+| 2.x | Berry | Via corepack (auto-managed) |
+| 3.x | Berry | Via corepack (auto-managed) |
+| 4.x | Berry | Via corepack (auto-managed) |
 
 ### Yarn 1.x (Classic)
 
+Yarn 1.x is directly downloaded and installed by vx:
+
 ```bash
 # Install Yarn 1.x
-vx install yarn 1.22.19
-vx yarn --version
+vx install yarn 1.22.22
+
+# Check version
+vx yarn@1.22.22 --version
+# Output: 1.22.22
 
 # Usage
 vx yarn install
@@ -90,22 +104,64 @@ vx yarn build
 vx yarn add react
 ```
 
-### Yarn 2.x+ (Berry)
+### Yarn 2.x+ (Berry/Modern)
 
-Yarn 2.x+ (Berry) is not directly installable via vx. Instead, use corepack which is bundled with Node.js:
+Yarn 2.x and later versions are **automatically managed via corepack** - vx handles this transparently:
 
 ```bash
-# Install Node.js first
-vx install node 20
+# Use any Yarn 2.x+ version directly
+vx yarn@2.4.3 --version    # Berry 2.x
+# Output: 2.4.3
 
-# Enable corepack (provides Yarn 2.x+)
-vx node -e "require('child_process').execSync('corepack enable', {stdio: 'inherit'})"
+vx yarn@3.6.0 --version    # Berry 3.x
+# Output: 3.6.0
 
-# Or use npx to run Yarn
-vx npx yarn@2.4.3 --version
+vx yarn@4.0.0 --version    # Berry 4.x
+# Output: 4.0.0
+
+vx yarn@4.12.0 --version   # Latest Berry
+# Output: 4.12.0
 ```
 
-For more details, see the [Yarn official documentation](https://yarnpkg.com/getting-started/install).
+**How it works:**
+
+1. When you request Yarn 2.x+, vx automatically:
+   - Ensures Node.js (with corepack) is installed
+   - Enables corepack if not already enabled
+   - Prepares the specific Yarn version via `corepack prepare yarn@<version> --activate`
+   - Executes Yarn through corepack
+
+2. You don't need to manually enable corepack or run any setup commands - vx handles everything transparently.
+
+### Using Yarn in Projects
+
+```bash
+# Create a new project with Yarn Berry
+mkdir my-project && cd my-project
+vx yarn@4.0.0 init
+
+# Install dependencies
+vx yarn@4.0.0 install
+
+# Add packages
+vx yarn@4.0.0 add react
+
+# Run scripts
+vx yarn@4.0.0 build
+```
+
+### Yarn Version Pinning
+
+For projects using Yarn Berry, vx respects the `packageManager` field in `package.json`:
+
+```json
+{
+  "name": "my-project",
+  "packageManager": "yarn@4.0.0"
+}
+```
+
+When this field exists, corepack ensures the correct version is used automatically.
 
 ## Bun
 
@@ -127,11 +183,12 @@ vx bun build ./index.ts
 [tools]
 node = "20"
 pnpm = "latest"
+yarn = "4.0.0"  # Yarn Berry works seamlessly
 
 [scripts]
-dev = "pnpm run dev"
-build = "pnpm run build"
-test = "pnpm test"
+dev = "yarn run dev"
+build = "yarn run build"
+test = "yarn test"
 ```
 
 ## Common Workflows
@@ -159,4 +216,14 @@ vx npm create vite@latest my-app
 cd my-app
 vx npm install
 vx npm run dev
+```
+
+### Yarn Berry Project
+
+```bash
+# Create a new project with Yarn 4.x
+mkdir my-yarn-project && cd my-yarn-project
+vx yarn@4.0.0 init
+vx yarn@4.0.0 add react react-dom
+vx yarn@4.0.0 dev
 ```

--- a/docs/zh/tools/nodejs.md
+++ b/docs/zh/tools/nodejs.md
@@ -1,6 +1,6 @@
-# Node.js
+# Node.js 生态系统
 
-vx 支持 Node.js 及其生态系统工具。
+vx 提供对 Node.js 生态系统的全面支持。
 
 ## 支持的工具
 
@@ -9,16 +9,37 @@ vx 支持 Node.js 及其生态系统工具。
 | `node` | Node.js 运行时 |
 | `npm` | Node.js 包管理器 |
 | `npx` | Node.js 包运行器 |
-| `pnpm` | 快速包管理器 |
-| `yarn` | Yarn 包管理器 |
+| `pnpm` | 快速、高效的包管理器 |
+| `yarn` | JavaScript 包管理器（支持所有版本） |
 | `bun` | Bun JavaScript 运行时 |
 
-## 使用示例
+## Node.js
+
+### 安装
+
+```bash
+vx install node 20
+vx install node lts
+vx install node latest
+```
+
+### 版本说明
+
+```bash
+node 20          # 最新 20.x.x
+node 20.10       # 最新 20.10.x
+node 20.10.0     # 精确版本
+node lts         # 最新 LTS
+node latest      # 最新稳定版
+```
+
+### 使用示例
 
 ```bash
 # 运行 Node.js
 vx node --version
 vx node script.js
+vx node -e "console.log('Hello')"
 
 # 使用 npm
 vx npm install
@@ -33,59 +54,189 @@ vx pnpm install
 vx pnpm run dev
 ```
 
-## 版本管理
+## npm
+
+npm 包含在 Node.js 中。
 
 ```bash
-# 安装特定版本
-vx install node@20
-vx install node@18.19.0
-
-# 使用 LTS 版本
-vx install node@lts
+vx npm install
+vx npm run build
+vx npm test
 ```
 
-## Yarn 支持说明
+## npx
 
-vx 支持 Yarn 1.x (Classic)。对于 Yarn 2.x+ (Berry)，请使用 Node.js 内置的 corepack。
+npx 包含在 Node.js 中。
+
+```bash
+vx npx create-react-app my-app
+vx npx eslint .
+vx npx prettier --write .
+```
+
+## pnpm
+
+```bash
+# 安装 pnpm
+vx install pnpm latest
+
+# 使用
+vx pnpm install
+vx pnpm run build
+vx pnpm add react
+```
+
+## Yarn
+
+vx 提供对**所有 Yarn 版本**的无缝支持 - 包括 Yarn 1.x（Classic）和 Yarn 2.x+（Berry/Modern）。
+
+### Yarn 版本支持
+
+| 版本 | 类型 | 安装方式 |
+|------|------|----------|
+| 1.x | Classic | 从 GitHub releases 直接下载 |
+| 2.x | Berry | 通过 corepack 自动管理 |
+| 3.x | Berry | 通过 corepack 自动管理 |
+| 4.x | Berry | 通过 corepack 自动管理 |
 
 ### Yarn 1.x (Classic)
 
+Yarn 1.x 由 vx 直接下载和安装：
+
 ```bash
 # 安装 Yarn 1.x
-vx install yarn 1.22.19
-vx yarn --version
+vx install yarn 1.22.22
 
-# 使用 Yarn
+# 检查版本
+vx yarn@1.22.22 --version
+# 输出: 1.22.22
+
+# 使用
 vx yarn install
 vx yarn build
 vx yarn add react
 ```
 
-### Yarn 2.x+ (Berry)
+### Yarn 2.x+ (Berry/Modern)
 
-Yarn 2.x+ (Berry) 无法直接通过 vx 安装。请使用 Node.js 内置的 corepack：
+Yarn 2.x 及更高版本**通过 corepack 自动管理** - vx 透明处理这一切：
 
 ```bash
-# 首先安装 Node.js
-vx install node 20
+# 直接使用任意 Yarn 2.x+ 版本
+vx yarn@2.4.3 --version    # Berry 2.x
+# 输出: 2.4.3
 
-# 启用 corepack（提供 Yarn 2.x+）
-vx node -e "require('child_process').execSync('corepack enable', {stdio: 'inherit'})"
+vx yarn@3.6.0 --version    # Berry 3.x
+# 输出: 3.6.0
 
-# 或使用 npx 运行 Yarn
-vx npx yarn@2.4.3 --version
+vx yarn@4.0.0 --version    # Berry 4.x
+# 输出: 4.0.0
+
+vx yarn@4.12.0 --version   # 最新 Berry
+# 输出: 4.12.0
 ```
 
-更多详情请参考 [Yarn 官方文档](https://yarnpkg.com/getting-started/install)。
+**工作原理：**
+
+1. 当您请求 Yarn 2.x+ 时，vx 自动：
+   - 确保 Node.js（包含 corepack）已安装
+   - 如果尚未启用，则启用 corepack
+   - 通过 `corepack prepare yarn@<version> --activate` 准备指定的 Yarn 版本
+   - 通过 corepack 执行 Yarn
+
+2. 您无需手动启用 corepack 或运行任何设置命令 - vx 透明处理一切。
+
+### 在项目中使用 Yarn
+
+```bash
+# 使用 Yarn Berry 创建新项目
+mkdir my-project && cd my-project
+vx yarn@4.0.0 init
+
+# 安装依赖
+vx yarn@4.0.0 install
+
+# 添加包
+vx yarn@4.0.0 add react
+
+# 运行脚本
+vx yarn@4.0.0 build
+```
+
+### Yarn 版本锁定
+
+对于使用 Yarn Berry 的项目，vx 遵循 `package.json` 中的 `packageManager` 字段：
+
+```json
+{
+  "name": "my-project",
+  "packageManager": "yarn@4.0.0"
+}
+```
+
+当此字段存在时，corepack 会自动确保使用正确的版本。
+
+## Bun
+
+Bun 是一个多合一的 JavaScript 运行时和工具包。
+
+```bash
+# 安装 bun
+vx install bun latest
+
+# 使用
+vx bun run script.ts
+vx bun install
+vx bun build ./index.ts
+```
 
 ## 项目配置
 
 ```toml
 [tools]
 node = "20"
+pnpm = "latest"
+yarn = "4.0.0"  # Yarn Berry 无缝支持
 
 [scripts]
-dev = "npm run dev"
-build = "npm run build"
-test = "npm test"
+dev = "yarn run dev"
+build = "yarn run build"
+test = "yarn test"
+```
+
+## 常见工作流
+
+### 创建 React 应用
+
+```bash
+vx npx create-react-app my-app
+cd my-app
+vx npm start
+```
+
+### Next.js 项目
+
+```bash
+vx npx create-next-app@latest my-app
+cd my-app
+vx npm run dev
+```
+
+### Vite 项目
+
+```bash
+vx npm create vite@latest my-app
+cd my-app
+vx npm install
+vx npm run dev
+```
+
+### Yarn Berry 项目
+
+```bash
+# 使用 Yarn 4.x 创建新项目
+mkdir my-yarn-project && cd my-yarn-project
+vx yarn@4.0.0 init
+vx yarn@4.0.0 add react react-dom
+vx yarn@4.0.0 dev
 ```


### PR DESCRIPTION
## Summary

This PR completes the remaining tasks for RFC-0028 (Proxy-Managed Runtimes), specifically for Yarn 2.x+ corepack support.

## Changes

### Documentation Updates
- Updated `docs/tools/nodejs.md` with comprehensive Yarn 2.x+ support documentation
- Updated `docs/zh/tools/nodejs.md` (Chinese version)
- Added examples for all Yarn versions (1.x, 2.x, 3.x, 4.x)
- Documented automatic corepack management

### RFC-0028 Status Update
- Updated Implementation Plan checkboxes (Phase 1-3, 5-6 completed for Yarn)
- Marked .NET phases as future RFC work
- Added detailed implementation status section

### New Tests
- `test_yarn_prepare_execution_v1_returns_default`: validates Yarn 1.x behavior
- `test_execution_prep_builder_methods`: validates ExecutionPrep API
- `test_yarn_2x_expected_execution_prep_flags`: validates Yarn 2.x+ expected flags

## Implementation Summary

Yarn 2.x+ (Berry) via corepack is now fully supported:

```bash
vx yarn@1.22.22 --version  # Classic - direct download
vx yarn@4.0.0 --version    # Berry - via corepack (auto-managed)
```

## Test Results

All 41 tests pass:
```
test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```