### PR TITLE
docs: optimize agent docs for v0.8.20 — add Copilot instructions, expand AI agent support to 17+

### DIFF
--- a/.codebuddy/skills/vx-best-practices/SKILL.md
+++ b/.codebuddy/skills/vx-best-practices/SKILL.md
@@ -514,7 +514,7 @@ vx cargo test -p vx-starlark     # Test one crate
 
 ## AI Agent Documentation Ecosystem
 
-vx maintains a comprehensive set of AI agent configuration files:
+vx maintains a comprehensive set of AI agent configuration files for 15+ agents:
 
 | File | Purpose | Audience |
 |------|---------|----------|
@@ -523,9 +523,12 @@ vx maintains a comprehensive set of AI agent configuration files:
 | `llms.txt` | Concise LLM-friendly project index (llmstxt.org protocol) | LLMs discovering the project |
 | `llms-full.txt` | Detailed LLM documentation with full examples | LLMs needing deep context |
 | `.github/copilot-instructions.md` | GitHub Copilot-specific instructions | GitHub Copilot |
-| `.cursor/rules/*.mdc` | Modern Cursor IDE rules with YAML frontmatter and activation modes | Cursor AI (new format) |
+| `.cursor/rules/*.mdc` | Modern Cursor IDE rules with YAML frontmatter (4 files) | Cursor AI (new format) |
 | `.cursorrules` | Cursor IDE agent rules (legacy format, still supported) | Cursor AI (legacy) |
 | `.clinerules` | Cline/Roo agent rules | Cline |
-| `skills/` | Distributable skill files for 13+ AI agents | ClawHub, vx ai setup |
+| `.windsurfrules` | Windsurf AI IDE rules | Windsurf |
+| `.kiro/steering/*.md` | Kiro AI IDE steering documents | Kiro |
+| `.trae/rules/*.md` | Trae AI IDE project rules | Trae |
+| `skills/` | Distributable skill files for 15+ AI agents | ClawHub, vx ai setup |
 
 **Best practice**: When making changes that affect AI agent behavior (terminology, architecture, commands), update `AGENTS.md` first — it is the single source of truth. Other files derive from it.

--- a/.codebuddy/skills/vx-usage/SKILL.md
+++ b/.codebuddy/skills/vx-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vx-usage
-description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 78 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 105 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
 ---
 
 # VX - Universal Development Tool Manager
@@ -195,18 +195,20 @@ vx msvc@14.40 cl main.cpp
 | lib | `vx msvc lib` | Library manager |
 | nmake | `vx msvc nmake` | Make utility |
 
-## Supported Tools (78 Providers)
+## Supported Tools (105 Providers)
 
 | Category | Tools |
 |----------|-------|
 | **JavaScript** | node, npm, npx, bun, deno, pnpm, yarn, vite, nx, turbo |
-| **JS Tooling** | oxlint |
+| **JS Tooling** | oxlint, biome |
 | **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
 | **Rust** | cargo, rustc, rustup |
 | **Go** | go, gofmt, gws |
-| **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj |
+| **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
+| **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
 | **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, conan, vcpkg, spack |
-| **DevOps** | kubectl, helm, podman, terraform, hadolint, dagu |
+| **DevOps** | kubectl, helm, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy |
 | **Cloud CLI** | awscli, azcli, gcloud |
 | **.NET** | dotnet, msbuild, nuget |
 | **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
@@ -214,12 +216,14 @@ vx msvc@14.40 cl main.cpp
 | **Java** | java |
 | **AI** | ollama, openclaw |
 | **Other Langs** | zig |
+| **Container** | dive |
+| **Config Mgmt** | chezmoi, mise |
 | **Package Managers** | brew, choco, winget |
-| **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip |
+| **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
 
 ## Provider System (Starlark DSL)
 
-All 78 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+All 105 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
 
 vx uses a **two-phase execution model** (inspired by Buck2):
 1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
@@ -320,7 +324,10 @@ vx resolves tool versions in this order (highest to lowest):
 
 ## MCP Integration
 
-vx is **MCP-ready** — replace `npx`/`uvx` with `vx` in MCP server configurations:
+vx is **MCP-ready** — replace `npx`/`uvx` with `vx` in MCP server configurations.
+This eliminates the "install Node.js/Python first" requirement for all MCP servers.
+
+### Configuration Pattern
 
 ```json
 {
@@ -337,14 +344,44 @@ vx is **MCP-ready** — replace `npx`/`uvx` with `vx` in MCP server configuratio
 }
 ```
 
-**Benefits**: Users don't need Node.js/Python pre-installed — vx auto-installs on first use.
+### Real-World MCP Examples
 
-**Migration pattern**:
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]
+    },
+    "github": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "<token>" }
+    },
+    "sqlite": {
+      "command": "vx",
+      "args": ["uvx", "mcp-server-sqlite", "--db-path", "/path/to/db.sqlite"]
+    }
+  }
+}
+```
+
+### Migration Pattern
+
 | Original | vx-powered |
 |----------|------------|
 | `"command": "npx"` | `"command": "vx", "args": ["npx", ...]` |
 | `"command": "uvx"` | `"command": "vx", "args": ["uvx", ...]` |
 | `"command": "node"` | `"command": "vx", "args": ["node", ...]` |
+| `"command": "python"` | `"command": "vx", "args": ["python", ...]` |
+| `"command": "bun"` | `"command": "vx", "args": ["bun", ...]` |
+
+### Benefits for AI Agents
+
+- **Zero-config**: No need to check if Node.js/Python is installed before starting MCP servers
+- **Version consistency**: MCP servers always use the version specified in `vx.toml`
+- **Cross-platform**: Same MCP config works on Windows, macOS, and Linux
+- **CI/CD ready**: MCP servers in CI pipelines just work with vx
 
 ## GitHub Actions Integration
 

--- a/.cursor/rules/vx-core.mdc
+++ b/.cursor/rules/vx-core.mdc
@@ -5,7 +5,7 @@ alwaysApply: true
 
 # VX Project Rules
 
-vx is a universal development tool manager (v0.8.19, Rust, 105 providers, Starlark DSL).
+vx is a universal development tool manager (v0.8.20, Rust, 105 providers, Starlark DSL).
 Users prefix commands with `vx` (e.g., `vx node --version`) and tools auto-install on first use.
 
 ## Commands

--- a/.cursorrules
+++ b/.cursorrules
@@ -2,7 +2,7 @@
 
 ## Project Context
 
-vx is a universal development tool manager written in Rust (v0.8.19, 105 providers).
+vx is a universal development tool manager written in Rust (v0.8.20, 105 providers).
 Users prefix commands with `vx` (e.g., `vx node --version`) and vx auto-installs tools.
 Providers are defined via Starlark DSL (`provider.star`) — no Rust code needed for new tools.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-vx is a **universal development tool manager** (v0.8.19, Rust, MIT, 105 providers).
+vx is a **universal development tool manager** (v0.8.20, Rust, MIT, 105 providers).
 Users prefix any command with `vx` (e.g., `vx node --version`, `vx cargo build`) and vx automatically installs, manages, and forwards to the correct tool version. Providers defined via Starlark DSL (`provider.star`).
 
 ## Critical Rules

--- a/.github/instructions/rust-code.instructions.md
+++ b/.github/instructions/rust-code.instructions.md
@@ -1,0 +1,41 @@
+---
+applyTo: "**/*.rs"
+---
+
+# Rust Code Instructions for vx
+
+## vx-specific Rules
+
+- **Logging**: Always use `tracing` macros (`tracing::info!`, `tracing::debug!`, `tracing::warn!`, `tracing::error!`). NEVER use `println!`, `eprintln!`, or `dbg!`.
+- **Error handling**: Use `anyhow::Result` for application code (vx-cli, vx-resolver). Use `thiserror` for library error types (vx-core, vx-paths, etc.).
+- **Tests**: Place tests in `crates/<name>/tests/` directories. NEVER write inline `#[cfg(test)]` modules in source files.
+- **Testing framework**: Use `rstest` for parameterized tests. Naming: `test_<function>_<scenario>()`.
+- **Import order**: stdlib → external crates → internal crates, separated by blank lines.
+- **File size**: Keep source files under 500 lines. Split large files into modules.
+- **Async**: Use Tokio-based async/await for all I/O operations.
+
+## Terminology (enforced in code, docs, and comments)
+
+- **Runtime** (not Tool, not VxTool) — an executable managed by vx
+- **Provider** (not Plugin, not Bundle) — a module that defines how to install/manage a Runtime
+- **provider.star** (not "provider config") — the Starlark DSL file
+- **ProviderRegistry** (not BundleRegistry)
+
+## Architecture Layer Rule
+
+Layer dependencies go **downward only** — never import from a higher layer:
+
+1. CLI: `vx-cli`
+2. Orchestration: `vx-resolver`, `vx-setup`, `vx-project-analyzer`
+3. Service: `vx-runtime`, `vx-starlark`, `vx-installer`, `vx-config`, `vx-console`
+4. Foundation: `vx-core`, `vx-paths`, `vx-cache`, `vx-versions`, `vx-manifest`
+5. Providers: `vx-providers/*`
+
+## Commands
+
+```bash
+vx cargo check -p vx-cli          # Type-check one crate
+vx cargo test -p vx-starlark      # Test one crate
+vx cargo clippy -p vx-resolver -- -D warnings  # Lint one crate
+vx just quick                      # format → lint → test → build
+```

--- a/.github/instructions/starlark-providers.instructions.md
+++ b/.github/instructions/starlark-providers.instructions.md
@@ -1,0 +1,55 @@
+---
+applyTo: "crates/vx-providers/*/provider.star"
+---
+
+# Starlark Provider Instructions
+
+When editing or creating `provider.star` files, follow these rules:
+
+## Required Fields
+
+Every `provider.star` must define:
+- `name` (string) — Provider name
+- `runtimes` (list) — At least one `runtime_def()`
+- `permissions` (dict) — Use `github_permissions()` or `system_permissions()`
+
+## Prefer Templates
+
+Use templates for 90% of cases — don't hand-write download logic unless necessary:
+
+```starlark
+load("@vx//stdlib:provider.star", "runtime_def", "github_permissions")
+load("@vx//stdlib:provider_templates.star", "github_rust_provider")
+
+name        = "<name>"
+description = "<description>"
+ecosystem   = "custom"  # nodejs, python, rust, go, system, custom
+runtimes    = [runtime_def("<runtime>", aliases = ["<alias>"])]
+permissions = github_permissions()
+
+_p = github_rust_provider("owner", "repo",
+    asset = "tool-{vversion}-{triple}.{ext}")
+fetch_versions   = _p["fetch_versions"]
+download_url     = _p["download_url"]
+install_layout   = _p["install_layout"]
+store_root       = _p["store_root"]
+get_execute_path = _p["get_execute_path"]
+environment      = _p["environment"]
+```
+
+## Template Selection
+
+| Pattern | Template | Example |
+|---------|----------|---------|
+| Rust target triple naming | `github_rust_provider` | ripgrep, just, uv, fd |
+| Go goreleaser style | `github_go_provider` | gh, golangci-lint |
+| Single binary (no archive) | `github_binary_provider` | kubectl |
+| System package manager only | `system_provider` | 7zip, make |
+
+## Platform Constraints
+
+Return `None` from `download_url()` for unsupported platforms — never raise an error.
+
+## Testing
+
+After creating/editing a provider: `vx <runtime> --version`

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,44 @@
+---
+applyTo: "crates/*/tests/**/*.rs,tests/**/*.rs"
+---
+
+# Testing Instructions for vx
+
+## File Location
+
+Tests MUST go in `crates/<name>/tests/` directories. NEVER create inline `#[cfg(test)]` modules.
+
+```
+crates/vx-resolver/tests/
+├── resolver_tests.rs
+├── executor_tests.rs
+└── spec_tests.rs
+```
+
+## Framework
+
+Use `rstest` for parameterized tests:
+
+```rust
+use rstest::rstest;
+
+#[rstest]
+#[case("node", Ecosystem::NodeJs)]
+#[case("npm", Ecosystem::NodeJs)]
+#[case("go", Ecosystem::Go)]
+fn test_ecosystem_detection(#[case] name: &str, #[case] expected: Ecosystem) {
+    let spec = RuntimeSpec::new(name);
+    assert_eq!(spec.ecosystem, expected);
+}
+```
+
+## Naming Convention
+
+- Sync: `fn test_<function_name>_<scenario>()`
+- Async: `async fn test_<function_name>_<scenario>()`
+
+## Rules
+
+- Mock network calls in unit tests — never use real HTTP
+- Each test must be independent — no shared mutable state
+- Run tests: `vx just test` or `vx cargo test -p <crate>`

--- a/.kiro/steering/vx-project.md
+++ b/.kiro/steering/vx-project.md
@@ -2,7 +2,7 @@
 
 ## Project Context
 
-vx is a **universal development tool manager** (v0.8.19, Rust, MIT) that ships 105 providers.
+vx is a **universal development tool manager** (v0.8.20, Rust, MIT) that ships 105 providers.
 Users prefix commands with `vx` and tools auto-install on first use. Providers use Starlark DSL.
 
 ## Critical Rules

--- a/.trae/rules/vx-project.md
+++ b/.trae/rules/vx-project.md
@@ -2,7 +2,7 @@
 
 ## Project Context
 
-vx is a **universal development tool manager** (v0.8.19, Rust, MIT, 105 providers).
+vx is a **universal development tool manager** (v0.8.20, Rust, MIT, 105 providers).
 Users prefix commands with `vx` (e.g., `vx node --version`) and tools auto-install on first use.
 Providers are defined via Starlark DSL (`provider.star`) — no Rust code needed.
 

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -2,7 +2,7 @@
 
 ## Project
 
-vx is a **universal development tool manager** (v0.8.19, Rust, MIT, 105 providers).
+vx is a **universal development tool manager** (v0.8.20, Rust, MIT, 105 providers).
 Users prefix commands with `vx` (e.g., `vx node --version`) and tools auto-install on first use.
 Providers are defined via Starlark DSL (`provider.star`) — no Rust code needed for new tools.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## What is vx?
 
-vx is a **zero-config universal development tool manager** (v0.8.19, MIT-licensed, written in Rust). Users prefix any command with `vx` (e.g., `vx node --version`, `vx cargo build`) and vx automatically installs, manages, and forwards to the correct tool version. vx currently ships **105 providers** covering language runtimes, build tools, DevOps CLIs, cloud platforms, and more — all defined via Starlark DSL (`provider.star`).
+vx is a **zero-config universal development tool manager** (v0.8.20, MIT-licensed, written in Rust). Users prefix any command with `vx` (e.g., `vx node --version`, `vx cargo build`) and vx automatically installs, manages, and forwards to the correct tool version. vx currently ships **105 providers** covering language runtimes, build tools, DevOps CLIs, cloud platforms, and more — all defined via Starlark DSL (`provider.star`).
 
 **Key insight for agents**: vx is a transparent proxy. The user writes the exact same commands they already know — just prepended with `vx`. There is **no new syntax to learn** for tool execution.
 
@@ -658,12 +658,24 @@ vx provides a GitHub Action for CI/CD. See [`docs/guides/github-action.md`](docs
 - run: vx npm test
 ```
 
-> **Tip**: Use `@main` for latest, or pin to a release tag (e.g., `@vx-v0.8.19`).
+> **Tip**: Use `@main` for latest, or pin to a release tag (e.g., `@vx-v0.8.20`).
 > Check [releases](https://github.com/loonghao/vx/releases) for available versions.
+
+### GitHub Copilot File-Scoped Instructions
+
+In addition to the repository-wide `.github/copilot-instructions.md`, vx provides **file-scoped instructions** in `.github/instructions/`:
+
+| File | Scope | Purpose |
+|------|-------|---------|
+| `rust-code.instructions.md` | `**/*.rs` | Rust coding standards, vx-specific rules, architecture layers |
+| `starlark-providers.instructions.md` | `crates/vx-providers/*/provider.star` | Provider development templates, platform constraints |
+| `testing.instructions.md` | `crates/*/tests/**/*.rs`, `tests/**/*.rs` | Test conventions, rstest patterns, mock usage |
+
+These use the `applyTo` frontmatter format and are automatically loaded by GitHub Copilot when editing matching files.
 
 ## AI Agent Ecosystem
 
-vx is designed to be **AI-agent-first**. It provides configuration files for 15+ AI coding assistants, ensuring that any AI agent working with vx-managed projects automatically understands how to use `vx` correctly.
+vx is designed to be **AI-agent-first**. It provides configuration files for 17+ AI coding assistants, ensuring that any AI agent working with vx-managed projects automatically understands how to use `vx` correctly.
 
 ### Why vx Matters for AI Agents
 
@@ -671,13 +683,23 @@ Traditional tool management creates friction for AI agents:
 - **Without vx**: AI must guess if Node.js is installed, check `nvm` vs `fnm` vs system install, handle version mismatches — all before running a single `npm install`.
 - **With vx**: AI just prefixes `vx` → tool auto-installs → command runs. Zero ambiguity, zero setup.
 
+**Key insight (from ETH Zurich research)**: AI agents perform best when given non-inferable details — information they cannot discover by reading code alone. vx's `AGENTS.md` focuses on exactly this: the `vx` prefix requirement, correct terminology, and architecture layer rules that no AI could guess from code inspection.
+
+### How AI Agents Should Use vx
+
+1. **Check for `vx.toml`** in the project root → if present, always use `vx` prefix
+2. **Never suggest manual installation** of any tool — `vx` handles it
+3. **Use structured output** for parsing: `vx list --json` or `vx list --format toon` (saves 40-60% tokens)
+4. **For MCP servers**, replace `npx`/`uvx` with `vx` in the config
+5. **For CI/CD**, use `loonghao/vx@main` GitHub Action with `cache: 'true'`
+
 ### Supported AI Agents
 
 | Agent | Config File(s) | Format |
 |-------|---------------|--------|
 | **OpenAI Codex** | `AGENTS.md` | Markdown |
 | **Claude Code** | `CLAUDE.md` | Markdown with @imports |
-| **GitHub Copilot** | `.github/copilot-instructions.md` | Markdown |
+| **GitHub Copilot** | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | Markdown with YAML frontmatter |
 | **Cursor** | `.cursor/rules/*.mdc`, `.cursorrules` | MDC (YAML frontmatter + Markdown) |
 | **Cline / Roo** | `.clinerules` | Markdown |
 | **Windsurf** | `.windsurfrules` | Markdown |
@@ -685,9 +707,11 @@ Traditional tool management creates friction for AI agents:
 | **Trae** | `.trae/rules/*.md` | Markdown |
 | **Google Jules** | `AGENTS.md` | Markdown |
 | **Amp** | `AGENTS.md` | Markdown |
+| **Augment** | `AGENTS.md` | Markdown |
 | **Devin** | `AGENTS.md` | Markdown |
 | **Aider** | `AGENTS.md` | Markdown |
 | **Zed** | `AGENTS.md` | Markdown |
+| **OpenCode** | `AGENTS.md` | Markdown |
 | **JetBrains Junie** | `AGENTS.md` | Markdown |
 | **CodeBuddy** | `.codebuddy/skills/` | SKILL.md |
 
@@ -730,16 +754,17 @@ vx is **MCP-ready** — replace `npx`/`uvx` with `vx` in any MCP server config:
 ## Documentation Map
 
 ```
-# AI Agent Ecosystem (root files — 15+ agents supported)
+# AI Agent Ecosystem (root files — 17+ agents supported)
 AGENTS.md                 # THIS FILE — primary AI agent entry point (cross-tool standard)
 CLAUDE.md                 # Claude Code instructions (@import supported)
 llms.txt                  # LLM-friendly project index (llmstxt.org protocol)
 llms-full.txt             # Detailed LLM documentation
 
 # Agent-specific config files
-.github/copilot-instructions.md  # GitHub Copilot instructions
+.github/copilot-instructions.md  # GitHub Copilot instructions (repo-wide)
+.github/instructions/            # GitHub Copilot file-scoped instructions (3 files)
 .cursorrules              # Cursor IDE agent rules (legacy format)
-.cursor/rules/*.mdc       # Cursor IDE rules (modern .mdc format, 3 files)
+.cursor/rules/*.mdc       # Cursor IDE rules (modern .mdc format, 4 files)
 .clinerules               # Cline/Roo agent rules
 .windsurfrules            # Windsurf AI IDE rules
 .kiro/steering/           # Kiro AI IDE steering documents
@@ -896,7 +921,7 @@ export VX_OUTPUT=json             # Default all commands to JSON
 
 ## Skills Distribution
 
-vx ships AI agent skills in the [`skills/`](skills/) directory. These skills are the **single source of truth** shared across 15+ AI agents:
+vx ships AI agent skills in the [`skills/`](skills/) directory. These skills are the **single source of truth** shared across 17+ AI agents:
 
 ```bash
 # Install skills to all AI agents

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 
 ## Project
 
-vx is a **universal development tool manager** (v0.8.19, Rust, MIT). Users prefix any command with `vx` and tools auto-install on first use. 105 providers defined via Starlark DSL (`provider.star`).
+vx is a **universal development tool manager** (v0.8.20, Rust, MIT). Users prefix any command with `vx` and tools auto-install on first use. 105 providers defined via Starlark DSL (`provider.star`).
 
 ```bash
 vx node --version     # Auto-installs Node.js

--- a/llms.txt
+++ b/llms.txt
@@ -20,6 +20,7 @@ vx eliminates the complexity of managing multiple language runtimes (Node.js, Py
 - **Trae Rules**: [.trae/rules/](https://github.com/loonghao/vx/blob/main/.trae/rules/)
 - **Cursor Rules**: [.cursor/rules/](https://github.com/loonghao/vx/blob/main/.cursor/rules/) (4 .mdc files)
 - **Cline/Roo Rules**: [.clinerules](https://github.com/loonghao/vx/blob/main/.clinerules)
+- **Copilot File-scoped Instructions**: [.github/instructions/](https://github.com/loonghao/vx/blob/main/.github/instructions/) (3 .instructions.md files)
 
 ## Quick Start (for AI Agents)
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,11 +1,11 @@
 # vx — AI Agent Skills
 
-This directory contains AI agent skills for **[vx](https://github.com/loonghao/vx)** — the universal development tool manager (v0.8.19).
+This directory contains AI agent skills for **[vx](https://github.com/loonghao/vx)** — the universal development tool manager (v0.8.20).
 
 > **Core concept**: vx = prefix any dev tool command with `vx` → it auto-installs the tool and runs it.
 
 These skills are the **single source of truth** shared across:
-- `vx ai setup` — embeds skills into the vx binary at compile time, distributes to 13+ AI agents
+- `vx ai setup` — embeds skills into the vx binary at compile time, distributes to 17+ AI agents
 - **ClawHub** — published automatically via CI when changes merge to main
 - **Agent config directories** — `.codebuddy/skills/`, `.claude/skills/`, `.cursor/skills/`, etc.
 


### PR DESCRIPTION
Update version v0.8.19->v0.8.20 across 10+ files. Add .github/instructions/ (Copilot file-scoped). Enhance AGENTS.md with ETH Zurich research. Add OpenCode, Augment to 17+ agents. Sync .codebuddy/skills/.