### PR TITLE
refactor: improve code safety by eliminating unsafe unwrap calls

### DIFF
--- a/crates/vx-cli/src/commands/container.rs
+++ b/crates/vx-cli/src/commands/container.rs
@@ -336,7 +336,10 @@ pub async fn handle_status() -> anyhow::Result<()> {
     // Check configuration
     if let Some(ref config_path) = config_path {
         let config = parse_config(config_path)?;
-        let config_name = config_path.file_name().unwrap().to_string_lossy();
+        let config_name = config_path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy();
 
         if let Some(container) = &config.container {
             println!("Configuration ({}):", config_name);

--- a/crates/vx-cli/src/commands/hook.rs
+++ b/crates/vx-cli/src/commands/hook.rs
@@ -162,7 +162,10 @@ pub async fn handle_status() -> Result<()> {
     // Config hooks status
     if let Some(config_path) = config_path {
         let config = vx_config::parse_config(&config_path)?;
-        let config_name = config_path.file_name().unwrap().to_string_lossy();
+        let config_name = config_path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy();
 
         println!("Configured Hooks ({}):", config_name);
         if let Some(hooks) = &config.hooks {

--- a/crates/vx-cli/src/commands/init.rs
+++ b/crates/vx-cli/src/commands/init.rs
@@ -108,7 +108,7 @@ pub async fn handle(
     {
         UI::warn(&format!(
             "Configuration file {} already exists",
-            existing.file_name().unwrap().to_string_lossy()
+            existing.file_name().unwrap_or_default().to_string_lossy()
         ));
         UI::info("Use --force to overwrite or edit the existing file");
         return Ok(());
@@ -133,7 +133,10 @@ pub async fn handle(
 
     // Determine which file to write to
     let target_path = existing_config.as_ref().unwrap_or(&config_path);
-    let target_filename = target_path.file_name().unwrap().to_string_lossy();
+    let target_filename = target_path
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy();
 
     if dry_run {
         UI::info(&format!("Preview of {} configuration:", target_filename));

--- a/crates/vx-cli/src/commands/setup.rs
+++ b/crates/vx-cli/src/commands/setup.rs
@@ -411,7 +411,10 @@ pub async fn add_tool(tool: &str, version: Option<&str>) -> Result<()> {
         "Added {}@{} to {}",
         tool,
         version,
-        config_path.file_name().unwrap().to_string_lossy()
+        config_path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
     ));
     UI::hint("Run 'vx setup' to install the tool");
 
@@ -436,7 +439,10 @@ pub async fn remove_tool(tool: &str) -> Result<()> {
     UI::success(&format!(
         "Removed '{}' from {}",
         tool,
-        config_path.file_name().unwrap().to_string_lossy()
+        config_path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
     ));
 
     Ok(())

--- a/crates/vx-cli/src/ui.rs
+++ b/crates/vx-cli/src/ui.rs
@@ -262,7 +262,7 @@ impl ProgressSpinner {
         let bar = pm.multi().add(ProgressBar::new_spinner());
         bar.set_style(
             ProgressStyle::with_template("{spinner:.cyan} {msg}")
-                .unwrap()
+                .expect("static progress template")
                 .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
         );
         bar.set_message(message.to_string());
@@ -276,7 +276,7 @@ impl ProgressSpinner {
         let bar = pm.multi().add(ProgressBar::new_spinner());
         bar.set_style(
             ProgressStyle::with_template("{spinner:.green} {msg}")
-                .unwrap()
+                .expect("static progress template")
                 .tick_strings(&["◜", "◠", "◝", "◞", "◡", "◟"]),
         );
         bar.set_message(message.to_string());
@@ -290,7 +290,7 @@ impl ProgressSpinner {
         let bar = pm.multi().add(ProgressBar::new_spinner());
         bar.set_style(
             ProgressStyle::with_template("{spinner:.blue} {msg}")
-                .unwrap()
+                .expect("static progress template")
                 .tick_strings(&["⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"]),
         );
         bar.set_message(message.to_string());
@@ -342,7 +342,7 @@ impl DownloadProgress {
             ProgressStyle::with_template(
                 "{spinner:.green} {msg} {wide_bar:.cyan/blue} {bytes}/{total_bytes} ({bytes_per_sec}, {eta})"
             )
-            .unwrap()
+            .expect("static progress template")
             .progress_chars("━━╺"),
         );
         bar.set_message(message.to_string());
@@ -356,7 +356,7 @@ impl DownloadProgress {
         let bar = pm.multi().add(ProgressBar::new_spinner());
         bar.set_style(
             ProgressStyle::with_template("{spinner:.green} {msg} {bytes} ({bytes_per_sec})")
-                .unwrap()
+                .expect("static progress template")
                 .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
         );
         bar.set_message(message.to_string());
@@ -418,7 +418,7 @@ impl MultiProgress {
         let bar = pm.multi().add(ProgressBar::new(total));
         bar.set_style(
             ProgressStyle::with_template("{spinner:.cyan} [{pos}/{len}] {msg}")
-                .unwrap()
+                .expect("static progress template")
                 .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
         );
 
@@ -472,7 +472,7 @@ impl InstallProgress {
         let main_bar = pm.multi().add(ProgressBar::new(total_tools as u64));
         main_bar.set_style(
             ProgressStyle::with_template("{msg} [{bar:40.green/dim}] {pos}/{len} tools")
-                .unwrap()
+                .expect("static progress template")
                 .progress_chars("━━╺"),
         );
         main_bar.set_message(title.to_string());
@@ -496,7 +496,7 @@ impl InstallProgress {
         let bar = pm.multi().add(ProgressBar::new_spinner());
         bar.set_style(
             ProgressStyle::with_template("  {spinner:.blue} Installing {msg}")
-                .unwrap()
+                .expect("static progress template")
                 .tick_strings(&["⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"]),
         );
         bar.set_message(format!("{}@{}", tool_name, version));

--- a/crates/vx-console/src/progress.rs
+++ b/crates/vx-console/src/progress.rs
@@ -367,7 +367,7 @@ impl DownloadProgress {
             ProgressStyle::with_template(
                 "  {spinner:.green} {msg} {wide_bar:.cyan/blue} {bytes}/{total_bytes} ({bytes_per_sec}, {eta})"
             )
-            .unwrap()
+            .expect("static progress template")
             .progress_chars("━━╺"),
         );
         bar.set_message(message.to_string());

--- a/crates/vx-metrics/src/init.rs
+++ b/crates/vx-metrics/src/init.rs
@@ -66,7 +66,7 @@ impl MetricsGuard {
     /// Force flush and write the metrics report now.
     pub fn flush(&self) {
         if let Err(e) = self.write_report() {
-            eprintln!("[vx-metrics] Failed to write metrics report: {}", e);
+            tracing::warn!("[vx-metrics] Failed to write metrics report: {}", e);
         }
     }
 

--- a/crates/vx-metrics/src/visualize.rs
+++ b/crates/vx-metrics/src/visualize.rs
@@ -29,7 +29,7 @@ pub fn load_metrics(dir: &Path, limit: usize) -> anyhow::Result<Vec<CommandMetri
         match serde_json::from_str::<CommandMetrics>(&content) {
             Ok(m) => results.push(m),
             Err(e) => {
-                eprintln!(
+                tracing::warn!(
                     "[vx-metrics] Skipping {}: {}",
                     path.file_name().unwrap_or_default().to_string_lossy(),
                     e

--- a/crates/vx-runtime/src/package_runtime.rs
+++ b/crates/vx-runtime/src/package_runtime.rs
@@ -638,7 +638,7 @@ async fn install_with_uv(
 
     // Create venv with uv, using vx-managed Python if available
     let mut cmd = TokioCommand::new(uv_exe);
-    cmd.args(["venv", "--quiet", venv_dir.to_str().unwrap()]);
+    cmd.args(["venv", "--quiet", &venv_dir.to_string_lossy()]);
 
     if let Some(ref python_path) = vx_python {
         debug!("Using vx-managed Python: {}", python_path.display());
@@ -678,12 +678,13 @@ async fn install_with_uv(
     // Install package with uv pip
     let install_spec = format!("{}=={}", package_name, version);
     let mut cmd = TokioCommand::new(uv_exe);
+    let venv_python_str = venv_python.to_string_lossy();
     cmd.args([
         "pip",
         "install",
         "--quiet",
         "--python",
-        venv_python.to_str().unwrap(),
+        &*venv_python_str,
         &install_spec,
     ])
     .stdin(std::process::Stdio::null())
@@ -755,7 +756,7 @@ async fn install_with_system_python(
 
     // Create venv
     let mut cmd = TokioCommand::new(&python_exe);
-    cmd.args(["-m", "venv", venv_dir.to_str().unwrap()])
+    cmd.args(["-m", "venv", &*venv_dir.to_string_lossy()])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())

--- a/crates/vx-setup/src/pipeline/executor.rs
+++ b/crates/vx-setup/src/pipeline/executor.rs
@@ -372,7 +372,9 @@ impl SetupPipeline {
             // Sort versions and get the latest
             let mut sorted_versions = versions;
             sorted_versions.sort();
-            let latest_version = sorted_versions.last().unwrap();
+            let Some(latest_version) = sorted_versions.last() else {
+                continue;
+            };
             let version_dir = tool_dir.join(latest_version);
 
             // Check for bin subdirectory


### PR DESCRIPTION
## Summary

This PR improves code safety and maintainability by systematically replacing unsafe `.unwrap()` calls with safer alternatives across 10 files.

## Changes

### Path Safety (package_runtime.rs)
- Replace 3x `.to_str().unwrap()` with `.to_string_lossy()` to prevent panics on non-UTF-8 paths

### Collection Safety (setup/executor.rs)
- Replace `sorted_versions.last().unwrap()` with `let-else` pattern to prevent panics on empty version lists

### Path Component Safety (CLI commands)
- Replace 6x `file_name().unwrap()` with `.unwrap_or_default()` in container.rs, hook.rs, init.rs, setup.rs

### Logging Standards (vx-metrics)
- Replace 2x `eprintln!` with `tracing::warn!` to align with project conventions

### Panic Message Clarity (ui.rs, progress.rs)
- Replace 9x `ProgressStyle::with_template().unwrap()` with `.expect("static progress template")`

## Testing
- All pre-commit hooks pass (typos, cargo fmt, clippy, cargo check --tests)
- No new warnings or errors introduced
