### PR TITLE
fix: restore WinGet auto-publish support for cargo-dist releases

### DIFF
--- a/.github/workflows/package-managers.yml
+++ b/.github/workflows/package-managers.yml
@@ -90,8 +90,12 @@ jobs:
           version="${{ steps.version.outputs.version }}"
           echo "Original version: $version"
 
-          # Remove 'v' prefix for WinGet (v0.1.0 -> 0.1.0)
-          normalized_version="${version#v}"
+          # Robustly strip all known prefixes for WinGet version
+          # Handles: vx-v0.7.8 -> 0.7.8, v0.7.8 -> 0.7.8, 0.7.8 -> 0.7.8
+          normalized_version="${version}"
+          normalized_version="${normalized_version#vx-v}"
+          normalized_version="${normalized_version#vx-}"
+          normalized_version="${normalized_version#v}"
           echo "Normalized version: $normalized_version"
           echo "normalized_version=$normalized_version" >> $GITHUB_OUTPUT
 
@@ -128,13 +132,17 @@ jobs:
         uses: vedantmgoyal9/winget-releaser@v2
         with:
           identifier: loonghao.vx
-          # Use the GitHub release tag (e.g., "v0.6.13") to find the release
+          # Use the GitHub release tag (e.g., "v0.7.8") to find the release
           release-tag: ${{ needs.check-release.outputs.version }}
           # Use normalized version for WinGet package version (without 'vx-' and 'v' prefix)
           version: ${{ needs.check-release.outputs.normalized_version }}
-          # Only match Windows MSVC zip files (exclude sha256 files and non-Windows builds)
-          # Matches: vx-0.6.2-x86_64-pc-windows-msvc.zip, vx-x86_64-pc-windows-msvc.zip
-          installers-regex: 'windows-msvc\.zip$'
+          # Match ONLY the cargo-dist original unversioned zip files to avoid duplicates.
+          # cargo-dist produces: vx-x86_64-pc-windows-msvc.zip (unversioned)
+          # release.yml also creates: vx-0.7.8-x86_64-pc-windows-msvc.zip (versioned copy)
+          # We must match only ONE of them to avoid duplicate installer entries.
+          # Pattern: starts with "vx-" immediately followed by arch (x86_64 or aarch64),
+          # which excludes versioned copies like "vx-0.7.8-x86_64-..."
+          installers-regex: 'vx-(x86_64|aarch64)-pc-windows-msvc\.zip$'
           max-versions-to-keep: 5
           token: ${{ secrets.WINGET_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -419,15 +419,64 @@ jobs:
           done
           git push
 
+  # Publish to Windows Package Manager (WinGet)
+  # Runs after host to ensure all release assets are uploaded.
+  # Uses vedantmgoyal9/winget-releaser to create PR at microsoft/winget-pkgs.
+  publish-winget:
+    needs:
+      - plan
+      - host
+    runs-on: windows-latest
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    steps:
+      - name: Check WinGet Token
+        id: check_token
+        shell: bash
+        run: |
+          if [ -z "${{ secrets.WINGET_TOKEN }}" ]; then
+            echo "::warning::WINGET_TOKEN not set, skipping WinGet publish"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Extract version from tag
+        if: steps.check_token.outputs.skip != 'true'
+        id: version
+        shell: bash
+        run: |
+          TAG="${{ needs.plan.outputs.tag }}"
+          # Strip all known prefixes: vx-v0.7.8 -> 0.7.8, v0.7.8 -> 0.7.8
+          VERSION="${TAG#vx-v}"
+          VERSION="${VERSION#vx-}"
+          VERSION="${VERSION#v}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Publishing to WinGet: tag=${TAG}, version=${VERSION}"
+
+      - name: Publish to WinGet
+        if: steps.check_token.outputs.skip != 'true'
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: loonghao.vx
+          release-tag: ${{ needs.plan.outputs.tag }}
+          version: ${{ steps.version.outputs.version }}
+          # Match ONLY cargo-dist original unversioned zip files to avoid duplicate entries.
+          # Excludes versioned copies like vx-0.7.8-x86_64-pc-windows-msvc.zip
+          installers-regex: 'vx-(x86_64|aarch64)-pc-windows-msvc\.zip$'
+          max-versions-to-keep: 5
+          token: ${{ secrets.WINGET_TOKEN }}
+
   announce:
     needs:
       - plan
       - host
       - publish-homebrew-formula
+      - publish-winget
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') && (needs.publish-winget.result == 'skipped' || needs.publish-winget.result == 'success') }}
     runs-on: "ubuntu-24.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Restore WinGet auto-publish support that broke after migrating to cargo-dist for v0.7.x releases.

## Problem

1. **Duplicate installer entries** — `installers-regex: 'windows-msvc\.zip$'` matched both versioned (`vx-0.7.8-x86_64-pc-windows-msvc.zip`) and unversioned (`vx-x86_64-pc-windows-msvc.zip`) artifacts, causing duplicate entries in winget manifest
2. **Version normalization failure** — `${version#v}` only strips `v` prefix, so `vx-v0.7.8` became `x-v0.7.8` instead of `0.7.8`
3. **Publishing delay** — `package-managers.yml` relies on `workflow_run` trigger which introduces delay and may race with asset uploads

## Changes

### `.github/workflows/release.yml`
- Added `publish-winget` job that runs immediately after `host` job (assets guaranteed uploaded)
- Uses precise `installers-regex: 'vx-(x86_64|aarch64)-pc-windows-msvc\.zip$'` to avoid duplicates
- Updated `announce` job dependencies

### `.github/workflows/package-managers.yml`
- Fixed version normalization: sequential prefix stripping (`#vx-v`, `#vx-`, `#v`)
- Fixed `installers-regex` to match only unversioned artifacts
- Now serves as backup for WinGet publish

### Documentation
- Updated `docs/advanced/release-process.md` (EN)
- Updated `docs/zh/advanced/release-process.md` (ZH)
- Added WinGet publishing in release workflow section
- Added WinGet duplicate installer entries troubleshooting section