### PR TITLE
fix(release): revert duplicate v0.8.9 release commit to fix release-please

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.9](https://github.com/loonghao/vx/compare/v0.8.8...v0.8.9) (2026-03-27)
-
-
-### Features
-
-* **hooks:** upgrade cargo-hakari pre-commit hook to auto-fix mode ([59d1c58](https://github.com/loonghao/vx/commit/59d1c580ee04103dc4bcbbc8910f98f85f2802aa))
-* **tests:** add comprehensive Python provider e2e tests ([861473d](https://github.com/loonghao/vx/commit/861473d25b889ad55aab0e38018c9abfd389fd23))
-
-
-### Bug Fixes
-
-* **tests:** relax assertion in test_vx_toml_python_setup_dry_run ([baa00df](https://github.com/loonghao/vx/commit/baa00df8f04a5140039911958f42513a7a369ca1))
+## [0.8.9](https://github.com/loonghao/vx/compare/v0.8.8...v0.8.9) (2026-03-26)
 
 
 ### Documentation


### PR DESCRIPTION
## Problem

`release-please` is failing with:
```
Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}
```

## Root Cause

There are **two** `chore: release v0.8.9` commits on `main`:

1. `f59ddf21` — Original release commit (tagged `v0.8.9`, GitHub Release created ✅)
2. `67b80d73` — **Duplicate** release commit that only updated CHANGELOG.md with additional entries (feat, fix commits merged after the first release)

When `release-please` runs again, it tries to create a release for `v0.8.9` (since the manifest still says `0.8.9` and there's a release commit), but the release already exists → `already_exists` error.

## Fix

Revert the duplicate release commit `67b80d73`. This restores the CHANGELOG to the state matching the actual `v0.8.9` release.

After this fix, when new conventional commits land on `main`, `release-please` will correctly create a `v0.8.10` release PR that bumps the version and includes the new changes.

## Verification

- [x] CHANGELOG.md restored to match the tagged `v0.8.9` release
- [x] `.release-please-manifest.json` still at `0.8.9` (correct — next release will bump it)
- [x] The 3 commits between `f59ddf21` and `67b80d73` (feat/fix/chore) will be picked up in the next release cycle