### PR TITLE
fix(ci): trigger release workflow via workflow_dispatch after release-please creates tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,11 @@
 # Release Please workflow
 # Runs on push to main to create/update release PRs
 # When a release PR is merged, creates a GitHub Release and tag
-# The tag push then triggers the cargo-dist Release workflow
+# Then triggers the cargo-dist Release workflow via workflow_dispatch
+#
+# Note: Tags created by GITHUB_TOKEN do NOT trigger other workflows'
+# on.push.tags events (GitHub security limitation). We work around this
+# by explicitly dispatching the Release workflow after release creation.
 
 name: Release Please
 
@@ -13,14 +17,26 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - name: Trigger Release workflow
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Release created, triggering cargo-dist Release workflow..."
+          echo "Tag: ${{ steps.release.outputs.tag_name }}"
+          gh workflow run release.yml \
+            --repo "${{ github.repository }}" \
+            --field "tag=${{ steps.release.outputs.tag_name }}"


### PR DESCRIPTION
## Problem

v0.7.0 release was created by release-please but has **no build artifacts** (binaries, installers, checksums).

## Root Cause

When the release workflow was refactored to use cargo-dist, it was split into two separate workflows:
- `release-please.yml`: creates tags and GitHub Releases on push to main
- `release.yml` (cargo-dist): builds artifacts, triggered by `on.push.tags`

However, **tags created by `GITHUB_TOKEN` do NOT trigger other workflows' `on.push.tags` events** ([GitHub docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)). This is a well-known GitHub security limitation.

Previously (e.g., v0.6.27), release-please and the build were in the **same workflow**, so this wasn't an issue.

## Fix

After release-please creates a release, explicitly trigger the Release workflow via `workflow_dispatch` (which IS allowed with `GITHUB_TOKEN`). This uses the existing `workflow_dispatch` input that cargo-dist's `release.yml` already supports.

## Changes

- Added `id: release` to the release-please action step to capture outputs
- Added `actions: write` permission for workflow dispatch
- Added a step that triggers `release.yml` via `gh workflow run` when `releases_created == 'true'`