### PR TITLE
chore: improve code quality - replace bare unwrap() with expect/proper error handling

### DIFF
--- a/crates/vx-cli/src/commands/ai.rs
+++ b/crates/vx-cli/src/commands/ai.rs
@@ -647,14 +647,18 @@ pub async fn handle_session(ctx: &CommandContext, command: &SessionCommand) -> R
 
 /// Session state file path
 fn session_file_path() -> PathBuf {
-    let home = dirs::home_dir().unwrap_or_else(|| std::env::current_dir().unwrap());
+    let home = dirs::home_dir()
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."));
     home.join(".vx").join("ai-session.json")
 }
 
 /// Handle session init
 async fn handle_session_init(_ctx: &CommandContext) -> Result<()> {
     let session_path = session_file_path();
-    let session_dir = session_path.parent().unwrap();
+    let session_dir = session_path
+        .parent()
+        .expect("session file path should have a parent directory");
 
     std::fs::create_dir_all(session_dir).context("Failed to create vx session directory")?;
 

--- a/crates/vx-cli/src/commands/auth.rs
+++ b/crates/vx-cli/src/commands/auth.rs
@@ -301,7 +301,8 @@ pub async fn get_token_status() -> Result<TokenStatus> {
     }
 
     // Get token and check with GitHub API
-    let token = load_github_token().unwrap();
+    let token = load_github_token()
+        .context("Failed to load GitHub token despite detecting a token source")?;
     let client = reqwest::Client::new();
 
     let response = client

--- a/crates/vx-cli/src/commands/env/handler.rs
+++ b/crates/vx-cli/src/commands/env/handler.rs
@@ -354,7 +354,7 @@ async fn delete_env(name: Option<&str>, force: bool, global: bool) -> Result<()>
     }
 
     if global {
-        let env_name = name.unwrap();
+        let env_name = name.expect("global env deletion requires a name");
         path_manager.remove_env(env_name)?;
     } else {
         std::fs::remove_dir_all(&env_dir)?;
@@ -553,7 +553,9 @@ async fn remove_runtime(runtime: &str, env_name: Option<&str>, global: bool) -> 
 /// Sync project environment from vx.toml
 async fn sync_env() -> Result<()> {
     let (config_path, config) = load_config_view_cwd()?;
-    let current_dir = config_path.parent().unwrap();
+    let current_dir = config_path
+        .parent()
+        .expect("config file path should have a parent directory");
     let path_manager = PathManager::new()?;
     let env_dir = current_dir.join(PROJECT_ENV_DIR);
 

--- a/crates/vx-cli/src/commands/init.rs
+++ b/crates/vx-cli/src/commands/init.rs
@@ -3,7 +3,7 @@
 // Detects project type and generates appropriate vx configuration
 
 use crate::ui::UI;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Write};
@@ -239,16 +239,20 @@ async fn generate_interactive_config(existing: Option<&VxConfig>) -> Result<Stri
 
     // Get project name
     print!("Project name (optional, press Enter to skip): ");
-    io::stdout().flush().unwrap();
+    io::stdout().flush().context("Failed to flush stdout")?;
     let mut project_name = String::new();
-    io::stdin().read_line(&mut project_name).unwrap();
+    io::stdin()
+        .read_line(&mut project_name)
+        .context("Failed to read project name from stdin")?;
     let project_name = project_name.trim();
 
     // Get description
     print!("Description (optional): ");
-    io::stdout().flush().unwrap();
+    io::stdout().flush().context("Failed to flush stdout")?;
     let mut description = String::new();
-    io::stdin().read_line(&mut description).unwrap();
+    io::stdin()
+        .read_line(&mut description)
+        .context("Failed to read description from stdin")?;
     let description = description.trim();
 
     // Use detected tools or ask for selection
@@ -287,9 +291,11 @@ async fn generate_interactive_config(existing: Option<&VxConfig>) -> Result<Stri
             "Include {} ({}){}? (y/N, default: {}): ",
             tool, desc, marker, default
         );
-        io::stdout().flush().unwrap();
+        io::stdout().flush().context("Failed to flush stdout")?;
         let mut input = String::new();
-        io::stdin().read_line(&mut input).unwrap();
+        io::stdin()
+            .read_line(&mut input)
+            .context("Failed to read input from stdin")?;
         let input = input.trim().to_lowercase();
 
         let should_include = if input.is_empty() {

--- a/crates/vx-cli/src/commands/list/handler.rs
+++ b/crates/vx-cli/src/commands/list/handler.rs
@@ -225,13 +225,12 @@ async fn list_tool_versions(
 ) -> Result<()> {
     // Check if tool is supported
     let runtime = registry.get_runtime(tool_name);
-    if runtime.is_none() {
+    let Some(runtime) = runtime else {
         let available_tools = registry.runtime_names();
         UI::tool_not_found(tool_name, &available_tools);
         return Ok(());
-    }
+    };
 
-    let runtime = runtime.unwrap();
     let current_platform = Platform::current();
     let platform_supported = is_platform_supported(&runtime, &current_platform);
     let canonical_name = runtime.name();

--- a/crates/vx-cli/src/commands/run.rs
+++ b/crates/vx-cli/src/commands/run.rs
@@ -382,7 +382,9 @@ async fn execute_dependencies(
     let mut env_vars = build_script_environment(config)?;
 
     // Load .env files
-    let current_dir = config_path.parent().unwrap();
+    let current_dir = config_path
+        .parent()
+        .expect("config file path should have a parent directory");
     load_dotenv_files(current_dir, &mut env_vars);
 
     // Add config env vars
@@ -459,7 +461,10 @@ fn topological_sort(
 
     // Cycle detection
     if stack.contains(&name.to_string()) {
-        let cycle_start = stack.iter().position(|s| s == name).unwrap();
+        let cycle_start = stack
+            .iter()
+            .position(|s| s == name)
+            .expect("name was confirmed to be in stack by contains() check above");
         let cycle: Vec<_> = stack[cycle_start..].to_vec();
         return Err(anyhow::anyhow!(
             "Circular dependency detected: {} -> {}",

--- a/crates/vx-cli/src/commands/setup.rs
+++ b/crates/vx-cli/src/commands/setup.rs
@@ -314,7 +314,9 @@ fn output_ci_paths(config: &ConfigView) -> Result<()> {
         // Sort versions and get the latest
         let mut sorted_versions = versions;
         sorted_versions.sort();
-        let latest_version = sorted_versions.last().unwrap();
+        let latest_version = sorted_versions
+            .last()
+            .expect("sorted_versions is non-empty (checked above)");
         let version_dir = tool_dir.join(latest_version);
 
         // Check for bin subdirectory
@@ -391,7 +393,10 @@ pub async fn add_tool(tool: &str, version: Option<&str>) -> Result<()> {
         UI::warn(&format!("Tool '{}' already configured", tool));
         UI::info(&format!(
             "Current version: {}",
-            config.tools.get(tool).unwrap()
+            config
+                .tools
+                .get(tool)
+                .expect("tool key was checked with contains_key")
         ));
         return Ok(());
     }

--- a/crates/vx-cli/src/commands/where_cmd.rs
+++ b/crates/vx-cli/src/commands/where_cmd.rs
@@ -250,11 +250,11 @@ pub async fn handle(
             let (path, source) = &locations[0];
             (Some(path.display().to_string()), *source, vec![])
         }
-    } else if explicit_version.is_some() {
+    } else if let Some(ref ev) = explicit_version {
         // When version is explicitly specified, don't fallback to system PATH
         UI::debug(&format!(
             "Version '{}' explicitly specified but not found in vx store, not falling back to system",
-            explicit_version.unwrap()
+            ev
         ));
         (None, ToolSource::NotFound, vec![])
     } else if let Some(ref rv) = resolved_version {

--- a/crates/vx-config/src/container.rs
+++ b/crates/vx-config/src/container.rs
@@ -61,7 +61,10 @@ impl ContainerManager {
         let build_config = self.config.build.as_ref();
 
         if build_config.and_then(|b| b.multi_stage).unwrap_or(false) {
-            self.generate_multistage_dockerfile(dockerfile_config, build_config.unwrap())
+            self.generate_multistage_dockerfile(
+                dockerfile_config,
+                build_config.expect("build_config is Some when multi_stage is true"),
+            )
         } else {
             self.generate_simple_dockerfile(dockerfile_config)
         }

--- a/crates/vx-console/src/progress.rs
+++ b/crates/vx-console/src/progress.rs
@@ -66,7 +66,7 @@ impl ProgressManager {
         let bar = self.multi.add(ProgressBar::new_spinner());
         bar.set_style(
             ProgressStyle::with_template("  {spinner:.green} {msg}")
-                .unwrap()
+                .expect("invalid progress template")
                 .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", "✓"]),
         );
         bar.set_message(message.to_string());
@@ -89,7 +89,7 @@ impl ProgressManager {
             ProgressStyle::with_template(
                 "  {spinner:.green} {msg} {wide_bar:.cyan/blue} {bytes}/{total_bytes} ({bytes_per_sec}, {eta})"
             )
-            .unwrap()
+            .expect("invalid progress template")
             .progress_chars("━━╺"),
         );
         bar.set_message(message.to_string());
@@ -109,7 +109,7 @@ impl ProgressManager {
             ProgressStyle::with_template(
                 "  {spinner:.green} {msg} [{bar:40.cyan/blue}] {pos}/{len}",
             )
-            .unwrap()
+            .expect("invalid progress template")
             .progress_chars("━━╺"),
         );
         bar.set_message(message.to_string());
@@ -190,7 +190,7 @@ impl ManagedSpinner {
     pub fn finish_success(&self, message: &str) {
         self.bar.set_style(
             ProgressStyle::with_template("  {spinner:.green} {msg}")
-                .unwrap()
+                .expect("invalid progress template")
                 .tick_strings(&["✓"]),
         );
         self.bar
@@ -201,7 +201,7 @@ impl ManagedSpinner {
     pub fn finish_error(&self, message: &str) {
         self.bar.set_style(
             ProgressStyle::with_template("  {spinner:.red} {msg}")
-                .unwrap()
+                .expect("invalid progress template")
                 .tick_strings(&["✗"]),
         );
         self.bar
@@ -292,7 +292,7 @@ impl ProgressSpinner {
         let bar = ProgressBar::new_spinner();
         bar.set_style(
             ProgressStyle::with_template("  {spinner:.green} {msg}")
-                .unwrap()
+                .expect("invalid progress template")
                 .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", "✓"]),
         );
         bar.set_message(message.to_string());
@@ -305,7 +305,7 @@ impl ProgressSpinner {
         let bar = ProgressBar::new_spinner();
         bar.set_style(
             ProgressStyle::with_template("  {spinner:.green} Downloading {msg}")
-                .unwrap()
+                .expect("invalid progress template")
                 .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", "✓"]),
         );
         bar.set_message(message.to_string());
@@ -318,7 +318,7 @@ impl ProgressSpinner {
         let bar = ProgressBar::new_spinner();
         bar.set_style(
             ProgressStyle::with_template("  {spinner:.green} Installing {msg}")
-                .unwrap()
+                .expect("invalid progress template")
                 .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", "✓"]),
         );
         bar.set_message(message.to_string());
@@ -345,7 +345,7 @@ impl ProgressSpinner {
     pub fn finish_with_error(&self, message: &str) {
         self.bar.set_style(
             ProgressStyle::with_template("  {spinner:.red} {msg}")
-                .unwrap()
+                .expect("invalid progress template")
                 .tick_strings(&["✗"]),
         );
         self.bar
@@ -380,7 +380,7 @@ impl DownloadProgress {
         let bar = ProgressBar::new_spinner();
         bar.set_style(
             ProgressStyle::with_template("  {spinner:.green} {msg} {bytes} ({bytes_per_sec})")
-                .unwrap(),
+                .expect("invalid progress template"),
         );
         bar.set_message(message.to_string());
         bar.enable_steady_tick(Duration::from_millis(100));
@@ -433,7 +433,7 @@ impl MultiStepProgress {
         let bar = ProgressBar::new(total);
         bar.set_style(
             ProgressStyle::with_template("  {spinner:.green} [{pos}/{len}] {msg}")
-                .unwrap()
+                .expect("invalid progress template")
                 .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", "✓"]),
         );
 
@@ -482,7 +482,7 @@ impl InstallProgress {
         let main_bar = multi.add(ProgressBar::new(total_tools));
         main_bar.set_style(
             ProgressStyle::with_template("{msg} [{bar:40.cyan/blue}] {pos}/{len}")
-                .unwrap()
+                .expect("invalid progress template")
                 .progress_chars("━━╺"),
         );
         main_bar.set_message(title.to_string());
@@ -505,7 +505,7 @@ impl InstallProgress {
         let bar = self.multi.add(ProgressBar::new_spinner());
         bar.set_style(
             ProgressStyle::with_template("  {spinner:.green} Installing {msg}")
-                .unwrap()
+                .expect("invalid progress template")
                 .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", "✓"]),
         );
         bar.set_message(name.to_string());

--- a/crates/vx-resolver/src/executor/bin_dir_cache.rs
+++ b/crates/vx-resolver/src/executor/bin_dir_cache.rs
@@ -26,7 +26,9 @@ static BIN_DIR_CACHE: Mutex<Option<BinDirCache>> = Mutex::new(None);
 ///
 /// Called by the Executor during construction to pre-warm the cache.
 pub(crate) fn init_bin_dir_cache(cache_dir: &std::path::Path) {
-    let mut cache = BIN_DIR_CACHE.lock().unwrap();
+    let mut cache = BIN_DIR_CACHE
+        .lock()
+        .expect("BIN_DIR_CACHE mutex poisoned");
     if cache.is_none() {
         *cache = Some(BinDirCache::load(cache_dir));
     }
@@ -36,7 +38,9 @@ pub(crate) fn init_bin_dir_cache(cache_dir: &std::path::Path) {
 ///
 /// Called by the Executor after command execution to persist new entries.
 pub(crate) fn save_bin_dir_cache(cache_dir: &std::path::Path) {
-    let cache = BIN_DIR_CACHE.lock().unwrap();
+    let cache = BIN_DIR_CACHE
+        .lock()
+        .expect("BIN_DIR_CACHE mutex poisoned");
     if let Some(ref c) = *cache
         && let Err(e) = c.save(cache_dir)
     {
@@ -48,7 +52,9 @@ pub(crate) fn save_bin_dir_cache(cache_dir: &std::path::Path) {
 ///
 /// Call this after installing or uninstalling a runtime.
 pub fn invalidate_bin_dir_cache(runtime_store_prefix: &str) {
-    let mut cache = BIN_DIR_CACHE.lock().unwrap();
+    let mut cache = BIN_DIR_CACHE
+        .lock()
+        .expect("BIN_DIR_CACHE mutex poisoned");
     if let Some(ref mut c) = *cache {
         c.invalidate_runtime(runtime_store_prefix);
     }
@@ -56,7 +62,9 @@ pub fn invalidate_bin_dir_cache(runtime_store_prefix: &str) {
 
 /// Clear the entire bin directory cache.
 pub fn clear_bin_dir_cache() {
-    let mut cache = BIN_DIR_CACHE.lock().unwrap();
+    let mut cache = BIN_DIR_CACHE
+        .lock()
+        .expect("BIN_DIR_CACHE mutex poisoned");
     *cache = None;
 }
 
@@ -82,7 +90,7 @@ pub fn find_bin_dir(store_dir: &std::path::Path, runtime_name: &str) -> Option<P
 
     // Check process-level cache first (backed by disk persistence)
     {
-        let mut cache = BIN_DIR_CACHE.lock().unwrap();
+        let mut cache = BIN_DIR_CACHE.lock().expect("BIN_DIR_CACHE mutex poisoned");
         if let Some(ref mut c) = *cache
             && let Some(cached) = c.get(&cache_key)
         {
@@ -121,7 +129,7 @@ pub fn find_bin_dir(store_dir: &std::path::Path, runtime_name: &str) -> Option<P
     // Phase 1: Quick check common locations first (avoids walkdir entirely
     // for most runtimes like uv, go, bun, pnpm where exe is in root or bin/)
     if let Some(result) = quick_find_bin_dir(search_dir, &exe_names) {
-        let mut cache = BIN_DIR_CACHE.lock().unwrap();
+        let mut cache = BIN_DIR_CACHE.lock().expect("BIN_DIR_CACHE mutex poisoned");
         let c = cache.get_or_insert_with(BinDirCache::new);
         c.put(cache_key, result.clone());
         return Some(result);
@@ -167,7 +175,7 @@ pub fn find_bin_dir(store_dir: &std::path::Path, runtime_name: &str) -> Option<P
                 parent.display()
             );
             let result = parent.to_path_buf();
-            let mut cache = BIN_DIR_CACHE.lock().unwrap();
+            let mut cache = BIN_DIR_CACHE.lock().expect("BIN_DIR_CACHE mutex poisoned");
             let c = cache.get_or_insert_with(BinDirCache::new);
             c.put(cache_key, result.clone());
             return Some(result);
@@ -177,7 +185,7 @@ pub fn find_bin_dir(store_dir: &std::path::Path, runtime_name: &str) -> Option<P
     // Fallback: check standard locations
     let bin_dir = platform_dir.join("bin");
     if bin_dir.exists() {
-        let mut cache = BIN_DIR_CACHE.lock().unwrap();
+        let mut cache = BIN_DIR_CACHE.lock().expect("BIN_DIR_CACHE mutex poisoned");
         let c = cache.get_or_insert_with(BinDirCache::new);
         c.put(cache_key, bin_dir.clone());
         return Some(bin_dir);
@@ -185,7 +193,7 @@ pub fn find_bin_dir(store_dir: &std::path::Path, runtime_name: &str) -> Option<P
 
     let bin_dir = store_dir.join("bin");
     if bin_dir.exists() {
-        let mut cache = BIN_DIR_CACHE.lock().unwrap();
+        let mut cache = BIN_DIR_CACHE.lock().expect("BIN_DIR_CACHE mutex poisoned");
         let c = cache.get_or_insert_with(BinDirCache::new);
         c.put(cache_key, bin_dir.clone());
         return Some(bin_dir);
@@ -193,7 +201,7 @@ pub fn find_bin_dir(store_dir: &std::path::Path, runtime_name: &str) -> Option<P
 
     // Last resort: return platform dir if it exists
     if platform_dir.exists() {
-        let mut cache = BIN_DIR_CACHE.lock().unwrap();
+        let mut cache = BIN_DIR_CACHE.lock().expect("BIN_DIR_CACHE mutex poisoned");
         let c = cache.get_or_insert_with(BinDirCache::new);
         c.put(cache_key, platform_dir.clone());
         return Some(platform_dir);
@@ -267,7 +275,7 @@ fn quick_find_bin_dir(search_dir: &std::path::Path, exe_names: &[String]) -> Opt
 ///
 /// Returns `true` if this is the first warning for the given tool name.
 pub(crate) fn record_warned_tool(tool_name: &str) -> bool {
-    let mut warned = WARNED_TOOLS.lock().unwrap();
+    let mut warned = WARNED_TOOLS.lock().expect("WARNED_TOOLS mutex poisoned");
     let warned_set = warned.get_or_insert_with(HashSet::new);
     warned_set.insert(tool_name.to_string())
 }

--- a/crates/vx-resolver/src/executor/environment.rs
+++ b/crates/vx-resolver/src/executor/environment.rs
@@ -31,7 +31,7 @@ static BIN_DIR_CACHE: Mutex<Option<BinDirCache>> = Mutex::new(None);
 ///
 /// Called by the Executor during construction to pre-warm the cache.
 pub(crate) fn init_bin_dir_cache(cache_dir: &std::path::Path) {
-    let mut cache = BIN_DIR_CACHE.lock().unwrap();
+    let mut cache = BIN_DIR_CACHE.lock().expect("BIN_DIR_CACHE mutex poisoned");
     if cache.is_none() {
         *cache = Some(BinDirCache::load(cache_dir));
     }
@@ -41,7 +41,7 @@ pub(crate) fn init_bin_dir_cache(cache_dir: &std::path::Path) {
 ///
 /// Called by the Executor after command execution to persist new entries.
 pub(crate) fn save_bin_dir_cache(cache_dir: &std::path::Path) {
-    let cache = BIN_DIR_CACHE.lock().unwrap();
+    let cache = BIN_DIR_CACHE.lock().expect("BIN_DIR_CACHE mutex poisoned");
     if let Some(ref c) = *cache
         && let Err(e) = c.save(cache_dir)
     {
@@ -53,7 +53,7 @@ pub(crate) fn save_bin_dir_cache(cache_dir: &std::path::Path) {
 ///
 /// Call this after installing or uninstalling a runtime.
 pub fn invalidate_bin_dir_cache(runtime_store_prefix: &str) {
-    let mut cache = BIN_DIR_CACHE.lock().unwrap();
+    let mut cache = BIN_DIR_CACHE.lock().expect("BIN_DIR_CACHE mutex poisoned");
     if let Some(ref mut c) = *cache {
         c.invalidate_runtime(runtime_store_prefix);
     }
@@ -61,7 +61,7 @@ pub fn invalidate_bin_dir_cache(runtime_store_prefix: &str) {
 
 /// Clear the entire bin directory cache.
 pub fn clear_bin_dir_cache() {
-    let mut cache = BIN_DIR_CACHE.lock().unwrap();
+    let mut cache = BIN_DIR_CACHE.lock().expect("BIN_DIR_CACHE mutex poisoned");
     *cache = None;
 }
 
@@ -1003,7 +1003,7 @@ impl<'a> EnvironmentManager<'a> {
                 return Some(version);
             } else {
                 // Requested version not installed, warn and fall back to latest
-                let mut warned = WARNED_TOOLS.lock().unwrap();
+                let mut warned = WARNED_TOOLS.lock().expect("WARNED_TOOLS mutex poisoned");
                 let warned_set = warned.get_or_insert_with(HashSet::new);
                 if warned_set.insert(runtime_name.to_string()) {
                     warn!(
@@ -1101,7 +1101,7 @@ impl<'a> EnvironmentManager<'a> {
 
         // Check process-level cache first (backed by disk persistence)
         {
-            let mut cache = BIN_DIR_CACHE.lock().unwrap();
+            let mut cache = BIN_DIR_CACHE.lock().expect("BIN_DIR_CACHE mutex poisoned");
             if let Some(ref mut c) = *cache
                 && let Some(cached) = c.get(&cache_key)
             {
@@ -1140,7 +1140,7 @@ impl<'a> EnvironmentManager<'a> {
         // Phase 1: Quick check common locations first (avoids walkdir entirely
         // for most runtimes like uv, go, bun, pnpm where exe is in root or bin/)
         if let Some(result) = self.quick_find_bin_dir(search_dir, &exe_names) {
-            let mut cache = BIN_DIR_CACHE.lock().unwrap();
+            let mut cache = BIN_DIR_CACHE.lock().expect("BIN_DIR_CACHE mutex poisoned");
             let c = cache.get_or_insert_with(BinDirCache::new);
             c.put(cache_key, result.clone());
             return Some(result);
@@ -1186,7 +1186,7 @@ impl<'a> EnvironmentManager<'a> {
                     parent.display()
                 );
                 let result = parent.to_path_buf();
-                let mut cache = BIN_DIR_CACHE.lock().unwrap();
+                let mut cache = BIN_DIR_CACHE.lock().expect("BIN_DIR_CACHE mutex poisoned");
                 let c = cache.get_or_insert_with(BinDirCache::new);
                 c.put(cache_key, result.clone());
                 return Some(result);
@@ -1196,7 +1196,7 @@ impl<'a> EnvironmentManager<'a> {
         // Fallback: check standard locations
         let bin_dir = platform_dir.join("bin");
         if bin_dir.exists() {
-            let mut cache = BIN_DIR_CACHE.lock().unwrap();
+            let mut cache = BIN_DIR_CACHE.lock().expect("BIN_DIR_CACHE mutex poisoned");
             let c = cache.get_or_insert_with(BinDirCache::new);
             c.put(cache_key, bin_dir.clone());
             return Some(bin_dir);
@@ -1204,7 +1204,7 @@ impl<'a> EnvironmentManager<'a> {
 
         let bin_dir = store_dir.join("bin");
         if bin_dir.exists() {
-            let mut cache = BIN_DIR_CACHE.lock().unwrap();
+            let mut cache = BIN_DIR_CACHE.lock().expect("BIN_DIR_CACHE mutex poisoned");
             let c = cache.get_or_insert_with(BinDirCache::new);
             c.put(cache_key, bin_dir.clone());
             return Some(bin_dir);
@@ -1212,7 +1212,7 @@ impl<'a> EnvironmentManager<'a> {
 
         // Last resort: return platform dir if it exists
         if platform_dir.exists() {
-            let mut cache = BIN_DIR_CACHE.lock().unwrap();
+            let mut cache = BIN_DIR_CACHE.lock().expect("BIN_DIR_CACHE mutex poisoned");
             let c = cache.get_or_insert_with(BinDirCache::new);
             c.put(cache_key, platform_dir.clone());
             return Some(platform_dir);

--- a/crates/vx-resolver/src/executor/installation.rs
+++ b/crates/vx-resolver/src/executor/installation.rs
@@ -628,7 +628,10 @@ impl<'a> InstallationManager<'a> {
                 .filter(|dep| {
                     let dep_runtime = dep.provided_by.as_deref().unwrap_or(&dep.runtime_name);
                     let resolution = self.resolver.resolve(dep_runtime);
-                    resolution.is_err() || resolution.as_ref().unwrap().runtime_needs_install
+                    match resolution {
+                        Err(_) => true,
+                        Ok(ref r) => r.runtime_needs_install,
+                    }
                 })
                 .collect();
 

--- a/crates/vx-resolver/src/version/solver.rs
+++ b/crates/vx-resolver/src/version/solver.rs
@@ -179,7 +179,10 @@ impl VersionSolver {
                     .map(|s| s.as_ref())
                     .unwrap_or_else(|| {
                         // Fallback to Node.js strategy
-                        self.strategies.get(&Ecosystem::NodeJs).unwrap().as_ref()
+                        self.strategies
+                            .get(&Ecosystem::NodeJs)
+                            .expect("NodeJs strategy must always be registered")
+                            .as_ref()
                     })
             })
     }

--- a/crates/vx-runtime/src/provider_loader.rs
+++ b/crates/vx-runtime/src/provider_loader.rs
@@ -206,7 +206,10 @@ impl ProviderLoader {
             .unwrap_or("")
             .to_string();
 
-        let source_path = path.parent().unwrap().to_path_buf();
+        let source_path = path
+            .parent()
+            .expect("provider file path should have a parent directory")
+            .to_path_buf();
         let source = self.determine_source(&source_path);
 
         // Parse runtimes


### PR DESCRIPTION
## Summary

Systematic code quality improvement across 15 files in 5 core crates, replacing dangerous bare `.unwrap()` calls with descriptive `.expect()` messages or proper error handling via `anyhow::Context`.

## Changes

### P0: Runtime Panic Prevention (CLI Commands)
- **ai.rs**: Fix nested unwrap that could panic if both `home_dir()` and `current_dir()` fail
- **auth.rs**: Replace `load_github_token().unwrap()` with proper `anyhow::Context`
- **init.rs**: Replace 6 IO `.unwrap()` calls (stdout flush, stdin read_line) with `anyhow::Context`
- **setup.rs**: Add descriptive expect messages for guaranteed-safe unwraps
- **env/handler.rs**: Fix bare unwraps on name and path operations
- **run.rs**: Fix 3 bare unwraps on path operations and stack position lookup

### P1: Mutex Lock Safety
- **bin_dir_cache.rs**: Replace ~12 `.lock().unwrap()` → `.lock().expect("mutex poisoned")`
- **environment.rs**: Replace ~11 `.lock().unwrap()` → `.lock().expect("mutex poisoned")`

### P2: ProgressStyle Template Safety
- **progress.rs**: Replace ~16 `ProgressStyle::with_template().unwrap()` → `.expect("invalid progress template")`

### P3: Idiomatic Patterns
- **list/handler.rs**: Replace `is_none()` + `unwrap()` with idiomatic `let-else`
- **where_cmd.rs**: Replace `is_some()` / `unwrap()` with `if let Some(ref x)`
- **installation.rs**: Replace unsafe `is_err()` / `unwrap()` chain with safe `match`

### Other Fixes
- **container.rs**, **solver.rs**, **provider_loader.rs**: Add descriptive expect messages

## Verification
- ✅ `cargo clippy --workspace --all-targets` — zero warnings
- ✅ All pre-commit hooks passed (typos, cargo fmt, cargo check)
