### PR TITLE
feat: add dagu workflow engine provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4251,7 +4251,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "indexmap",
  "regex",
@@ -4280,7 +4280,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4346,6 +4346,7 @@ dependencies = [
  "vx-provider-bun",
  "vx-provider-choco",
  "vx-provider-cmake",
+ "vx-provider-dagu",
  "vx-provider-deno",
  "vx-provider-docker",
  "vx-provider-dotnet",
@@ -4399,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4421,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4441,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "vx-core"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4460,7 +4461,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4477,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4496,7 +4497,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4518,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4549,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4564,7 +4565,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4607,7 +4608,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4625,7 +4626,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4649,7 +4650,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-awscli"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4662,7 +4663,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-azcli"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4675,7 +4676,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-brew"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4688,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bun"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4702,7 +4703,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-choco"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4715,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cmake"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4729,8 +4730,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "vx-provider-dagu"
+version = "0.7.5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "reqwest 0.12.28",
+ "rstest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "vx-runtime",
+ "vx-version-fetcher",
+]
+
+[[package]]
 name = "vx-provider-deno"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4744,7 +4760,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-docker"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4758,7 +4774,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dotnet"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4774,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ffmpeg"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4791,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gcloud"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4805,7 +4821,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gh"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4820,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-git"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4835,7 +4851,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-go"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4851,7 +4867,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-helm"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4865,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-imagemagick"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4884,7 +4900,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-java"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4899,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-jq"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4914,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-just"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4927,7 +4943,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kubectl"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4941,7 +4957,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-make"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4957,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-meson"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4973,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-msbuild"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4989,7 +5005,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-msvc"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5006,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nasm"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5020,7 +5036,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ninja"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5036,7 +5052,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-node"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5052,7 +5068,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nuget"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5065,7 +5081,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ollama"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5080,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pnpm"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5094,7 +5110,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pre-commit"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5110,7 +5126,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-protoc"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5126,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pwsh"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5139,7 +5155,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-python"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5150,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rcedit"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5165,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-release-please"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5180,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rez"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5196,7 +5212,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rust"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5211,7 +5227,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-spack"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5226,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-task"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5242,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-terraform"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5255,7 +5271,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-uv"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5272,7 +5288,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vite"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5287,7 +5303,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vscode"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5299,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-winget"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5313,7 +5329,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yarn"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5329,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zig"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5342,7 +5358,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5373,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5413,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5429,7 +5445,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "serde",
@@ -5445,7 +5461,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5467,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,8 @@ members = [
   "crates/vx-providers/nuget",
   # Windows Package Manager (winget)
   "crates/vx-providers/winget",
+  # Workflow engine
+  "crates/vx-providers/dagu",
 ]
 resolver = "2"
 
@@ -220,6 +222,7 @@ vx-provider-dotnet = { path = "crates/vx-providers/dotnet" }
 vx-provider-msbuild = { path = "crates/vx-providers/msbuild" }
 vx-provider-nuget = { path = "crates/vx-providers/nuget" }
 vx-provider-winget = { path = "crates/vx-providers/winget" }
+vx-provider-dagu = { path = "crates/vx-providers/dagu" }
 vx-console = { path = "crates/vx-console" }
 vx-manifest = { path = "crates/vx-manifest" }
 

--- a/crates/vx-cli/Cargo.toml
+++ b/crates/vx-cli/Cargo.toml
@@ -77,6 +77,7 @@ vx-provider-dotnet = { workspace = true }
 vx-provider-msbuild = { workspace = true }
 vx-provider-nuget = { workspace = true }
 vx-provider-winget = { workspace = true }
+vx-provider-dagu = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/vx-cli/src/registry.rs
+++ b/crates/vx-cli/src/registry.rs
@@ -224,6 +224,7 @@ pub fn create_manifest_registry() -> ManifestRegistry {
         msbuild,
         nuget,
         winget,
+        dagu,
     );
 
     registry
@@ -282,6 +283,7 @@ fn create_static_registry() -> ProviderRegistry {
         msbuild,
         nuget,
         winget,
+        dagu,
     );
 
     registry

--- a/crates/vx-providers/dagu/Cargo.toml
+++ b/crates/vx-providers/dagu/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "vx-provider-dagu"
+version.workspace = true
+edition.workspace = true
+description = "Dagu workflow engine provider for vx"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+vx-runtime = { workspace = true }
+vx-version-fetcher = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/crates/vx-providers/dagu/provider.toml
+++ b/crates/vx-providers/dagu/provider.toml
@@ -1,0 +1,49 @@
+# Dagu Provider Manifest
+# Dagu is a self-contained workflow engine with a built-in Web UI.
+# It supports YAML-based DAG definitions with cron scheduling.
+#
+# Key features for vx integration:
+# - Single binary, no dependencies
+# - Built-in cron scheduler
+# - Web UI for workflow management
+# - Can invoke `vx python`, `vx node`, etc. in workflow steps
+
+[provider]
+name = "dagu"
+description = "Self-contained workflow engine with Web UI and cron scheduling"
+homepage = "https://dagu.readthedocs.io"
+repository = "https://github.com/dagu-org/dagu"
+ecosystem = "devtools"
+
+[[runtimes]]
+name = "dagu"
+description = "Dagu workflow engine CLI"
+executable = "dagu"
+
+[runtimes.versions]
+source = "github-releases"
+owner = "dagu-org"
+repo = "dagu"
+strip_v_prefix = true
+
+# RFC 0019: Executable Layout Configuration
+[runtimes.layout]
+download_type = "archive"
+
+[runtimes.layout.archive]
+strip_prefix = ""
+executable_paths = [
+    "dagu.exe",  # Windows (root directory)
+    "dagu"       # Unix (root directory)
+]
+
+[runtimes.platforms.windows]
+executable_extensions = [".exe"]
+
+[runtimes.platforms.unix]
+executable_extensions = []
+
+# Dagu has no external dependencies
+[[runtimes.constraints]]
+when = "*"
+recommends = []

--- a/crates/vx-providers/dagu/src/config.rs
+++ b/crates/vx-providers/dagu/src/config.rs
@@ -1,0 +1,31 @@
+//! Dagu URL builder
+//!
+//! This module provides URL building functionality for Dagu downloads.
+//! Dagu release assets follow the pattern:
+//!   dagu_{version}_{os}_{arch}.tar.gz
+//!
+//! All platforms use .tar.gz format.
+
+use vx_runtime::Platform;
+
+/// URL builder for Dagu
+pub struct DaguUrlBuilder;
+
+impl DaguUrlBuilder {
+    pub fn download_url(version: &str, platform: &Platform) -> Option<String> {
+        let (os_name, arch_name) = match (&platform.os, &platform.arch) {
+            (vx_runtime::Os::Windows, vx_runtime::Arch::X86_64) => ("windows", "amd64"),
+            (vx_runtime::Os::Windows, vx_runtime::Arch::Aarch64) => ("windows", "arm64"),
+            (vx_runtime::Os::MacOS, vx_runtime::Arch::X86_64) => ("darwin", "amd64"),
+            (vx_runtime::Os::MacOS, vx_runtime::Arch::Aarch64) => ("darwin", "arm64"),
+            (vx_runtime::Os::Linux, vx_runtime::Arch::X86_64) => ("linux", "amd64"),
+            (vx_runtime::Os::Linux, vx_runtime::Arch::Aarch64) => ("linux", "arm64"),
+            _ => return None,
+        };
+
+        Some(format!(
+            "https://github.com/dagu-org/dagu/releases/download/v{}/dagu_{}_{}_{}.tar.gz",
+            version, version, os_name, arch_name
+        ))
+    }
+}

--- a/crates/vx-providers/dagu/src/lib.rs
+++ b/crates/vx-providers/dagu/src/lib.rs
@@ -1,0 +1,62 @@
+//! Dagu Workflow Engine Provider for vx
+//!
+//! This provider adds support for Dagu - a self-contained, powerful workflow engine
+//! with a built-in Web UI, designed for defining and running DAGs (Directed Acyclic Graphs).
+//!
+//! ## Features
+//!
+//! - Version management via GitHub releases
+//! - Cross-platform support (Windows, macOS, Linux)
+//! - Automatic installation and verification
+//! - Built-in Web UI for workflow management
+//! - YAML-based workflow definition with cron scheduling
+//! - Can invoke `vx python`, `vx node`, etc. in workflow steps
+//!
+//! ## Usage with vx
+//!
+//! ```bash
+//! # Install dagu
+//! vx install dagu
+//!
+//! # Start the dagu server (Web UI at http://localhost:8080)
+//! vx dagu server
+//!
+//! # Run a workflow
+//! vx dagu start my-workflow
+//!
+//! # Check workflow status
+//! vx dagu status my-workflow
+//! ```
+//!
+//! ## Integration with vx environment
+//!
+//! Dagu workflows can leverage the full vx environment by using `vx` as the command prefix:
+//!
+//! ```yaml
+//! # my-workflow.yaml
+//! schedule: "0 9 * * *"
+//! env:
+//!   - VX_HOME: "~/.vx"
+//! steps:
+//!   - name: "Run Python script"
+//!     command: "vx python script.py"
+//!   - name: "Run Node.js script"
+//!     command: "vx node app.js"
+//!     depends:
+//!       - "Run Python script"
+//! ```
+
+use std::sync::Arc;
+
+pub mod config;
+pub mod provider;
+pub mod runtime;
+
+pub use config::DaguUrlBuilder;
+pub use provider::DaguProvider;
+pub use runtime::DaguRuntime;
+
+/// Factory function to create the Dagu provider
+pub fn create_provider() -> Arc<dyn vx_runtime::Provider> {
+    Arc::new(provider::DaguProvider::new())
+}

--- a/crates/vx-providers/dagu/src/provider.rs
+++ b/crates/vx-providers/dagu/src/provider.rs
@@ -1,0 +1,32 @@
+use std::sync::Arc;
+use vx_runtime::Provider;
+
+use crate::runtime::DaguRuntime;
+
+/// Dagu Provider implementation
+#[derive(Debug, Clone, Default)]
+pub struct DaguProvider;
+
+impl DaguProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Provider for DaguProvider {
+    fn name(&self) -> &str {
+        "dagu"
+    }
+
+    fn description(&self) -> &str {
+        "Dagu - self-contained workflow engine with Web UI"
+    }
+
+    fn runtimes(&self) -> Vec<Arc<dyn vx_runtime::Runtime>> {
+        vec![Arc::new(DaguRuntime::new())]
+    }
+
+    fn supports(&self, name: &str) -> bool {
+        name == "dagu"
+    }
+}

--- a/crates/vx-providers/dagu/src/runtime.rs
+++ b/crates/vx-providers/dagu/src/runtime.rs
@@ -1,0 +1,104 @@
+//! Dagu runtime implementation
+//!
+//! Dagu is a self-contained workflow engine with a built-in Web UI.
+//! It uses YAML-based DAG definitions with cron scheduling support.
+//!
+//! Homepage: https://dagu.readthedocs.io/
+//! Repository: https://github.com/dagu-org/dagu
+
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::path::Path;
+
+use vx_runtime::{Ecosystem, Platform, Runtime, RuntimeContext, VerificationResult, VersionInfo};
+use vx_version_fetcher::VersionFetcherBuilder;
+
+use crate::config::DaguUrlBuilder;
+
+/// Dagu runtime implementation
+#[derive(Debug, Clone, Default)]
+pub struct DaguRuntime;
+
+impl DaguRuntime {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Runtime for DaguRuntime {
+    fn name(&self) -> &str {
+        "dagu"
+    }
+
+    fn description(&self) -> &str {
+        "Dagu - self-contained workflow engine with Web UI and cron scheduling"
+    }
+
+    fn aliases(&self) -> &[&str] {
+        &[]
+    }
+
+    fn ecosystem(&self) -> Ecosystem {
+        Ecosystem::Custom("devops".to_string())
+    }
+
+    fn metadata(&self) -> HashMap<String, String> {
+        let mut meta = HashMap::new();
+        meta.insert(
+            "homepage".to_string(),
+            "https://dagu.readthedocs.io/".to_string(),
+        );
+        meta.insert(
+            "repository".to_string(),
+            "https://github.com/dagu-org/dagu".to_string(),
+        );
+        meta.insert(
+            "documentation".to_string(),
+            "https://dagu.readthedocs.io/".to_string(),
+        );
+        meta.insert("category".to_string(), "workflow".to_string());
+        meta.insert("license".to_string(), "GPL-3.0".to_string());
+        meta
+    }
+
+    /// Dagu archives extract directly to the binary (no subdirectory)
+    fn executable_relative_path(&self, _version: &str, platform: &Platform) -> String {
+        platform.exe_name("dagu")
+    }
+
+    async fn fetch_versions(&self, ctx: &RuntimeContext) -> Result<Vec<VersionInfo>> {
+        VersionFetcherBuilder::github_releases("dagu-org", "dagu")
+            .tool_name("dagu")
+            .strip_v_prefix()
+            .skip_prereleases()
+            .limit(50)
+            .build()
+            .fetch(ctx)
+            .await
+            .map_err(|e| anyhow::anyhow!("{}", e))
+    }
+
+    async fn download_url(&self, version: &str, platform: &Platform) -> Result<Option<String>> {
+        Ok(DaguUrlBuilder::download_url(version, platform))
+    }
+
+    fn verify_installation(
+        &self,
+        version: &str,
+        install_path: &Path,
+        platform: &Platform,
+    ) -> VerificationResult {
+        let exe_path = install_path.join(self.executable_relative_path(version, platform));
+
+        if exe_path.exists() {
+            VerificationResult::success(exe_path)
+        } else {
+            VerificationResult::failure(
+                vec!["Dagu executable not found at expected location".to_string()],
+                vec!["Check download URL and extraction process".to_string()],
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add [Dagu](https://github.com/dagu-org/dagu) as a new provider for vx. Dagu is a self-contained workflow engine with a built-in Web UI, supporting YAML-based DAG definitions with cron scheduling.

## Key Features

- **Single binary, no external dependencies** - perfect fit for vx's philosophy
- **Cross-platform support** - Windows, macOS, Linux (amd64 & arm64)
- **Version management** via GitHub releases
- **Built-in Web UI** for workflow management
- **YAML-based DAG definitions** with cron scheduling
- **vx integration** - can invoke `vx python`, `vx node`, etc. in workflow steps

## Changes

- `crates/vx-providers/dagu/` - New provider crate with:
  - `provider.toml` - Manifest-driven provider definition (ecosystem: devtools)
  - `src/runtime.rs` - Runtime implementation with GitHub releases version fetching
  - `src/config.rs` - URL builder for cross-platform download URLs
  - `src/provider.rs` - Provider implementation
  - `src/lib.rs` - Crate entry point with documentation
- `Cargo.toml` - Workspace member and dependency registration
- `crates/vx-cli/Cargo.toml` - CLI dependency
- `crates/vx-cli/src/registry.rs` - Provider factory and static registration

## Usage

```bash
# Install dagu
vx install dagu

# Start the dagu server (Web UI at http://localhost:8080)
vx dagu server

# Run a workflow
vx dagu start my-workflow

# Check version
vx dagu version
```

## Workflow Example with vx

```yaml
# my-workflow.yaml
schedule: "0 9 * * *"
steps:
  - name: "Run Python script"
    command: "vx python script.py"
  - name: "Run Node.js script"
    command: "vx node app.js"
    depends:
      - "Run Python script"
```