### PR TITLE
fix: wire post_extract hooks, fix bundled runtime detection, and correct provider URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4470,7 +4470,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4487,7 +4487,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "indexmap",
  "regex",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4526,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4663,7 +4663,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4685,7 +4685,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4706,7 +4706,7 @@ dependencies = [
 
 [[package]]
 name = "vx-core"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "pretty_assertions",
@@ -4723,7 +4723,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4741,7 +4741,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "colored",
@@ -4763,7 +4763,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4785,7 +4785,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4818,7 +4818,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4859,7 +4859,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4881,14 +4881,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-paths"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4907,7 +4907,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4932,7 +4932,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-7zip"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -4943,7 +4943,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-actionlint"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -4954,7 +4954,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-actrun"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-atuin"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-awscli"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -4987,7 +4987,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-azcli"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -4998,7 +4998,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bash"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5009,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bat"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-biome"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bottom"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5042,7 +5042,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-brew"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5053,7 +5053,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-buildcache"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bun"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5075,7 +5075,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cargo-audit"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5086,7 +5086,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cargo-deny"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5097,7 +5097,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cargo-nextest"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ccache"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-chezmoi"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-choco"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5141,7 +5141,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cmake"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-conan"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-curl"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dagu"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-delta"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-deno"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5207,7 +5207,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dive"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dotnet"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-duckdb"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-duf"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dust"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5262,7 +5262,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-eza"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-fd"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5284,7 +5284,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ffmpeg"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5295,7 +5295,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-flux"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-fzf"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gcloud"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gh"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-git"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gitleaks"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-go"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5372,7 +5372,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gping"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-grpcurl"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5394,7 +5394,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-hadolint"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5405,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-helix"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-helm"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-hyperfine"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-imagemagick"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-java"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-jj"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-jq"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-just"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5493,7 +5493,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-k3d"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-k9s"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5515,7 +5515,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kind"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kubectl"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lazydocker"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5548,7 +5548,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lazygit"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5559,7 +5559,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-make"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5570,7 +5570,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-meson"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-mise"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5592,7 +5592,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-msbuild"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-msvc"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nasm"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5625,7 +5625,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ninja"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5636,7 +5636,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-node"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nuget"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5658,7 +5658,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nx"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ollama"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5680,7 +5680,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pnpm"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-podman"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5702,7 +5702,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pre-commit"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5713,7 +5713,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-prek"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-protoc"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5735,7 +5735,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pwsh"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-python"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rcedit"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5768,7 +5768,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-release-please"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5779,7 +5779,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rez"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ripgrep"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5801,7 +5801,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rust"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5812,7 +5812,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-sccache"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-sd"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5834,7 +5834,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-spack"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5845,7 +5845,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-starship"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5856,7 +5856,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-systemctl"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-task"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5878,7 +5878,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-tealdeer"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5889,7 +5889,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-terraform"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5900,7 +5900,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-tokei"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5911,7 +5911,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-trippy"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5922,7 +5922,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-trivy"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-turbo"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-uv"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5955,7 +5955,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vcpkg"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5966,7 +5966,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vite"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5977,7 +5977,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vscode"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5988,7 +5988,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-watchexec"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-winget"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -6010,7 +6010,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-wix"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-xcodebuild"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -6032,7 +6032,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-xh"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -6043,7 +6043,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-xmake"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -6054,7 +6054,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yarn"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -6065,7 +6065,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yazi"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -6076,7 +6076,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yq"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -6087,7 +6087,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zellij"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -6098,7 +6098,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zig"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -6109,7 +6109,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zoxide"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "rstest",
  "starlark",
@@ -6120,7 +6120,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "flate2",
@@ -6203,7 +6203,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6220,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6252,7 +6252,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6269,7 +6269,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "serde",
@@ -6287,11 +6287,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.8.24"
+version = "0.8.25"
 
 [[package]]
 name = "vx-starlark"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6321,7 +6321,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6344,7 +6344,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6362,7 +6362,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/vx-providers/cmake/provider.star
+++ b/crates/vx-providers/cmake/provider.star
@@ -65,11 +65,11 @@ fetch_versions = make_fetch_versions("Kitware", "CMake")
 # ---------------------------------------------------------------------------
 
 _CMAKE_PLATFORMS = {
-    "windows/x64":   ("windows", "x86_64", "zip"),
-    "windows/arm64": ("windows", "arm64",  "zip"),
-    "macos/x64":     ("Darwin",  "x86_64", "tar.gz"),
-    "macos/arm64":   ("Darwin",  "arm64",  "tar.gz"),
-    "linux/x64":     ("linux",   "x86_64", "tar.gz"),
+    "windows/x64":   ("windows", "x86_64",  "zip"),
+    "windows/arm64": ("windows", "arm64",   "zip"),
+    "macos/x64":     ("macos",   "universal", "tar.gz"),
+    "macos/arm64":   ("macos",   "universal", "tar.gz"),
+    "linux/x64":     ("linux",   "x86_64",  "tar.gz"),
     "linux/arm64":   ("linux",   "aarch64", "tar.gz"),
 }
 

--- a/crates/vx-providers/duckdb/provider.star
+++ b/crates/vx-providers/duckdb/provider.star
@@ -3,10 +3,14 @@
 # DuckDB is an in-process SQL OLAP database management system.
 # The CLI tool is released as a compressed single binary.
 #
-# Asset naming: duckdb_cli-{os}-{arch}.{ext}
+# Asset naming: duckdb_cli-{os}-{arch}.zip
 #   - Linux:   duckdb_cli-linux-amd64.zip, duckdb_cli-linux-arm64.zip
-#   - macOS:   duckdb_cli-osx-universal.gz  (universal binary)
+#   - macOS:   duckdb_cli-osx-amd64.zip, duckdb_cli-osx-arm64.zip
+#              (universal: duckdb_cli-osx-universal.zip — used as fallback)
 #   - Windows: duckdb_cli-windows-amd64.zip, duckdb_cli-windows-arm64.zip
+#
+# Note: .gz variants also exist but contain a raw binary (not an archive).
+#       Always use .zip — it contains the duckdb binary and is a proper archive.
 
 load("@vx//stdlib:provider.star",
      "runtime_def", "github_permissions", "path_fns")
@@ -51,9 +55,15 @@ fetch_versions = make_fetch_versions("duckdb", "duckdb")
 # ---------------------------------------------------------------------------
 
 def _duckdb_asset(ctx):
-    """Return the asset filename for the DuckDB CLI on the current platform."""
+    """Return the asset filename for the DuckDB CLI on the current platform.
+
+    All platforms use .zip archives (not .gz, which is a raw binary).
+    macOS uses arch-specific builds: osx-amd64 for x64, osx-arm64 for arm64.
+    """
     if ctx.platform.os == "macos":
-        return "duckdb_cli-osx-universal.gz"
+        arch_map = {"x64": "amd64", "arm64": "arm64"}
+        arch_str = arch_map.get(ctx.platform.arch, "amd64")
+        return "duckdb_cli-osx-{}.zip".format(arch_str)
     elif ctx.platform.os == "linux":
         arch_map = {"x64": "amd64", "arm64": "arm64"}
         arch_str = arch_map.get(ctx.platform.arch, "amd64")

--- a/crates/vx-providers/duckdb/tests/starlark_logic_tests.rs
+++ b/crates/vx-providers/duckdb/tests/starlark_logic_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! DuckDB uses an unusual asset naming scheme:
 //!   - Linux:   duckdb_cli-linux-{arch}.zip
-//!   - macOS:   duckdb_cli-osx-universal.gz  (universal binary)
+//!   - macOS:   duckdb_cli-osx-{arch}.zip  (arch-specific .zip, NOT .gz)
 //!   - Windows: duckdb_cli-windows-{arch}.zip
 
 use starlark::assert::Assert;
@@ -82,8 +82,8 @@ url != None and "windows" in url and url.endswith(".zip")
 }
 
 #[test]
-fn test_download_url_macos_is_gz() {
-    // macOS uses universal .gz format: duckdb_cli-osx-universal.gz
+fn test_download_url_macos_is_zip() {
+    // macOS uses arch-specific .zip format: duckdb_cli-osx-arm64.zip
     let mut a = Assert::new();
     a.dialect(&Dialect::Standard);
     a.is_true(&format!(
@@ -91,7 +91,7 @@ fn test_download_url_macos_is_gz() {
 {}
 ctx = struct(platform = struct(os = "macos", arch = "arm64", target = ""))
 url = download_url(ctx, "1.2.0")
-url != None and "osx" in url and url.endswith(".gz")
+url != None and "osx" in url and "arm64" in url and url.endswith(".zip")
 "#,
         provider_star_prefix()
     ));

--- a/crates/vx-providers/grpcurl/provider.star
+++ b/crates/vx-providers/grpcurl/provider.star
@@ -3,17 +3,19 @@
 # grpcurl is a command-line tool that lets you interact with gRPC servers.
 # It is basically curl for gRPC servers.
 #
-# Release assets (GitHub releases, goreleaser format):
+# Release assets (GitHub releases, goreleaser with custom naming):
 #   grpcurl_{version}_{os}_{arch}.tar.gz  (Linux/macOS)
 #   grpcurl_{version}_{os}_{arch}.zip     (Windows)
 #
-# OS:   linux, darwin, windows
-# Arch: amd64, arm64
+# OS:   linux, osx, windows  (NOTE: macOS uses "osx", not "darwin")
+# Arch: x86_64, arm64        (NOTE: x64 uses "x86_64", not "amd64")
 #
 # Version source: fullstorydev/grpcurl releases on GitHub (tag prefix "v")
 
 load("@vx//stdlib:provider.star",
-     "runtime_def", "github_permissions", "github_go_provider")
+     "runtime_def", "github_permissions", "path_fns")
+load("@vx//stdlib:github.star", "make_fetch_versions")
+load("@vx//stdlib:env.star", "env_prepend")
 
 # ---------------------------------------------------------------------------
 # Provider metadata
@@ -43,25 +45,65 @@ runtimes = [
 permissions = github_permissions()
 
 # ---------------------------------------------------------------------------
-# Provider template - github_go_provider
-#
-# Asset: grpcurl_{version}_{os}_{arch}.{ext}
-# Repo:  fullstorydev/grpcurl
-# Tag:   v{version}
+# fetch_versions - from fullstorydev/grpcurl releases
 # ---------------------------------------------------------------------------
 
-_p = github_go_provider(
-    "fullstorydev", "grpcurl",
-    asset      = "grpcurl_{version}_{os}_{arch}.{ext}",
-    executable = "grpcurl",
-    store      = "grpcurl",
-)
+fetch_versions = make_fetch_versions("fullstorydev", "grpcurl")
 
-fetch_versions   = _p["fetch_versions"]
-download_url     = _p["download_url"]
-install_layout   = _p["install_layout"]
-store_root       = _p["store_root"]
-get_execute_path = _p["get_execute_path"]
-post_install     = _p["post_install"]
-environment      = _p["environment"]
-deps             = _p["deps"]
+# ---------------------------------------------------------------------------
+# Platform helpers
+# grpcurl uses non-standard naming: "osx" (not "darwin"), "x86_64" (not "amd64")
+# ---------------------------------------------------------------------------
+
+_PLATFORMS = {
+    "windows/x64":   ("windows", "x86_64"),
+    "macos/x64":     ("osx",    "x86_64"),
+    "macos/arm64":   ("osx",    "arm64"),
+    "linux/x64":     ("linux",  "x86_64"),
+    "linux/arm64":   ("linux",  "arm64"),
+}
+
+def _grpcurl_platform(ctx):
+    key = "{}/{}".format(ctx.platform.os, ctx.platform.arch)
+    return _PLATFORMS.get(key)
+
+# ---------------------------------------------------------------------------
+# download_url - GitHub releases
+# ---------------------------------------------------------------------------
+
+def download_url(ctx, version):
+    platform = _grpcurl_platform(ctx)
+    if not platform:
+        return None
+    os_str, arch_str = platform
+    ext = "zip" if ctx.platform.os == "windows" else "tar.gz"
+    return "https://github.com/fullstorydev/grpcurl/releases/download/v{}/grpcurl_{}_{}_{}.{}".format(
+        version, version, os_str, arch_str, ext)
+
+# ---------------------------------------------------------------------------
+# install_layout - archive containing grpcurl binary
+# ---------------------------------------------------------------------------
+
+def install_layout(ctx, _version):
+    exe = "grpcurl.exe" if ctx.platform.os == "windows" else "grpcurl"
+    return {
+        "__type":           "archive",
+        "executable_paths": [exe],
+    }
+
+# ---------------------------------------------------------------------------
+# Path queries + environment
+# ---------------------------------------------------------------------------
+
+paths            = path_fns("grpcurl")
+store_root       = paths["store_root"]
+get_execute_path = paths["get_execute_path"]
+
+def environment(ctx, _version):
+    return [env_prepend("PATH", ctx.install_dir)]
+
+def post_install(_ctx, _version):
+    return None
+
+def deps(_ctx, _version):
+    return []

--- a/crates/vx-providers/grpcurl/tests/starlark_logic_tests.rs
+++ b/crates/vx-providers/grpcurl/tests/starlark_logic_tests.rs
@@ -53,7 +53,7 @@ fn test_download_url_linux_x64() {
 {}
 ctx = struct(platform = struct(os = "linux", arch = "x64", target = ""))
 url = download_url(ctx, "1.9.3")
-url != None and "linux" in url and "amd64" in url and url.endswith(".tar.gz")
+url != None and "linux" in url and "x86_64" in url and url.endswith(".tar.gz")
 "#,
         provider_star_prefix()
     ));
@@ -68,7 +68,7 @@ fn test_download_url_windows_x64() {
 {}
 ctx = struct(platform = struct(os = "windows", arch = "x64", target = ""))
 url = download_url(ctx, "1.9.3")
-url != None and "windows" in url and "amd64" in url
+url != None and "windows" in url and "x86_64" in url
 "#,
         provider_star_prefix()
     ));
@@ -83,7 +83,7 @@ fn test_download_url_macos_arm64() {
 {}
 ctx = struct(platform = struct(os = "macos", arch = "arm64", target = ""))
 url = download_url(ctx, "1.9.3")
-url != None and "darwin" in url and "arm64" in url
+url != None and "osx" in url and "arm64" in url
 "#,
         provider_star_prefix()
     ));

--- a/crates/vx-providers/jq/provider.star
+++ b/crates/vx-providers/jq/provider.star
@@ -87,4 +87,4 @@ def get_execute_path(ctx, _version):
     return ctx.install_dir + "/bin/" + exe
 
 def environment(ctx, _version):
-    return [{"op": "prepend", "name": "PATH", "value": ctx.install_dir + "/bin"}]
+    return [{"op": "prepend", "key": "PATH", "value": ctx.install_dir + "/bin"}]

--- a/crates/vx-providers/k3d/provider.star
+++ b/crates/vx-providers/k3d/provider.star
@@ -4,8 +4,8 @@
 # distribution) in Docker.
 #
 # Release assets (GitHub releases):
-#   - Linux/macOS: k3d-{os}-{arch}.tar.gz  (contains single binary)
-#   - Windows:     k3d-windows-amd64.exe   (direct executable)
+#   - Linux/macOS: k3d-{os}-{arch}           (direct binary, no extension)
+#   - Windows:     k3d-windows-amd64.exe      (direct executable)
 #
 # OS:   linux, darwin, windows
 # Arch: amd64, arm64 (Linux/macOS), amd64 (Windows)
@@ -14,9 +14,9 @@
 
 load("@vx//stdlib:provider.star",
      "runtime_def", "github_permissions",
-     "path_fns",
      "fetch_versions_with_tag_prefix")
 load("@vx//stdlib:env.star", "env_prepend")
+load("@vx//stdlib:layout.star", "binary_layout")
 
 # ---------------------------------------------------------------------------
 # Provider metadata
@@ -69,7 +69,8 @@ def _k3d_platform(ctx):
 
 # ---------------------------------------------------------------------------
 # download_url - GitHub releases
-# Linux/macOS: https://github.com/k3d-io/k3d/releases/download/v{version}/k3d-{os}-{arch}.tar.gz
+# All platforms: direct binary download (no archive)
+# Linux/macOS: https://github.com/k3d-io/k3d/releases/download/v{version}/k3d-{os}-{arch}
 # Windows:     https://github.com/k3d-io/k3d/releases/download/v{version}/k3d-windows-amd64.exe
 # ---------------------------------------------------------------------------
 
@@ -78,36 +79,28 @@ def download_url(ctx, version):
     if not platform:
         return None
     os_str, arch_str = platform
-    if ctx.platform.os == "windows":
-        return "https://github.com/k3d-io/k3d/releases/download/v{}/k3d-{}-{}.exe".format(
-            version, os_str, arch_str)
-    return "https://github.com/k3d-io/k3d/releases/download/v{}/k3d-{}-{}.tar.gz".format(
-        version, os_str, arch_str)
+    exe = ".exe" if ctx.platform.os == "windows" else ""
+    return "https://github.com/k3d-io/k3d/releases/download/v{}/k3d-{}-{}{}".format(
+        version, os_str, arch_str, exe)
 
 # ---------------------------------------------------------------------------
-# install_layout
-# Windows: direct .exe binary
-# Linux/macOS: tar.gz containing 'k3d' binary at root
+# install_layout - all platforms are direct binary downloads
+# binary_layout places the binary at <install_dir>/bin/k3d[.exe]
 # ---------------------------------------------------------------------------
 
-def install_layout(ctx, _version):
-    if ctx.platform.os == "windows":
-        return {
-            "__type":           "binary",
-            "executable_paths": ["k3d.exe"],
-        }
-    return {
-        "__type":           "archive",
-        "executable_paths": ["k3d"],
-    }
+install_layout = binary_layout("k3d")
 
 # ---------------------------------------------------------------------------
 # Path queries + environment
 # ---------------------------------------------------------------------------
 
-paths            = path_fns("k3d")
-store_root       = paths["store_root"]
-get_execute_path = paths["get_execute_path"]
+def store_root(ctx):
+    return ctx.vx_home + "/store/k3d"
+
+
+def get_execute_path(ctx, _version):
+    exe = "k3d.exe" if ctx.platform.os == "windows" else "k3d"
+    return ctx.install_dir + "/bin/" + exe
 
 
 def environment(ctx, _version):

--- a/crates/vx-providers/k3d/tests/starlark_logic_tests.rs
+++ b/crates/vx-providers/k3d/tests/starlark_logic_tests.rs
@@ -53,7 +53,7 @@ fn test_download_url_linux_x64() {
 {}
 ctx = struct(platform = struct(os = "linux", arch = "x64", target = ""))
 url = download_url(ctx, "5.7.4")
-url != None and "linux" in url and "amd64" in url and url.endswith(".tar.gz")
+url != None and "linux" in url and "amd64" in url and not url.endswith(".tar.gz")
 "#,
         provider_star_prefix()
     ));
@@ -83,7 +83,7 @@ fn test_download_url_macos_arm64() {
 {}
 ctx = struct(platform = struct(os = "macos", arch = "arm64", target = ""))
 url = download_url(ctx, "5.7.4")
-url != None and "darwin" in url and "arm64" in url and url.endswith(".tar.gz")
+url != None and "darwin" in url and "arm64" in url and not url.endswith(".tar.gz") and not url.endswith(".exe")
 "#,
         provider_star_prefix()
     ));

--- a/crates/vx-providers/kind/provider.star
+++ b/crates/vx-providers/kind/provider.star
@@ -13,7 +13,6 @@
 
 load("@vx//stdlib:provider.star",
      "runtime_def", "github_permissions",
-     "path_fns",
      "fetch_versions_with_tag_prefix")
 load("@vx//stdlib:env.star", "env_prepend")
 load("@vx//stdlib:layout.star", "binary_layout")
@@ -88,21 +87,27 @@ def download_url(ctx, version):
 # Layout + path/env functions
 # kind is a single binary (no archive compression on Linux/macOS,
 # .exe directly on Windows)
+# binary_layout places the binary at <install_dir>/bin/kind[.exe]
 # ---------------------------------------------------------------------------
 
 install_layout = binary_layout("kind")
 
-paths            = path_fns("kind")
-store_root       = paths["store_root"]
-get_execute_path = paths["get_execute_path"]
+
+def store_root(ctx):
+    return ctx.vx_home + "/store/kind"
 
 
-def environment(ctx, _version):
-    return [env_prepend("PATH", ctx.install_dir + "/bin")]
+def get_execute_path(ctx, _version):
+    exe = "kind.exe" if ctx.platform.os == "windows" else "kind"
+    return ctx.install_dir + "/bin/" + exe
 
 
 def post_install(_ctx, _version):
     return None
+
+
+def environment(ctx, _version):
+    return [env_prepend("PATH", ctx.install_dir + "/bin")]
 
 
 def deps(_ctx, _version):

--- a/crates/vx-providers/rust/provider.star
+++ b/crates/vx-providers/rust/provider.star
@@ -11,7 +11,7 @@
 
 load("@vx//stdlib:provider.star",
      "runtime_def", "bundled_runtime_def", "github_permissions")
-load("@vx//stdlib:github.star", "make_fetch_versions", "github_asset_url")
+load("@vx//stdlib:github.star", "make_fetch_versions")
 load("@vx//stdlib:install.star", "set_permissions", "run_command")
 load("@vx//stdlib:env.star",    "env_set", "env_prepend")
 
@@ -62,7 +62,7 @@ fetch_versions = make_fetch_versions("rust-lang", "rustup")
 
 # ---------------------------------------------------------------------------
 # Platform helpers
-# rustup-init asset: rustup-init-{version}-{triple}[.exe]
+# rustup-init is hosted at: static.rust-lang.org/rustup/archive/{ver}/{triple}/rustup-init[.exe]
 # ---------------------------------------------------------------------------
 
 _RUSTUP_TRIPLES = {
@@ -112,7 +112,11 @@ def version_info(_ctx, user_version):
     }
 
 # ---------------------------------------------------------------------------
-# download_url — rustup-init binary
+# download_url — rustup-init binary from static.rust-lang.org
+#
+# rustup does NOT publish release assets to GitHub Releases (the releases
+# API returns []). Binaries are hosted on static.rust-lang.org instead:
+#   https://static.rust-lang.org/rustup/archive/{version}/{triple}/rustup-init[.exe]
 # ---------------------------------------------------------------------------
 
 def download_url(ctx, version):
@@ -120,24 +124,18 @@ def download_url(ctx, version):
     if not triple:
         return None
     if ctx.platform.os == "windows":
-        asset = "rustup-init-{}-{}.exe".format(version, triple)
-    else:
-        asset = "rustup-init-{}-{}".format(version, triple)
-    return github_asset_url("rust-lang", "rustup", version, asset)
+        return "https://static.rust-lang.org/rustup/archive/{}/{}/rustup-init.exe".format(version, triple)
+    return "https://static.rust-lang.org/rustup/archive/{}/{}/rustup-init".format(version, triple)
 
 # ---------------------------------------------------------------------------
 # install_layout — single binary installer
 # ---------------------------------------------------------------------------
 
-def install_layout(ctx, version):
-    triple = _rustup_triple(ctx)
-    if not triple:
+def install_layout(ctx, _version):
+    if not _rustup_triple(ctx):
         return None
-    source = "rustup-init-{}-{}".format(version, triple)
-    target = "rustup-init"
-    if ctx.platform.os == "windows":
-        source = source + ".exe"
-        target = target + ".exe"
+    source = "rustup-init.exe" if ctx.platform.os == "windows" else "rustup-init"
+    target = source
     return {
         "type":               "binary",
         "source_name":        source,

--- a/crates/vx-runtime/src/manifest_runtime/mod.rs
+++ b/crates/vx-runtime/src/manifest_runtime/mod.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 /// On Windows, if `path` has no known executable extension, check for `.cmd` /
 /// `.exe` / `.bat` variants in the same directory and return the first one that
@@ -153,6 +153,24 @@ pub type VersionInfoFn = Arc<
         + Sync,
 >;
 
+/// Type alias for an async `post_install` function injected from Starlark providers.
+///
+/// Called after installation to run post-extract hooks (set permissions, run commands, etc.).
+/// Signature: `(version: String, install_dir: PathBuf) -> Vec<serde_json::Value>`
+///
+/// Each JSON value is an action descriptor:
+/// - `{"type": "set_permissions", "path": "...", "mode": "755"}`
+/// - `{"type": "run_command", "executable": "...", "args": [...], "env": {...}, "on_failure": "error"}`
+pub type PostInstallFn = Arc<
+    dyn Fn(
+            String,
+            std::path::PathBuf,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<Vec<serde_json::Value>>> + Send>,
+        > + Send
+        + Sync,
+>;
+
 /// A runtime driven by manifest configuration (`provider.star`).
 ///
 /// For Starlark-driven providers, the `fetch_versions_fn`, `download_url_fn`, and
@@ -183,6 +201,11 @@ pub struct ManifestDrivenRuntime {
     pub deps_fn: Option<DepsFn>,
     /// Optional Starlark-driven `version_info(user_version)` implementation (RFC 0040).
     pub version_info_fn: Option<VersionInfoFn>,
+    /// Optional Starlark-driven `post_install` implementation.
+    ///
+    /// Called after download/extract to run post-extract hooks (e.g., rustup-init
+    /// to install the actual toolchain, set permissions on binaries, etc.).
+    pub post_install_fn: Option<PostInstallFn>,
     /// Optional pip package name for Python-based tools.
     pub pip_package: Option<String>,
 
@@ -246,6 +269,7 @@ impl ManifestDrivenRuntime {
             install_layout_fn: None,
             deps_fn: None,
             version_info_fn: None,
+            post_install_fn: None,
             pip_package: None,
 
             shells: Vec::new(),
@@ -277,6 +301,12 @@ impl ManifestDrivenRuntime {
     /// Set the `version_info` function (RFC 0040).
     pub fn with_version_info(mut self, f: VersionInfoFn) -> Self {
         self.version_info_fn = Some(f);
+        self
+    }
+
+    /// Set the `post_install` function for Starlark-driven post-extract hooks.
+    pub fn with_post_install(mut self, f: PostInstallFn) -> Self {
+        self.post_install_fn = Some(f);
         self
     }
 
@@ -664,6 +694,201 @@ impl Runtime for ManifestDrivenRuntime {
         self.bundled_with.is_none()
     }
 
+    async fn post_install(&self, version: &str, ctx: &RuntimeContext) -> Result<()> {
+        let post_install_fn = match &self.post_install_fn {
+            Some(f) => f,
+            None => {
+                debug!(
+                    "post_install: no post_install_fn for {}",
+                    self.name
+                );
+                return Ok(());
+            }
+        };
+
+        let store_name = self.bundled_with.as_deref().unwrap_or(&self.name);
+        let base_path = ctx.paths.version_store_dir(store_name, version);
+        let platform = Platform::current();
+        let install_dir = base_path.join(platform.as_str());
+
+        debug!(
+            "post_install: {} v{} install_dir={}",
+            self.name,
+            version,
+            install_dir.display()
+        );
+
+        if !install_dir.exists() {
+            debug!(
+                "Skipping post_install for {} — install dir does not exist: {}",
+                self.name,
+                install_dir.display()
+            );
+            return Ok(());
+        }
+
+        let actions = match post_install_fn(version.to_string(), install_dir.clone()).await {
+            Ok(a) => a,
+            Err(e) => {
+                warn!("post_install_fn for {} failed: {}", self.name, e);
+                return Err(e);
+            }
+        };
+        debug!(
+            "post_install: got {} actions for {} v{}",
+            actions.len(),
+            self.name,
+            version
+        );
+        if actions.is_empty() {
+            return Ok(());
+        }
+
+        debug!(
+            "Running {} post_install actions for {} v{}",
+            actions.len(),
+            self.name,
+            version
+        );
+
+        for action in &actions {
+            let action_type = action
+                .get("type")
+                .and_then(|t| t.as_str())
+                .unwrap_or("unknown");
+
+            match action_type {
+                "set_permissions" => {
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::PermissionsExt;
+                        let path = action
+                            .get("path")
+                            .and_then(|p| p.as_str())
+                            .unwrap_or("");
+                        let mode_str =
+                            action.get("mode").and_then(|m| m.as_str()).unwrap_or("755");
+                        let full_path = install_dir.join(path);
+                        if full_path.exists() {
+                            let mode =
+                                u32::from_str_radix(mode_str, 8).unwrap_or(0o755);
+                            std::fs::set_permissions(
+                                &full_path,
+                                std::fs::Permissions::from_mode(mode),
+                            )?;
+                            debug!("Set permissions {} on {}", mode_str, full_path.display());
+                        } else {
+                            debug!(
+                                "Skipping set_permissions — file not found: {}",
+                                full_path.display()
+                            );
+                        }
+                    }
+                }
+                "run_command" => {
+                    let executable = action
+                        .get("executable")
+                        .and_then(|e| e.as_str())
+                        .unwrap_or("");
+                    let args: Vec<String> = action
+                        .get("args")
+                        .and_then(|a| a.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let env_map: HashMap<String, String> = action
+                        .get("env")
+                        .and_then(|e| e.as_object())
+                        .map(|obj| {
+                            obj.iter()
+                                .filter_map(|(k, v)| {
+                                    v.as_str().map(|s| (k.clone(), s.to_string()))
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let on_failure = action
+                        .get("on_failure")
+                        .and_then(|o| o.as_str())
+                        .unwrap_or("warn");
+
+                    info!(
+                        "Running post-install command: {} {}",
+                        executable,
+                        args.join(" ")
+                    );
+
+                    let mut cmd = std::process::Command::new(executable);
+                    cmd.args(&args);
+                    for (k, v) in &env_map {
+                        cmd.env(k, v);
+                    }
+
+                    match cmd.output() {
+                        Ok(output) => {
+                            if output.status.success() {
+                                debug!("Post-install command succeeded");
+                            } else {
+                                let stderr =
+                                    String::from_utf8_lossy(&output.stderr);
+                                match on_failure {
+                                    "error" => {
+                                        return Err(anyhow::anyhow!(
+                                            "Post-install command failed (exit {}): {}",
+                                            output.status,
+                                            stderr
+                                        ));
+                                    }
+                                    "ignore" => {
+                                        debug!(
+                                            "Post-install command failed (ignored): {}",
+                                            stderr
+                                        );
+                                    }
+                                    _ => {
+                                        warn!(
+                                            "Post-install command failed: {}",
+                                            stderr
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => match on_failure {
+                            "error" => {
+                                return Err(anyhow::anyhow!(
+                                    "Failed to run post-install command '{}': {}",
+                                    executable,
+                                    e
+                                ));
+                            }
+                            "ignore" => {
+                                debug!(
+                                    "Failed to run post-install command (ignored): {}",
+                                    e
+                                );
+                            }
+                            _ => {
+                                warn!(
+                                    "Failed to run post-install command '{}': {}",
+                                    executable, e
+                                );
+                            }
+                        },
+                    }
+                }
+                other => {
+                    debug!("Unknown post-install action type: {}", other);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     async fn prepare_execution(
         &self,
         version: &str,
@@ -727,7 +952,7 @@ impl Runtime for ManifestDrivenRuntime {
                     }
 
                     for path in &candidates {
-                        if path.exists() {
+                        if path.is_file() {
                             let resolved = prefer_windows_executable(path.clone());
                             debug!(
                                 "Found bundled executable {} at {} (parent version: {})",

--- a/crates/vx-starlark/src/provider/bridge.rs
+++ b/crates/vx-starlark/src/provider/bridge.rs
@@ -407,3 +407,88 @@ pub fn make_version_info_fn_owned(
         })
     })
 }
+
+// ---------------------------------------------------------------------------
+// Post-install hooks (post_extract → post_install bridge)
+// ---------------------------------------------------------------------------
+
+/// Create a `PostInstallFn` closure backed by an embedded `provider.star`.
+///
+/// The closure calls `post_extract(ctx, version, install_dir)` in Starlark and converts
+/// the returned `PostExtractAction` values to JSON descriptors that can be executed
+/// by `ManifestDrivenRuntime::post_install()`.
+pub fn make_post_install_fn_owned(
+    provider_name: Arc<str>,
+    content: Arc<str>,
+    _runtime_name: String,
+) -> vx_runtime::manifest_runtime::PostInstallFn {
+    Arc::new(move |version: String, install_dir: std::path::PathBuf| {
+        let provider_name = Arc::clone(&provider_name);
+        let content = Arc::clone(&content);
+        Box::pin(async move {
+            let provider = StarlarkProvider::from_content(&*provider_name, &*content)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!("Failed to load {} provider.star: {e}", provider_name)
+                })?;
+
+            let actions = provider
+                .post_extract(&version, &install_dir)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!("{} post_extract failed: {e}", provider_name)
+                })?;
+
+            // Convert PostExtractAction to JSON descriptors
+            Ok(actions
+                .into_iter()
+                .filter_map(|action| post_extract_action_to_json(action))
+                .collect())
+        })
+    })
+}
+
+/// Convert a `PostExtractAction` to a JSON descriptor for `ManifestDrivenRuntime::post_install`.
+fn post_extract_action_to_json(
+    action: crate::provider::types::PostExtractAction,
+) -> Option<serde_json::Value> {
+    use crate::provider::types::PostExtractAction;
+
+    match action {
+        PostExtractAction::SetPermissions { path, mode } => Some(serde_json::json!({
+            "type": "set_permissions",
+            "path": path,
+            "mode": mode,
+        })),
+        PostExtractAction::RunCommand {
+            executable,
+            args,
+            working_dir,
+            env,
+            on_failure,
+        } => Some(serde_json::json!({
+            "type": "run_command",
+            "executable": executable,
+            "args": args,
+            "env": env,
+            "working_dir": working_dir,
+            "on_failure": on_failure,
+        })),
+        PostExtractAction::CreateShim {
+            name,
+            target,
+            args,
+            shim_dir,
+        } => Some(serde_json::json!({
+            "type": "create_shim",
+            "name": name,
+            "target": target,
+            "args": args,
+            "shim_dir": shim_dir,
+        })),
+        PostExtractAction::FlattenDir { pattern, .. } => Some(serde_json::json!({
+            "type": "flatten_dir",
+            "pattern": pattern,
+        })),
+    }
+}

--- a/crates/vx-starlark/src/provider/builder.rs
+++ b/crates/vx-starlark/src/provider/builder.rs
@@ -12,7 +12,7 @@ use vx_star_metadata::StarMetadata;
 use super::bridge::{
     make_deps_fn_owned, make_download_url_fn, make_download_url_fn_owned, make_fetch_versions_fn,
     make_fetch_versions_fn_owned, make_install_layout_fn, make_install_layout_fn_owned,
-    make_version_info_fn_owned,
+    make_post_install_fn_owned, make_version_info_fn_owned,
 };
 
 use crate::context::ProviderContext;
@@ -148,6 +148,11 @@ pub fn build_runtimes(
             Arc::clone(&content),
             provider_name.to_string(),
         ));
+        rt = rt.with_post_install(make_post_install_fn_owned(
+            Arc::clone(&provider_name),
+            Arc::clone(&content),
+            provider_name.to_string(),
+        ));
 
         return vec![Arc::new(rt)];
     }
@@ -238,6 +243,13 @@ pub fn build_runtimes(
 
             // RFC 0040: Wire up version_info for toolchain-managed tools (e.g., Rust)
             runtime = runtime.with_version_info(make_version_info_fn_owned(
+                Arc::clone(&provider_name),
+                Arc::clone(&content),
+                name.clone(),
+            ));
+
+            // Wire up post_install for Starlark post_extract hooks (e.g., rustup-init)
+            runtime = runtime.with_post_install(make_post_install_fn_owned(
                 Arc::clone(&provider_name),
                 Arc::clone(&content),
                 name.clone(),


### PR DESCRIPTION
## Summary

- **Wire Starlark `post_extract` hooks into `ManifestDrivenRuntime`**: Add `PostInstallFn` type, bridge function, and full `post_install()` implementation that executes `set_permissions` and `run_command` actions from provider.star scripts. This ensures tools like Rust's `rustup-init` are actually executed after download.
- **Fix bundled runtime executable detection**: Change `path.exists()` to `path.is_file()` in `ManifestDrivenRuntime` to prevent directories (e.g. `cargo/` CARGO_HOME) from being incorrectly matched as executables.
- **Fix cmake macOS download URL**: Update platform mapping from `Darwin-{arch}` to `macos-universal` to match actual GitHub release asset naming (`cmake-4.3.1-macos-universal.tar.gz`). The old URLs returned 404, causing cmake to attempt re-installation on every invocation.
- **Fix jq environment key**: Change `"name"` to `"key"` in `environment()` dict. The Rust env parser only recognizes `"key"`, so the PATH prepend was silently ignored.

## Root Cause

When running `vx cargo --version` on macOS, two bugs caused repeated `⬇ Installing rust@1.29.0...` messages:

1. **`post_extract` hooks were never executed** — `ManifestDrivenRuntime` had no wiring from Starlark `post_extract()` to Rust `post_install()`. So `rustup-init` was downloaded but never run, leaving `cargo/bin/` empty.
2. **`path.exists()` matched directories** — The bundled runtime search at `mod.rs:955` used `path.exists()` which returns `true` for directories. The `cargo/` CARGO_HOME directory was treated as the cargo executable, causing "Permission denied" errors.

After fixing rust, `⬇ Installing cmake@4.3.1...` appeared on every run because cmake's macOS download URLs were 404 (asset naming changed from `Darwin-arm64` to `macos-universal`).

## Test plan

- [ ] `vx cargo --version` — should install rust once, then detect as installed on subsequent runs
- [ ] `vx cmake --version` — should download `cmake-*-macos-universal.tar.gz` successfully on macOS
- [ ] `vx rustc --version` — bundled runtime should resolve correctly
- [ ] Verify on macOS ARM64 and x64
- [ ] Verify cmake `install_layout` strip_prefix matches the new asset naming