### PR TITLE
fix(ci): remove max-versions-to-keep from winget-releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -478,7 +478,11 @@ jobs:
           # Match ONLY cargo-dist original unversioned zip files to avoid duplicate entries.
           # Excludes versioned copies like vx-0.7.8-x86_64-pc-windows-msvc.zip
           installers-regex: 'vx-(x86_64|aarch64)-pc-windows-msvc\.zip$'
-          max-versions-to-keep: 5
+          # REMOVED: max-versions-to-keep parameter
+          # This parameter causes winget-releaser to delete old versions automatically.
+          # However, it has a bug that can incorrectly identify the highest version
+          # as "old" and attempt to delete it (see: https://github.com/microsoft/winget-pkgs/pull/340410).
+          # Let WinGet maintain version history naturally without automatic deletions.
           token: ${{ secrets.WINGET_TOKEN }}
 
   announce:

--- a/docs/advanced/release-process.md
+++ b/docs/advanced/release-process.md
@@ -243,6 +243,26 @@ unversioned (`vx-x86_64-pc-windows-msvc.zip`) copies of the same artifact. If th
 installers-regex: 'vx-(x86_64|aarch64)-pc-windows-msvc\.zip$'
 ```
 
+### WinGet Automatic Version Deletion
+
+**Problem**: When publishing a new version to WinGet, an automated PR is created to delete an older version, but it incorrectly identifies the highest version as "old" and attempts to delete it.
+
+**Example**: See [microsoft/winget-pkgs#340410](https://github.com/microsoft/winget-pkgs/pull/340410) where version 0.8.1 (the highest version at that time) was incorrectly marked for deletion.
+
+**Cause**: The `max-versions-to-keep` parameter in `vedantmgoyal9/winget-releaser` action triggers automatic deletion of old versions when the version count exceeds the threshold. However, this feature has a bug that can incorrectly identify the current highest version as "old" based on timestamp comparison.
+
+**Solution**: Removed the `max-versions-to-keep` parameter from the WinGet publishing configuration:
+
+```yaml
+# REMOVED: max-versions-to-keep: 5
+# This parameter causes winget-releaser to delete old versions automatically.
+# However, it has a bug that can incorrectly identify the highest version
+# as "old" and attempt to delete it.
+# Let WinGet maintain version history naturally without automatic deletions.
+```
+
+**Best Practice**: Let WinGet maintain its own version history. Package managers typically have their own policies for version management, and automatic deletion can lead to user disruption and incorrect version removal.
+
 ### Verifying Release Assets
 
 To verify release assets are available:

--- a/docs/zh/advanced/release-process.md
+++ b/docs/zh/advanced/release-process.md
@@ -242,6 +242,25 @@ if: |
 installers-regex: 'vx-(x86_64|aarch64)-pc-windows-msvc\.zip$'
 ```
 
+### WinGet 自动版本删除
+
+**问题**: 当发布新版本到 WinGet 时，会创建一个自动化 PR 来删除旧版本，但它错误地将最高版本识别为"旧版本"并尝试删除它。
+
+**示例**: 参见 [microsoft/winget-pkgs#340410](https://github.com/microsoft/winget-pkgs/pull/340410)，其中版本 0.8.1（当时的最高版本）被错误标记为删除。
+
+**原因**: `vedantmgoyal9/winget-releaser` 操作中的 `max-versions-to-keep` 参数会在版本数量超过阈值时触发自动删除旧版本。然而，此功能存在 bug，可能根据时间戳比较错误地将当前最高版本识别为"旧版本"。
+
+**解决方案**: 从 WinGet 发布配置中移除 `max-versions-to-keep` 参数：
+
+```yaml
+# 已移除: max-versions-to-keep: 5
+# 此参数会导致 winget-releaser 自动删除旧版本。
+# 然而，它存在 bug，可能会错误地将最高版本识别为"旧版本"并尝试删除。
+# 让 WinGet 自然维护版本历史，不进行自动删除。
+```
+
+**最佳实践**: 让 WinGet 维护自己的版本历史。包管理器通常有自己的版本管理策略，自动删除可能会导致用户中断和错误的版本删除。
+
 ### 验证发布资源
 
 要验证发布资源是否可用:


### PR DESCRIPTION
## Summary

Removes the `max-versions-to-keep` parameter from the WinGet publishing workflow to prevent automatic version deletion issues.

## Problem

The `max-versions-to-keep: 5` parameter in `.github/workflows/release.yml` causes `winget-releaser` to automatically delete old versions when the version count exceeds 5. However, this feature has a bug that can incorrectly identify the highest version as "old" and attempt to delete it.

### Example Issue

See [microsoft/winget-pkgs#340410](https://github.com/microsoft/winget-pkgs/pull/340410) where:
- A new version was published to WinGet
- The automated system created a PR to delete version 0.8.1
- Version 0.8.1 was actually the **highest version** at that time
- This happened because of a bug in the version comparison logic

## Solution

Removed the `max-versions-to-keep` parameter to:
1. Prevent automatic version deletion
2. Let WinGet maintain version history naturally
3. Avoid potential user disruption from incorrect deletions

## Changes

### Code Changes
- `.github/workflows/release.yml`: Removed `max-versions-to-keep: 5` parameter and added explanatory comment

### Documentation Updates
- `docs/advanced/release-process.md`: Added "WinGet Automatic Version Deletion" section in troubleshooting
- `docs/zh/advanced/release-process.md`: Added Chinese translation of the same section

## Testing

- No code changes required (only CI configuration)
- All pre-commit hooks passed (typos, prettier, etc.)

## Impact

- **Positive**: Prevents incorrect version deletions in WinGet
- **Neutral**: WinGet will now maintain all versions naturally (no automatic cleanup)
- **No Breaking Changes**: This only affects WinGet publishing behavior

## Checklist

- [x] Code changes implemented
- [x] Documentation updated (English)
- [x] Documentation updated (Chinese)
- [x] All pre-commit hooks passed
- [x] Commit message follows conventional commits

Fixes #340410