### PR TITLE
refactor: replace bare .unwrap() with descriptive .expect() in production code

### DIFF
--- a/crates/vx-config/src/config_manager/toml_writer.rs
+++ b/crates/vx-config/src/config_manager/toml_writer.rs
@@ -442,7 +442,9 @@ impl TomlDocument {
             if current.get(part).is_none() {
                 current[part] = Item::Table(Table::new());
             }
-            current = current[*part].as_table_mut().unwrap();
+            current = current[*part]
+                .as_table_mut()
+                .expect("intermediate table must exist (just created above)");
         }
 
         // Set the final value

--- a/crates/vx-paths/src/resolver.rs
+++ b/crates/vx-paths/src/resolver.rs
@@ -89,7 +89,7 @@ impl PathResolver {
     /// end of a command execution, or after install/uninstall).
     pub fn save_cache(&self) {
         if let Some(ref cache_dir) = self.cache_dir {
-            let cache = self.exec_cache.lock().unwrap();
+            let cache = self.exec_cache.lock().expect("exec_cache lock poisoned");
             if let Err(e) = cache.save(cache_dir) {
                 tracing::debug!("Failed to save exec path cache: {}", e);
             }
@@ -101,7 +101,7 @@ impl PathResolver {
     /// Call this after installing or uninstalling a runtime version.
     pub fn invalidate_runtime_cache(&self, runtime_name: &str) {
         let runtime_store_dir = self.manager.runtime_store_dir(runtime_name);
-        let mut cache = self.exec_cache.lock().unwrap();
+        let mut cache = self.exec_cache.lock().expect("exec_cache lock poisoned");
         cache.invalidate_runtime(&runtime_store_dir);
         // Persist immediately after invalidation
         if let Some(ref cache_dir) = self.cache_dir
@@ -113,7 +113,7 @@ impl PathResolver {
 
     /// Clear the entire exec path cache.
     pub fn clear_exec_cache(&self) {
-        let mut cache = self.exec_cache.lock().unwrap();
+        let mut cache = self.exec_cache.lock().expect("exec_cache lock poisoned");
         cache.clear();
         if let Some(ref cache_dir) = self.cache_dir {
             let _ = ExecPathCache::remove_file(cache_dir);
@@ -568,7 +568,7 @@ impl PathResolver {
 
         // Check cache first
         {
-            let mut cache = self.exec_cache.lock().unwrap();
+            let mut cache = self.exec_cache.lock().expect("exec_cache lock poisoned");
             if let Some(cached) = cache.get(dir, exe_name) {
                 tracing::trace!(
                     "find_executable_in_dir: cache hit for '{}' in {} -> {}",
@@ -615,7 +615,7 @@ impl PathResolver {
         // Most runtimes have their executable in root, bin/, or one-level subdirectory.
         // This avoids traversing deep trees like node_modules/ for the common case.
         if let Some(result) = self.quick_find_executable(dir, &possible_names, &platform_patterns) {
-            let mut cache = self.exec_cache.lock().unwrap();
+            let mut cache = self.exec_cache.lock().expect("exec_cache lock poisoned");
             cache.put(dir, exe_name, result.clone());
             return Some(result);
         }
@@ -653,7 +653,7 @@ impl PathResolver {
                 "find_executable_in_dir: found executable at {}",
                 path.display()
             );
-            let mut cache = self.exec_cache.lock().unwrap();
+            let mut cache = self.exec_cache.lock().expect("exec_cache lock poisoned");
             cache.put(dir, exe_name, path.clone());
         } else {
             tracing::trace!(

--- a/crates/vx-runtime/src/registry.rs
+++ b/crates/vx-runtime/src/registry.rs
@@ -73,12 +73,15 @@ impl ProviderRegistry {
 
     /// Register a provider (eager — immediately materialized)
     pub fn register(&self, provider: Arc<dyn Provider>) {
-        let mut providers = self.providers.write().unwrap();
+        let mut providers = self.providers.write().expect("providers lock poisoned");
         let index = providers.len();
 
         // Update cache for all runtimes in this provider
         {
-            let mut cache = self.runtime_cache.write().unwrap();
+            let mut cache = self
+                .runtime_cache
+                .write()
+                .expect("runtime_cache lock poisoned");
             for runtime in provider.runtimes() {
                 cache.insert(runtime.name().to_string(), index);
                 for alias in runtime.aliases() {
@@ -108,7 +111,10 @@ impl ProviderRegistry {
 
         // Build the pending index: runtime name/alias → provider name
         {
-            let mut index = self.pending_index.write().unwrap();
+            let mut index = self
+                .pending_index
+                .write()
+                .expect("pending_index lock poisoned");
             for name in runtime_names {
                 // Detect alias conflicts: warn if a runtime name/alias is already
                 // claimed by a different provider. The last writer wins, which can
@@ -131,7 +137,10 @@ impl ProviderRegistry {
 
         // Store the factory
         {
-            let mut factories = self.pending_factories.lock().unwrap();
+            let mut factories = self
+                .pending_factories
+                .lock()
+                .expect("pending_factories lock poisoned");
             factories.insert(provider_name, factory);
         }
     }
@@ -143,7 +152,10 @@ impl ProviderRegistry {
     fn materialize_provider(&self, provider_name: &str) -> bool {
         // Take the factory out of pending (if present)
         let factory = {
-            let mut factories = self.pending_factories.lock().unwrap();
+            let mut factories = self
+                .pending_factories
+                .lock()
+                .expect("pending_factories lock poisoned");
             factories.remove(provider_name)
         };
 
@@ -157,7 +169,10 @@ impl ProviderRegistry {
 
         // Remove all pending index entries for this provider
         {
-            let mut index = self.pending_index.write().unwrap();
+            let mut index = self
+                .pending_index
+                .write()
+                .expect("pending_index lock poisoned");
             index.retain(|_, v| v != provider_name);
         }
 
@@ -173,7 +188,10 @@ impl ProviderRegistry {
     fn materialize_all(&self) {
         // Drain all pending factories
         let factories: Vec<(String, ProviderFactory)> = {
-            let mut pending = self.pending_factories.lock().unwrap();
+            let mut pending = self
+                .pending_factories
+                .lock()
+                .expect("pending_factories lock poisoned");
             pending.drain().collect()
         };
 
@@ -183,7 +201,10 @@ impl ProviderRegistry {
 
         // Clear the pending index
         {
-            let mut index = self.pending_index.write().unwrap();
+            let mut index = self
+                .pending_index
+                .write()
+                .expect("pending_index lock poisoned");
             index.clear();
         }
 
@@ -197,13 +218,19 @@ impl ProviderRegistry {
 
     /// Check if there are any pending (not yet materialized) factories
     pub fn has_pending(&self) -> bool {
-        let factories = self.pending_factories.lock().unwrap();
+        let factories = self
+            .pending_factories
+            .lock()
+            .expect("pending_factories lock poisoned");
         !factories.is_empty()
     }
 
     /// Get the count of pending (not yet materialized) factories
     pub fn pending_factories_count(&self) -> usize {
-        let factories = self.pending_factories.lock().unwrap();
+        let factories = self
+            .pending_factories
+            .lock()
+            .expect("pending_factories lock poisoned");
         factories.len()
     }
 
@@ -211,9 +238,12 @@ impl ProviderRegistry {
     pub fn get_runtime(&self, name: &str) -> Option<Arc<dyn Runtime>> {
         // Fast path: check runtime_cache for already-materialized providers
         {
-            let cache = self.runtime_cache.read().unwrap();
+            let cache = self
+                .runtime_cache
+                .read()
+                .expect("runtime_cache lock poisoned");
             if let Some(&index) = cache.get(name) {
-                let providers = self.providers.read().unwrap();
+                let providers = self.providers.read().expect("providers lock poisoned");
                 if let Some(provider) = providers.get(index) {
                     return provider.get_runtime(name);
                 }
@@ -222,7 +252,10 @@ impl ProviderRegistry {
 
         // Check if there's a pending factory for this runtime name
         let provider_name = {
-            let index = self.pending_index.read().unwrap();
+            let index = self
+                .pending_index
+                .read()
+                .expect("pending_index lock poisoned");
             let result = index.get(name).cloned();
             trace!(
                 "get_runtime('{}'): pending_index lookup = {:?}",
@@ -240,9 +273,12 @@ impl ProviderRegistry {
             );
 
             // Now look up in the freshly populated cache
-            let cache = self.runtime_cache.read().unwrap();
+            let cache = self
+                .runtime_cache
+                .read()
+                .expect("runtime_cache lock poisoned");
             if let Some(&index) = cache.get(name) {
-                let providers = self.providers.read().unwrap();
+                let providers = self.providers.read().expect("providers lock poisoned");
                 if let Some(provider) = providers.get(index) {
                     return provider.get_runtime(name);
                 }
@@ -250,7 +286,7 @@ impl ProviderRegistry {
         }
 
         // Fallback: search all materialized providers
-        let providers = self.providers.read().unwrap();
+        let providers = self.providers.read().expect("providers lock poisoned");
         for provider in providers.iter() {
             if let Some(runtime) = provider.get_runtime(name) {
                 return Some(runtime);
@@ -264,7 +300,7 @@ impl ProviderRegistry {
     pub fn get_provider(&self, name: &str) -> Option<Arc<dyn Provider>> {
         // Try materialized providers first
         {
-            let providers = self.providers.read().unwrap();
+            let providers = self.providers.read().expect("providers lock poisoned");
             if let Some(p) = providers.iter().find(|p| p.name() == name) {
                 return Some(p.clone());
             }
@@ -272,7 +308,7 @@ impl ProviderRegistry {
 
         // Try to materialize from pending
         if self.materialize_provider(name) {
-            let providers = self.providers.read().unwrap();
+            let providers = self.providers.read().expect("providers lock poisoned");
             return providers.iter().find(|p| p.name() == name).cloned();
         }
 
@@ -282,13 +318,16 @@ impl ProviderRegistry {
     /// Get all registered providers (materializes all pending factories)
     pub fn providers(&self) -> Vec<Arc<dyn Provider>> {
         self.materialize_all();
-        self.providers.read().unwrap().clone()
+        self.providers
+            .read()
+            .expect("providers lock poisoned")
+            .clone()
     }
 
     /// Get all available runtime names (materializes all pending factories)
     pub fn runtime_names(&self) -> Vec<String> {
         self.materialize_all();
-        let providers = self.providers.read().unwrap();
+        let providers = self.providers.read().expect("providers lock poisoned");
         let mut names = Vec::new();
         for provider in providers.iter() {
             for runtime in provider.runtimes() {
@@ -302,7 +341,10 @@ impl ProviderRegistry {
     pub fn supports(&self, name: &str) -> bool {
         // Check materialized cache first
         {
-            let cache = self.runtime_cache.read().unwrap();
+            let cache = self
+                .runtime_cache
+                .read()
+                .expect("runtime_cache lock poisoned");
             if cache.contains_key(name) {
                 return true;
             }
@@ -310,7 +352,10 @@ impl ProviderRegistry {
 
         // Check pending index
         {
-            let index = self.pending_index.read().unwrap();
+            let index = self
+                .pending_index
+                .read()
+                .expect("pending_index lock poisoned");
             if index.contains_key(name) {
                 return true;
             }
@@ -321,10 +366,22 @@ impl ProviderRegistry {
 
     /// Clear all registered providers and pending factories
     pub fn clear(&self) {
-        self.providers.write().unwrap().clear();
-        self.runtime_cache.write().unwrap().clear();
-        self.pending_factories.lock().unwrap().clear();
-        self.pending_index.write().unwrap().clear();
+        self.providers
+            .write()
+            .expect("providers lock poisoned")
+            .clear();
+        self.runtime_cache
+            .write()
+            .expect("runtime_cache lock poisoned")
+            .clear();
+        self.pending_factories
+            .lock()
+            .expect("pending_factories lock poisoned")
+            .clear();
+        self.pending_index
+            .write()
+            .expect("pending_index lock poisoned")
+            .clear();
     }
 
     /// Get all runtimes that support the current platform (materializes all pending)
@@ -338,7 +395,7 @@ impl ProviderRegistry {
     /// Get all runtimes that support a specific platform (materializes all pending)
     pub fn supported_runtimes_for(&self, platform: &Platform) -> Vec<Arc<dyn Runtime>> {
         self.materialize_all();
-        let providers = self.providers.read().unwrap();
+        let providers = self.providers.read().expect("providers lock poisoned");
         let mut runtimes = Vec::new();
 
         for provider in providers.iter() {
@@ -399,7 +456,7 @@ impl ProviderRegistry {
     pub fn runtimes_by_platform_support(&self) -> (Vec<Arc<dyn Runtime>>, Vec<Arc<dyn Runtime>>) {
         self.materialize_all();
         let current = Platform::current();
-        let providers = self.providers.read().unwrap();
+        let providers = self.providers.read().expect("providers lock poisoned");
         let mut supported = Vec::new();
         let mut unsupported = Vec::new();
 


### PR DESCRIPTION
## Summary

Replace 34 bare `.unwrap()` calls with descriptive `.expect()` messages in production code across three critical files. This improves panic diagnostics without changing any logic.

## Changes

### `crates/vx-runtime/src/registry.rs` (28 unwraps → 0)
- All `RwLock`/`Mutex` lock operations now include `"<field> lock poisoned"` messages
- Covers: `providers`, `runtime_cache`, `pending_factories`, `pending_index`

### `crates/vx-paths/src/resolver.rs` (5 unwraps → 0)
- All `exec_cache.lock()` calls now include `"exec_cache lock poisoned"` message
- Affects: `save_cache()`, `invalidate_runtime_cache()`, `clear_exec_cache()`, `find_executable_in_dir()`

### `crates/vx-config/src/config_manager/toml_writer.rs` (1 unwrap → 0)
- `as_table_mut().unwrap()` now uses `.expect("intermediate table must exist (just created above)")` explaining the invariant

## What's NOT changed
- `.unwrap()` calls in test code (`#[cfg(test)]` blocks) are left as-is
- No logic changes — only panic message improvements
- No new dependencies

## Verification
- ✅ `cargo fmt -- --check` passes
- ✅ `cargo clippy -p vx-runtime -p vx-paths -p vx-config -- -D warnings` passes
- ✅ `cargo check --tests` passes (pre-commit hook)
- ✅ All pre-commit hooks pass