### PR TITLE
fix: update release workflow tag trigger pattern to match v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ permissions:
 on:
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Problem

After merging #504, the release workflow did not trigger when release-please created tag `v0.6.30`. 

The tag pattern `**[0-9]+.[0-9]+.[0-9]+*` matches tags like `0.6.30` but **not** `v0.6.30` (with `v` prefix).

## Solution

Change the tag trigger pattern from:
```yaml
- '**[0-9]+.[0-9]+.[0-9]+*'
```

To:
```yaml
- 'v[0-9]+.[0-9]+.[0-9]+*'
```

This properly matches release-please generated tags like `v0.6.30`, `v1.0.0-beta.1`, etc.

## Testing

After merging, the next release-please tag push should trigger the cargo-dist release workflow correctly.