### PR TITLE
fix(ci): switch apt mirror to azure.archive.ubuntu.com for cross builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4488,7 +4488,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "indexmap",
  "regex",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4705,7 +4705,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4726,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "vx-core"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "pretty_assertions",
@@ -4743,7 +4743,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "colored",
@@ -4783,7 +4783,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4838,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4901,14 +4901,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-output-filter"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "regex",
@@ -4921,7 +4921,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4940,7 +4940,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-7zip"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-actionlint"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -4987,7 +4987,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-actrun"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -4998,7 +4998,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-atuin"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5009,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-awscli"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-azcli"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bash"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5042,7 +5042,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bat"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5053,7 +5053,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-biome"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bottom"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5075,7 +5075,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-brew"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5086,7 +5086,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-buf"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5097,7 +5097,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-buildcache"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bun"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cargo-audit"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cargo-deny"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5141,7 +5141,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cargo-nextest"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ccache"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-chezmoi"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-choco"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cmake"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-conan"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5207,7 +5207,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cosign"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ctlptl"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-curl"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dagu"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-delta"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5262,7 +5262,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-deno"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dive"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5284,7 +5284,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dotnet"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5295,7 +5295,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-duckdb"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-duf"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dust"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-eza"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-fd"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ffmpeg"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-flux"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5372,7 +5372,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-fzf"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gcloud"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5394,7 +5394,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gh"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5405,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-git"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gitleaks"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-go"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-golangci-lint"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-goreleaser"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gping"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-grpcurl"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-grype"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5493,7 +5493,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-hadolint"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-helix"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5515,7 +5515,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-helm"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-hyperfine"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-imagemagick"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5548,7 +5548,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-java"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5559,7 +5559,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-jj"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5570,7 +5570,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-jq"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-just"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5592,7 +5592,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-k3d"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-k9s"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kind"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5625,7 +5625,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kubectl"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5636,7 +5636,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kustomize"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lazydocker"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5658,7 +5658,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lazygit"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lefthook"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5680,7 +5680,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lima"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-make"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5702,7 +5702,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-maturin"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5713,7 +5713,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-meson"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-minikube"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5735,7 +5735,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-mise"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-msbuild"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-msvc"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5768,7 +5768,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nasm"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5779,7 +5779,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nerdctl"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ninja"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5801,7 +5801,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-node"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5812,7 +5812,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nuget"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nx"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5834,7 +5834,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ollama"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5845,7 +5845,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pnpm"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5856,7 +5856,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-podman"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pre-commit"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5878,7 +5878,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-prek"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5889,7 +5889,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-protoc"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5900,7 +5900,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pwsh"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5911,7 +5911,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-python"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5922,7 +5922,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rcedit"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-release-please"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rez"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5955,7 +5955,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ripgrep"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5966,7 +5966,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ruff"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5977,7 +5977,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rust"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5988,7 +5988,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-sccache"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-sd"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6010,7 +6010,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-skaffold"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-spack"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6032,7 +6032,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-starship"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6043,7 +6043,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-syft"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6054,7 +6054,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-systemctl"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6065,7 +6065,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-task"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6076,7 +6076,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-tealdeer"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6087,7 +6087,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-terraform"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6098,7 +6098,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-tilt"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6109,7 +6109,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-tokei"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6120,7 +6120,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-trippy"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6131,7 +6131,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-trivy"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6142,7 +6142,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-turbo"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-usql"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6164,7 +6164,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-uv"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6175,7 +6175,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vcpkg"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6186,7 +6186,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vite"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6197,7 +6197,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vscode"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6208,7 +6208,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-watchexec"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6219,7 +6219,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-winget"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6230,7 +6230,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-wix"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6241,7 +6241,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-xcodebuild"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6252,7 +6252,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-xh"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6263,7 +6263,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-xmake"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6274,7 +6274,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yarn"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6285,7 +6285,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yazi"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6296,7 +6296,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yq"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6307,7 +6307,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zellij"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6318,7 +6318,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zig"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6329,7 +6329,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zoxide"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "rstest",
  "starlark",
@@ -6340,7 +6340,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6374,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6405,7 +6405,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "flate2",
@@ -6424,7 +6424,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6441,7 +6441,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6474,7 +6474,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6491,7 +6491,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "serde",
@@ -6509,11 +6509,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.8.27"
+version = "0.8.28"
 
 [[package]]
 name = "vx-starlark"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6543,7 +6543,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6566,7 +6566,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6584,7 +6584,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cross.toml
+++ b/Cross.toml
@@ -6,17 +6,34 @@ passthrough = ["GITHUB_TOKEN", "RUSTC_WRAPPER", "AWS_LC_SYS_CMAKE_BUILDER"]
 # 1. Has no lld package available
 # 2. Has binutils too old for armv8.4-a assembly instructions (aws-lc-sys)
 # The edge images are based on Ubuntu 22.04+ and have modern toolchains.
+#
+# APT mirror note: GitHub Actions runs on Azure infrastructure. The default
+# archive.ubuntu.com mirror is geographically distant and can time out.
+# We switch to azure.archive.ubuntu.com (a Microsoft-maintained mirror that
+# is co-located with the Azure runners) for reliable package downloads.
+# The `|| true` fallback means the sed never blocks the build even when
+# running on non-Ubuntu base images or images with no sources.list.
+
 [target.aarch64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"
-pre-build = ["apt-get update && apt-get install -y cmake g++ pkg-config"]
+pre-build = [
+    "sed -i 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g; s|http://security.ubuntu.com|http://azure.archive.ubuntu.com|g' /etc/apt/sources.list 2>/dev/null || true",
+    "apt-get update -y && apt-get install -y --no-install-recommends cmake g++ pkg-config",
+]
 
 [target.x86_64-unknown-linux-musl]
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-musl:edge"
-pre-build = ["apt-get update && apt-get install -y cmake g++ pkg-config"]
+pre-build = [
+    "sed -i 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g; s|http://security.ubuntu.com|http://azure.archive.ubuntu.com|g' /etc/apt/sources.list 2>/dev/null || true",
+    "apt-get update -y && apt-get install -y --no-install-recommends cmake g++ pkg-config",
+]
 
 [target.aarch64-unknown-linux-musl]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:edge"
-pre-build = ["apt-get update && apt-get install -y cmake g++ pkg-config"]
+pre-build = [
+    "sed -i 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g; s|http://security.ubuntu.com|http://azure.archive.ubuntu.com|g' /etc/apt/sources.list 2>/dev/null || true",
+    "apt-get update -y && apt-get install -y --no-install-recommends cmake g++ pkg-config",
+]
 
 # workaround for https://github.com/cross-rs/cross/issues/1345
 [target.x86_64-unknown-netbsd]


### PR DESCRIPTION
## Problem

The `cross-build` CI job fails intermittently when building for `aarch64-unknown-linux-gnu`. The pre-build step runs `apt-get update && apt-get install -y cmake g++ pkg-config` inside a Docker container, which times out connecting to `archive.ubuntu.com`:

```
E: Failed to fetch http://archive.ubuntu.com/.../librhash0_1.3.9-1_amd64.deb
   Connection timed out [IP: 91.189.92.23 80]
E: Failed to fetch http://archive.ubuntu.com/.../cmake_3.16.3-...amd64.deb
   Connection failed [IP: 91.189.91.83 80]
E: Unable to fetch some archives
```

**Root cause:** GitHub Actions runners are hosted on Azure (typically US-East). The default Ubuntu mirror `archive.ubuntu.com` resolves to servers in the UK (`91.189.92.x`). The cross-Atlantic TCP connection is unreliable and frequently times out inside Docker containers.

## Fix

Prepend a `sed` command to each target's `pre-build` list that rewrites the APT sources to use `azure.archive.ubuntu.com` — a Microsoft-maintained Ubuntu mirror that is **co-located with GitHub Actions infrastructure** and therefore always fast and reachable.

```toml
pre-build = [
    # Switch to Azure-colocated mirror before apt-get (fixes GH Actions timeouts)
    "sed -i 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g; ...' /etc/apt/sources.list 2>/dev/null || true",
    "apt-get update -y && apt-get install -y --no-install-recommends cmake g++ pkg-config",
]
```

The `|| true` fallback ensures the `sed` command never blocks the build on images that don't have `/etc/apt/sources.list` (e.g. Alpine-based images).

## Additional improvements

- Added `-y` to `apt-get update` (suppress interactive prompts)
- Added `--no-install-recommends` to `apt-get install` (smaller, faster install)
- Expanded single-string `pre-build` to an array (better readability)

## Targets affected

- `aarch64-unknown-linux-gnu`
- `x86_64-unknown-linux-musl`
- `aarch64-unknown-linux-musl`