### PR TITLE
fix(ci): remove package-name from release-please config to fix tag pattern

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,6 @@
   "group-pull-request-title-pattern": "chore: release v${version}",
   "packages": {
     ".": {
-      "package-name": "vx",
       "changelog-path": "CHANGELOG.md",
       "release-type": "simple",
       "bump-minor-pre-major": true,


### PR DESCRIPTION
## Problem

Since v0.6.28 (when cargo-dist was adopted), all releases are missing build artifacts (binaries, checksums, installers). This breaks install scripts (`install.ps1`, `install.sh`) and package managers (winget, scoop, chocolatey, homebrew).

## Root Cause

Tag format mismatch between `release-please` and `cargo-dist`:

- `release-please` creates tags like `vx-v0.6.31` (due to `package-name: "vx"` in config)
- `cargo-dist`'s release workflow triggers only on tags matching `v[0-9]+.[0-9]+.[0-9]+*`
- The `vx-v0.6.31` tag does **not** match this pattern, so cargo-dist never runs

## Fix

Remove `package-name` from `release-please-config.json`. This changes the tag format from `vx-v{version}` to `v{version}` (e.g., `v0.6.32`), which matches cargo-dist's expected trigger pattern.

## Verification

All downstream consumers already support the `v{version}` format:
- ✅ `release.yml` - tag pattern `v[0-9]+.[0-9]+.[0-9]+*` matches
- ✅ `docker-publish.yml` - uses `${VERSION#v}` to strip prefix
- ✅ `linux-packages.yml` - uses `${VERSION#v}` to strip prefix
- ✅ `package-managers.yml` - uses `${version#v}` normalization
- ✅ `install.ps1` - uses `$tagName -replace '^v', ''`
- ✅ `install.sh` - uses `sed -E 's/^(vx-)?v//'` (handles both old and new format)