### PR TITLE
fix: skip CI/CodeQL/Benchmark workflows on release commits

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,6 +36,11 @@ env:
 jobs:
   benchmark:
     name: Benchmark (${{ matrix.platform.name }})
+    # Skip benchmarks for release commits (e.g., "chore: release v0.7.6") since
+    # they only bump version numbers and don't affect performance.
+    if: >-
+      github.event_name != 'push' ||
+      !startsWith(github.event.head_commit.message, 'chore: release')
     runs-on: ${{ matrix.platform.os }}
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
   # ============================================================================
   detect-changes:
     name: Detect Changes
+    # Skip CI for release commits (e.g., "chore: release v0.7.6") to avoid
+    # unnecessary full CI runs when Release Please merges a release PR.
+    if: >-
+      github.event_name != 'push' ||
+      !startsWith(github.event.head_commit.message, 'chore: release')
     runs-on: ubuntu-latest
     outputs:
       # High-level flags

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,11 @@ permissions:
 jobs:
   analyze:
     name: Analyze (CodeQL via vx)
+    # Skip CodeQL for release commits (e.g., "chore: release v0.7.6") since
+    # they only bump version numbers and update changelogs.
+    if: >-
+      github.event_name != 'push' ||
+      !startsWith(github.event.head_commit.message, 'chore: release')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Problem

When Release Please merges a release PR (e.g., `chore: release v0.7.6`), the resulting commit triggers multiple unnecessary workflows:

| Workflow | Time Wasted | Should Run? |
|---------|------------|------------|
| CI | ~15 min | No (only version bumps) |
| CodeQL | ~12 min | No (only version bumps) |
| Benchmark | ~10+ min | No (no performance impact) |

This wastes significant CI resources on every release.

## Solution

Added job-level `if` conditions to skip these workflows when the commit message starts with `chore: release`:

```yaml
if: >-
  github.event_name != 'push' ||
  !startsWith(github.event.head_commit.message, 'chore: release')
```

This condition:
- Allows the job to run normally for PRs, scheduled runs, and manual dispatches
- Only skips when the event is a `push` AND the commit message starts with `chore: release`
- When the first job is skipped, all downstream dependent jobs are automatically skipped too

## Changes

### Workflows Modified
- **`ci.yml`**: Added skip condition on `detect-changes` job (gates all downstream CI jobs)
- **`codeql.yml`**: Added skip condition on `analyze` job
- **`benchmark.yml`**: Added skip condition on `benchmark` job

### Not Modified (intentionally)
- **`release-please.yml`**: Must still run on release commits to detect `releases_created` and trigger the Release workflow

### Documentation Updated
- `docs/advanced/release-process.md` (English)
- `docs/zh/advanced/release-process.md` (Chinese)

## Testing

The `if` condition logic:
- `github.event_name != 'push'` → allows PRs, schedule, workflow_dispatch to pass through
- `!startsWith(github.event.head_commit.message, 'chore: release')` → only blocks release commits
- Combined with `||` → both conditions must be false to skip (i.e., it must be a push AND a release commit)