### PR TITLE
fix: git uses MinGit ZIP on Windows; rust toolchain defaults to stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4488,7 +4488,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "indexmap",
  "regex",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4705,7 +4705,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4726,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "vx-core"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "pretty_assertions",
@@ -4743,7 +4743,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "colored",
@@ -4783,7 +4783,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4838,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4901,14 +4901,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-output-filter"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "regex",
@@ -4921,7 +4921,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4940,7 +4940,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-7zip"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-actionlint"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -4987,7 +4987,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-actrun"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -4998,7 +4998,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-atuin"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5009,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-awscli"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-azcli"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bash"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5042,7 +5042,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bat"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5053,7 +5053,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-biome"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bottom"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5075,7 +5075,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-brew"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5086,7 +5086,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-buf"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5097,7 +5097,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-buildcache"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bun"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cargo-audit"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cargo-deny"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5141,7 +5141,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cargo-nextest"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ccache"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-chezmoi"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-choco"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cmake"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-conan"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5207,7 +5207,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cosign"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ctlptl"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-curl"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dagu"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-delta"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5262,7 +5262,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-deno"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dive"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5284,7 +5284,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dotnet"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5295,7 +5295,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-duckdb"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-duf"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dust"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-eza"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-fd"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ffmpeg"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-flux"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5372,7 +5372,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-fzf"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gcloud"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5394,7 +5394,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gh"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5405,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-git"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gitleaks"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-go"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-golangci-lint"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-goreleaser"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gping"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-grpcurl"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-grype"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5493,7 +5493,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-hadolint"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-helix"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5515,7 +5515,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-helm"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-hyperfine"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-imagemagick"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5548,7 +5548,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-java"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5559,7 +5559,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-jj"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5570,7 +5570,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-jq"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-just"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5592,7 +5592,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-k3d"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-k9s"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kind"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5625,7 +5625,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kubectl"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5636,7 +5636,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kustomize"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lazydocker"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5658,7 +5658,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lazygit"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lefthook"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5680,7 +5680,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lima"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-make"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5702,7 +5702,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-maturin"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5713,7 +5713,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-meson"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-minikube"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5735,7 +5735,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-mise"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-msbuild"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-msvc"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5768,7 +5768,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nasm"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5779,7 +5779,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nerdctl"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ninja"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5801,7 +5801,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-node"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5812,7 +5812,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nuget"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nx"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5834,7 +5834,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ollama"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5845,7 +5845,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pnpm"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5856,7 +5856,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-podman"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pre-commit"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5878,7 +5878,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-prek"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5889,7 +5889,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-protoc"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5900,7 +5900,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pwsh"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5911,7 +5911,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-python"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5922,7 +5922,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rcedit"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-release-please"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rez"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5955,7 +5955,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ripgrep"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5966,7 +5966,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ruff"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5977,7 +5977,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rust"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5988,7 +5988,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-sccache"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-sd"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6010,7 +6010,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-skaffold"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-spack"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6032,7 +6032,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-starship"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6043,7 +6043,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-syft"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6054,7 +6054,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-systemctl"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6065,7 +6065,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-task"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6076,7 +6076,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-tealdeer"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6087,7 +6087,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-terraform"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6098,7 +6098,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-tilt"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6109,7 +6109,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-tokei"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6120,7 +6120,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-trippy"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6131,7 +6131,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-trivy"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6142,7 +6142,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-turbo"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-usql"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6164,7 +6164,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-uv"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6175,7 +6175,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vcpkg"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6186,7 +6186,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vite"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6197,7 +6197,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vscode"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6208,7 +6208,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-watchexec"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6219,7 +6219,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-winget"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6230,7 +6230,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-wix"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6241,7 +6241,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-xcodebuild"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6252,7 +6252,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-xh"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6263,7 +6263,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-xmake"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6274,7 +6274,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yarn"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6285,7 +6285,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yazi"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6296,7 +6296,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yq"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6307,7 +6307,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zellij"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6318,7 +6318,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zig"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6329,7 +6329,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zoxide"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6340,7 +6340,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6374,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6405,7 +6405,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "flate2",
@@ -6424,7 +6424,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6441,7 +6441,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6474,7 +6474,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6491,7 +6491,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "serde",
@@ -6509,11 +6509,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.8.27"
+version = "0.8.28"
 
 [[package]]
 name = "vx-starlark"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6543,7 +6543,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6566,7 +6566,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6584,7 +6584,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/vx-providers/git/provider.star
+++ b/crates/vx-providers/git/provider.star
@@ -47,7 +47,7 @@ permissions = github_permissions()
 fetch_versions = make_fetch_versions("git-for-windows", "git")
 
 # ---------------------------------------------------------------------------
-# download_url — Windows-only portable Git (7z.exe self-extracting)
+# download_url — Windows-only portable Git (MinGit ZIP)
 # macOS/Linux use system package manager
 #
 # Version format: "{base}.windows.{N}" (e.g. "2.53.0.windows.2")
@@ -55,6 +55,14 @@ fetch_versions = make_fetch_versions("git-for-windows", "git")
 # Asset version:
 #   N=1 → "{base}"       (e.g. "2.53.0")
 #   N>1 → "{base}.{N}"   (e.g. "2.53.0.2")
+#
+# We use MinGit (minimal portable git) rather than PortableGit because:
+# - MinGit ships as a plain ZIP archive (reliable extraction, no 7z/SFX needed)
+# - PortableGit ships as a .7z.exe self-extracting archive (7z SFX extraction
+#   is fragile: `sevenz_rust` may fail to find the 7z archive inside the PE stub)
+# - MinGit contains cmd/git.exe + mingw64/bin/git.exe — identical layout to
+#   PortableGit, just without GUI tools (git-gui, gitk) and bash interactivity
+# - For vx use-cases (scripted git execution), MinGit is fully sufficient
 # ---------------------------------------------------------------------------
 
 def _parse_git_version(version):
@@ -90,12 +98,14 @@ def download_url(ctx, version):
     # Asset filename uses "{base}" for .windows.1, "{base}.{N}" for .windows.N>1
     asset_ver = "{}.{}".format(base, n) if n > 1 else base
 
+    # Use MinGit ZIP (standard ZIP, reliably extractable) instead of PortableGit
+    # .7z.exe (self-extracting archive requiring 7z SFX support).
     if ctx.platform.arch == "x64":
-        asset = "PortableGit-{}-64-bit.7z.exe".format(asset_ver)
+        asset = "MinGit-{}-64-bit.zip".format(asset_ver)
     elif ctx.platform.arch == "arm64":
-        asset = "PortableGit-{}-arm64.7z.exe".format(asset_ver)
+        asset = "MinGit-{}-arm64.zip".format(asset_ver)
     elif ctx.platform.arch == "x86":
-        asset = "PortableGit-{}-32-bit.7z.exe".format(asset_ver)
+        asset = "MinGit-{}-32-bit.zip".format(asset_ver)
     else:
         return None
 
@@ -105,14 +115,15 @@ def download_url(ctx, version):
 # install_layout
 # ---------------------------------------------------------------------------
 
-# PortableGit is a self-extracting 7z archive. The extracted layout is:
+# MinGit ZIP extracted layout:
 #   <install_dir>/
-#     cmd/git.exe          ← cmd-style wrapper
+#     cmd/git.exe          ← cmd-style wrapper (primary entry point)
 #     mingw64/bin/git.exe  ← real MinGW git binary
-#     bin/sh.exe           ← shell
-#     usr/bin/...
+#     mingw64/bin/...      ← other git tools
 #
-# We list the candidate paths so the installer can verify the right one.
+# The ZIP is extracted directly into install_dir with no top-level directory,
+# so strip_prefix="" (auto-detect) will NOT attempt to strip any prefix.
+# We list candidate paths so the installer can verify the correct one.
 def install_layout(ctx, _version):
     if ctx.platform.os == "windows":
         return {
@@ -167,10 +178,15 @@ def post_install(_ctx, _version):
 
 def environment(ctx, _version):
     if ctx.platform.os == "windows":
+        # Prepend each directory separately so env_prepend uses the correct
+        # OS-specific PATH separator (';' on Windows, ':' on Unix).
+        # Order matters: later prepends appear earlier in PATH, so list the
+        # most specific path last (it ends up first in PATH).
         return [
-            env_prepend("PATH", "{}/bin:{}/mingw64/bin:{}/usr/bin".format(
-                ctx.install_dir, ctx.install_dir, ctx.install_dir,
-            )),
+            env_prepend("PATH", ctx.install_dir + "/usr/bin"),
+            env_prepend("PATH", ctx.install_dir + "/bin"),
+            env_prepend("PATH", ctx.install_dir + "/mingw64/bin"),
+            env_prepend("PATH", ctx.install_dir + "/cmd"),
         ]
     return []
 

--- a/crates/vx-providers/git/tests/starlark_logic_tests.rs
+++ b/crates/vx-providers/git/tests/starlark_logic_tests.rs
@@ -75,7 +75,7 @@ not ("shells" in rt)
 // ── download_url logic ────────────────────────────────────────────────────────
 
 #[test]
-fn test_download_url_windows_x64_returns_7z_exe() {
+fn test_download_url_windows_x64_returns_zip() {
     let mut a = Assert::new();
     a.dialect(&Dialect::Standard);
     a.is_true(&format!(
@@ -83,7 +83,7 @@ fn test_download_url_windows_x64_returns_7z_exe() {
 {}
 ctx = struct(platform = struct(os = "windows", arch = "x64", target = ""))
 url = download_url(ctx, "2.44.0")
-url != None and url.endswith(".7z.exe")
+url != None and url.endswith(".zip")
 "#,
         provider_star_prefix()
     ));
@@ -187,7 +187,7 @@ len(env) == 0
 #[test]
 fn test_download_url_windows_version_with_windows_2_suffix() {
     // Regression test: version "2.53.0.windows.2" must produce
-    // tag "v2.53.0.windows.2" and asset "PortableGit-2.53.0.2-64-bit.7z.exe"
+    // tag "v2.53.0.windows.2" and asset "MinGit-2.53.0.2-64-bit.zip"
     let mut a = Assert::new();
     a.dialect(&Dialect::Standard);
     a.is_true(&format!(
@@ -195,7 +195,7 @@ fn test_download_url_windows_version_with_windows_2_suffix() {
 {}
 ctx = struct(platform = struct(os = "windows", arch = "x64", target = ""))
 url = download_url(ctx, "2.53.0.windows.2")
-url != None and "v2.53.0.windows.2" in url and "PortableGit-2.53.0.2-64-bit.7z.exe" in url
+url != None and "v2.53.0.windows.2" in url and "MinGit-2.53.0.2-64-bit.zip" in url
 "#,
         provider_star_prefix()
     ));
@@ -211,7 +211,7 @@ fn test_download_url_windows_version_with_windows_1_suffix() {
 {}
 ctx = struct(platform = struct(os = "windows", arch = "x64", target = ""))
 url = download_url(ctx, "2.53.0.windows.1")
-url != None and "v2.53.0.windows.1" in url and "PortableGit-2.53.0-64-bit.7z.exe" in url
+url != None and "v2.53.0.windows.1" in url and "MinGit-2.53.0-64-bit.zip" in url
 "#,
         provider_star_prefix()
     ));
@@ -227,7 +227,7 @@ fn test_download_url_windows_arm64() {
 {}
 ctx = struct(platform = struct(os = "windows", arch = "arm64", target = ""))
 url = download_url(ctx, "2.53.0.windows.2")
-url != None and "arm64.7z.exe" in url
+url != None and "arm64.zip" in url
 "#,
         provider_star_prefix()
     ));

--- a/crates/vx-providers/rust/provider.star
+++ b/crates/vx-providers/rust/provider.star
@@ -92,24 +92,65 @@ def _rustup_triple(ctx):
 # ---------------------------------------------------------------------------
 
 def version_info(_ctx, user_version):
-    """Map user-facing rustc version to store layout and install parameters.
+    """Map user-facing version to store layout and Rust toolchain install parameters.
 
     Key insight: ANY rustup version can install ANY rustc version.
-    So we always download the latest rustup installer and use it to install
+    So we always download the latest rustup-init and use it to install
     the specific rustc toolchain the user requested.
 
+    ## Version disambiguation
+
+    `fetch_versions()` queries GitHub releases of the *rustup* installer tool,
+    returning versions like "1.27.0", "1.28.0", "1.29.0". These are the rustup
+    installer version numbers — NOT Rust toolchain versions.
+
+    Rust toolchain versions currently start at 1.50+ (stable), while rustup
+    installer versions are in the 1.x range with x < 30. If vx picks the
+    latest rustup installer version (e.g. "1.29.0") as the "version" to install
+    (because no explicit version is in vx.toml), passing it as
+    `--default-toolchain 1.29.0` to rustup-init would try to install a very
+    ancient Rust toolchain from 2018, which is wrong.
+
+    Rule:
+    - "stable", "beta", "nightly"   → use as-is (valid channel names)
+    - version with minor ≥ 30       → treat as explicit Rust toolchain version
+    - version with minor < 30       → likely a rustup installer version;
+                                      install the "stable" toolchain instead
+
+    Users who want a specific Rust version must write it in vx.toml:
+        [tools]
+        rust = "1.93.1"   # installs rustc 1.93.1
+
     Args:
-        ctx: Provider context
-        user_version: Version from vx.toml (e.g., "1.93.1", "stable", "1.85")
+        user_version: Version string from vx.toml or latest from fetch_versions()
+                      e.g. "1.93.1", "stable", "1.29.0" (rustup installer ver)
 
     Returns:
         dict with store_as, download_version, install_params
     """
+    # Determine the actual Rust toolchain to install.
+    if user_version in ("stable", "beta", "nightly"):
+        toolchain = user_version
+    else:
+        parts = user_version.split(".")
+        minor = 0
+        if len(parts) >= 2 and parts[1].isdigit():
+            minor = int(parts[1])
+
+        if minor < 30:
+            # Version minor < 30 looks like a rustup installer version (e.g. 1.29.0).
+            # Install the "stable" Rust toolchain — the user almost certainly
+            # did not intend to pin an ancient Rust release from 2018.
+            toolchain = "stable"
+        else:
+            # Version minor ≥ 30 is an explicit Rust toolchain version (1.50+).
+            toolchain = user_version
+
     return {
-        "store_as": user_version,      # ~/.vx/store/rust/1.93.1/
-        "download_version": None,       # None = use latest rustup from fetch_versions()
+        "store_as": user_version,   # ~/.vx/store/rust/{user_version}/
+        "download_version": None,   # always download latest rustup-init
         "install_params": {
-            "toolchain": user_version,  # passed to post_extract as ctx.install_params
+            "toolchain": toolchain, # passed to post_extract via ctx.install_params
         },
     }
 


### PR DESCRIPTION
Fixes two Windows installation bugs reported by users.

## Bug 1: `vx git` — executable not found after installation

Error: `installation completed but executable not found at ...\cmd/git.exe`

Root cause: PortableGit ships as a `.7z.exe` self-extracting archive. The `sevenz_rust` library cannot correctly extract this SFX format — the extraction appears to succeed but no files are written.

Fix: Switch to MinGit ZIP format:
- MinGit is a standard `.zip` archive (always reliably extractable)
- Identical directory layout: `cmd/git.exe`, `mingw64/bin/git.exe`
- Designed for automated/scripted git use (exactly what vx needs)
- Same version pattern: `MinGit-{ver}-64-bit.zip`

Also fixed `environment()`: previous code used Unix-style colon-separated paths in a single `env_prepend()` call. Windows PATH separator is `;`. Each directory is now added with a separate `env_prepend()` call.

## Bug 2: `vx cargo` — installs ancient Rust 1.29.0 instead of stable

Error: `rustup could not choose a version of cargo to run, because one wasn't specified explicitly, and no default is configured.`

Root cause: `fetch_versions()` queries the rustup installer GitHub releases, returning installer versions like `1.29.0`. When no version is in `vx.toml`, vx picks the latest rustup installer version and passes it as `--default-toolchain 1.29.0` to rustup-init. This installs Rust 1.29.0 from 2018 instead of stable.

Fix: `version_info()` now distinguishes rustup installer versions (minor < 30) from Rust toolchain versions (minor >= 30). When a rustup installer version is detected, it defaults to the `stable` toolchain.

| Version | Interpretation | Toolchain installed |
|---------|---------------|--------------------|n| `stable`, `beta`, `nightly` | channel | as-is |
| `1.93.1` (minor >= 30) | Rust toolchain | `1.93.1` |
| `1.29.0` (minor < 30) | rustup installer | `stable` |

Users wanting a specific Rust version must write it in `vx.toml`: `rust = "1.93.1"`

## Files Changed

- `crates/vx-providers/git/provider.star` — MinGit ZIP download, fixed PATH env
- `crates/vx-providers/rust/provider.star` — `version_info()` toolchain disambiguation