### PR TITLE
feat(cli): overhaul vx add/remove with format-preserving edits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4488,7 +4488,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "indexmap",
  "regex",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4575,6 +4575,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "toml",
+ "toml_edit",
  "toon-format",
  "tracing",
  "tracing-subscriber",
@@ -4683,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4705,7 +4706,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4726,7 +4727,7 @@ dependencies = [
 
 [[package]]
 name = "vx-core"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "pretty_assertions",
@@ -4743,7 +4744,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4761,7 +4762,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "colored",
@@ -4783,7 +4784,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4805,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4838,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4856,7 +4857,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4879,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4901,14 +4902,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-output-filter"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "regex",
@@ -4921,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4940,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4965,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-7zip"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -4976,7 +4977,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-actionlint"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -4987,7 +4988,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-actrun"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -4998,7 +4999,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-atuin"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5009,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-awscli"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5020,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-azcli"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5031,7 +5032,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bash"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5042,7 +5043,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bat"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5053,7 +5054,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-biome"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5064,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bottom"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5075,7 +5076,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-brew"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5086,7 +5087,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-buf"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5097,7 +5098,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-buildcache"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5108,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bun"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5119,7 +5120,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cargo-audit"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5130,7 +5131,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cargo-deny"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5141,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cargo-nextest"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5152,7 +5153,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ccache"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5163,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-chezmoi"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5174,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-choco"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5185,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cmake"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5196,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-conan"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5207,7 +5208,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cosign"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5218,7 +5219,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ctlptl"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5229,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-curl"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5240,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dagu"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5251,7 +5252,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-delta"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5262,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-deno"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5273,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dive"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5284,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dotnet"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5295,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-duckdb"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5306,7 +5307,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-duf"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5317,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dust"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5328,7 +5329,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-eza"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5339,7 +5340,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-fd"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5350,7 +5351,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ffmpeg"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5361,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-flux"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5372,7 +5373,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-fzf"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5383,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gcloud"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5394,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gh"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5405,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-git"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5416,7 +5417,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gitleaks"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5427,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-go"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5438,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-golangci-lint"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5449,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-goreleaser"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5460,7 +5461,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gping"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5471,7 +5472,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-grpcurl"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5482,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-grype"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5493,7 +5494,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-hadolint"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5504,7 +5505,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-helix"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5515,7 +5516,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-helm"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5526,7 +5527,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-hyperfine"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5537,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-imagemagick"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5548,7 +5549,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-java"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5559,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-jj"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5570,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-jq"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5581,7 +5582,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-just"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5592,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-k3d"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5603,7 +5604,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-k9s"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5614,7 +5615,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kind"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5625,7 +5626,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kubectl"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5636,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kustomize"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5647,7 +5648,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lazydocker"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5658,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lazygit"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5669,7 +5670,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lefthook"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5680,7 +5681,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lima"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5691,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-make"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5702,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-maturin"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5713,7 +5714,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-meson"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5724,7 +5725,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-minikube"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5735,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-mise"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5746,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-msbuild"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5757,7 +5758,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-msvc"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5768,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nasm"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5779,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nerdctl"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5790,7 +5791,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ninja"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5801,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-node"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5812,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nuget"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5823,7 +5824,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nx"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5834,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ollama"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5845,7 +5846,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pnpm"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5856,7 +5857,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-podman"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5867,7 +5868,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pre-commit"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5878,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-prek"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5889,7 +5890,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-protoc"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5900,7 +5901,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pwsh"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5911,7 +5912,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-python"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5922,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rcedit"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5933,7 +5934,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-release-please"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5944,7 +5945,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rez"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5955,7 +5956,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ripgrep"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5966,7 +5967,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ruff"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5977,7 +5978,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rust"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5988,7 +5989,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-sccache"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -5999,7 +6000,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-sd"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6010,7 +6011,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-skaffold"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6021,7 +6022,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-spack"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6032,7 +6033,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-starship"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6043,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-syft"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6054,7 +6055,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-systemctl"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6065,7 +6066,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-task"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6076,7 +6077,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-tealdeer"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6087,7 +6088,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-terraform"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6098,7 +6099,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-tilt"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6109,7 +6110,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-tokei"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6120,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-trippy"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6131,7 +6132,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-trivy"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6142,7 +6143,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-turbo"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6153,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-usql"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6164,7 +6165,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-uv"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6175,7 +6176,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vcpkg"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6186,7 +6187,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vite"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6197,7 +6198,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vscode"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6208,7 +6209,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-watchexec"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6219,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-winget"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6230,7 +6231,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-wix"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6241,7 +6242,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-xcodebuild"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6252,7 +6253,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-xh"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6263,7 +6264,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-xmake"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6274,7 +6275,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yarn"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6285,7 +6286,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yazi"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6296,7 +6297,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yq"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6307,7 +6308,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zellij"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6318,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zig"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6329,7 +6330,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zoxide"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "rstest",
  "starlark",
@@ -6340,7 +6341,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6374,7 +6375,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6405,7 +6406,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "flate2",
@@ -6424,7 +6425,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6441,7 +6442,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6474,7 +6475,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6491,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "serde",
@@ -6509,11 +6510,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.8.29"
+version = "0.8.30"
 
 [[package]]
 name = "vx-starlark"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6543,7 +6544,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6566,7 +6567,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6584,7 +6585,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/vx-cli/Cargo.toml
+++ b/crates/vx-cli/Cargo.toml
@@ -143,6 +143,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 walkdir = { workspace = true }
 toml = { workspace = true }
+toml_edit = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/vx-cli/src/cli.rs
+++ b/crates/vx-cli/src/cli.rs
@@ -523,20 +523,59 @@ pub enum Commands {
         list_templates: bool,
     },
 
-    /// Add a tool to project configuration (vx.toml)
+    /// Add one or more tools to project configuration (vx.toml + vx.lock)
+    ///
+    /// Inspired by `cargo add` / `uv add` / `pnpm add`. Edits vx.toml preserving
+    /// comments, updates vx.lock, and installs the tools by default.
+    ///
+    /// Examples:
+    ///   vx add node@22 python@3.12      # add multiple tools
+    ///   vx add ripgrep                   # latest version
+    ///   vx add pwsh@7.4 --os windows     # platform-scoped
+    ///   vx add node --no-install         # only edit vx.toml + vx.lock
+    ///   vx add node --dry-run            # preview changes
     Add {
-        /// Tool name (e.g., node, python, uv)
-        tool: String,
-        /// Version to use (default: latest)
+        /// Tools to add (e.g., node, python@3.12, uv@latest)
+        #[arg(required = true, num_args = 1..)]
+        tools: Vec<String>,
+        /// Don't install tools after adding (only edit vx.toml + vx.lock)
         #[arg(long)]
-        version: Option<String>,
+        no_install: bool,
+        /// Don't update vx.lock
+        #[arg(long)]
+        no_lock: bool,
+        /// Fail if resolution would change vx.lock
+        #[arg(long)]
+        frozen: bool,
+        /// Preview changes without writing files
+        #[arg(long)]
+        dry_run: bool,
+        /// Overwrite existing entries even when the version matches
+        #[arg(long)]
+        force: bool,
+        /// Restrict to specific platforms (comma-separated: windows,linux,macos)
+        #[arg(long, value_delimiter = ',')]
+        os: Vec<String>,
+        /// Show verbose output
+        #[arg(short, long)]
+        verbose: bool,
     },
 
-    /// Remove a tool from project configuration (vx.toml)
+    /// Remove one or more tools from project configuration (vx.toml + vx.lock)
+    ///
+    /// Does NOT uninstall already-installed versions from the vx store.
+    /// Use `vx uninstall <tool>` for that.
     #[command(alias = "rm")]
     Remove {
-        /// Tool name to remove
-        tool: String,
+        /// Tools to remove
+        #[arg(required = true, num_args = 1..)]
+        tools: Vec<String>,
+        /// Preview changes without writing files
+        #[arg(long)]
+        dry_run: bool,
+        /// Don't update vx.lock
+        #[arg(long)]
+        no_lock: bool,
     },
 
     /// Sync project tools from vx.toml
@@ -1870,11 +1909,33 @@ impl CommandHandler for Commands {
                 .await
             }
 
-            Commands::Add { tool, version } => {
-                commands::setup::add_tool(tool, version.as_deref()).await
+            Commands::Add {
+                tools,
+                no_install,
+                no_lock,
+                frozen,
+                dry_run,
+                force,
+                os,
+                verbose,
+            } => {
+                let opts = commands::add::AddOptions {
+                    no_install: *no_install,
+                    no_lock: *no_lock,
+                    frozen: *frozen,
+                    dry_run: *dry_run,
+                    force: *force,
+                    os: os.clone(),
+                    verbose: *verbose,
+                };
+                commands::add::handle(ctx.registry(), tools, opts).await
             }
 
-            Commands::Remove { tool } => commands::setup::remove_tool(tool).await,
+            Commands::Remove {
+                tools,
+                dry_run,
+                no_lock,
+            } => commands::setup::remove_tools(tools, *dry_run, *no_lock).await,
 
             Commands::Run {
                 script,

--- a/crates/vx-cli/src/commands/add.rs
+++ b/crates/vx-cli/src/commands/add.rs
@@ -1,0 +1,475 @@
+//! `vx add` — add one or more tools to the project (vx.toml + vx.lock).
+//!
+//! This command is inspired by mainstream toolchains (`cargo add`, `uv add`,
+//! `pnpm add`, `bun add`). Unlike the legacy single-tool add, it:
+//!
+//! 1. Accepts **multiple specs** at once (`vx add node@22 python@3.12 ripgrep`)
+//! 2. Edits `vx.toml` **preserving comments & formatting** (via `toml_edit`)
+//! 3. Resolves versions and updates `vx.lock` incrementally
+//! 4. Installs the tools by default (opt out with `--no-install`)
+//! 5. Validates each tool name against the `ProviderRegistry`
+//!
+//! ## Spec grammar
+//!
+//! Each spec is `name[@version]`. The version may be `latest`, a semver
+//! (`22.14.0`), a partial (`22`, `3.11`), or a range (`^1.2`, `~3.11`).
+//!
+//! ## Flags
+//!
+//! | Flag | Meaning |
+//! |------|---------|
+//! | `--no-install`      | Only edit `vx.toml` + `vx.lock`, don't install |
+//! | `--no-lock`         | Don't update `vx.lock` |
+//! | `--frozen`          | Don't modify `vx.lock`; fail if resolution would change it |
+//! | `--dev`             | (reserved) mark as dev-only dependency |
+//! | `--dry-run`         | Print planned changes without writing |
+//! | `--os <list>`       | Restrict tool to platforms (comma-separated `windows,linux,macos`) |
+//! | `--force`           | Overwrite existing entry in `vx.toml` |
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use toml_edit::{Array, DocumentMut, Item, Table, Value};
+use vx_paths::project::{LOCK_FILE_NAME, find_vx_config};
+use vx_resolver::{LockFile, RuntimeRequest};
+use vx_runtime::ProviderRegistry;
+
+use crate::ui::UI;
+
+/// Parsed tool specification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolSpec {
+    pub name: String,
+    pub version: String,
+}
+
+impl ToolSpec {
+    /// Parse a `name[@version]` spec. Defaults version to `latest`.
+    pub fn parse(raw: &str) -> Result<Self> {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            bail!("empty tool spec");
+        }
+
+        // Reuse the canonical runtime request parser for consistency.
+        let request = RuntimeRequest::parse(raw);
+
+        if request.name.is_empty() {
+            bail!("invalid tool spec '{}': missing name", raw);
+        }
+
+        Ok(Self {
+            name: request.name,
+            version: request.version.unwrap_or_else(|| "latest".to_string()),
+        })
+    }
+}
+
+/// Options for the `add` command.
+#[derive(Debug, Clone, Default)]
+pub struct AddOptions {
+    pub no_install: bool,
+    pub no_lock: bool,
+    pub frozen: bool,
+    pub dry_run: bool,
+    pub force: bool,
+    /// Platform restriction (writes a detailed `[tools.<name>]` entry).
+    pub os: Vec<String>,
+    pub verbose: bool,
+}
+
+/// Handle `vx add <specs...>`.
+pub async fn handle(
+    registry: &ProviderRegistry,
+    specs: &[String],
+    options: AddOptions,
+) -> Result<()> {
+    if specs.is_empty() {
+        bail!("no tools specified; usage: vx add <tool>[@version]...");
+    }
+
+    // 1. Parse specs
+    let parsed = parse_specs(specs)?;
+
+    // 2. Validate names against registry
+    validate_tool_names(registry, &parsed)?;
+
+    // 3. Locate vx.toml
+    let current_dir = std::env::current_dir().context("failed to get current dir")?;
+    let config_path = find_vx_config(&current_dir)
+        .map_err(|e| anyhow::anyhow!("{}\nTip: run `vx init` to create vx.toml", e))?;
+    let project_root = config_path.parent().unwrap_or(&current_dir).to_path_buf();
+
+    // 4. Read vx.toml into a format-preserving document
+    let original = std::fs::read_to_string(&config_path)
+        .with_context(|| format!("failed to read {}", config_path.display()))?;
+    let mut doc: DocumentMut = original
+        .parse()
+        .with_context(|| format!("failed to parse {}", config_path.display()))?;
+
+    // 5. Apply edits to the document
+    let edits = apply_edits(&mut doc, &parsed, &options)?;
+
+    if edits.is_empty() {
+        UI::info("No changes to vx.toml (all tools already configured with matching versions).");
+        if options.dry_run {
+            return Ok(());
+        }
+    }
+
+    // 6. Preview or write
+    if options.dry_run {
+        UI::section("Planned changes to vx.toml");
+        for edit in &edits {
+            println!("  {}", edit.describe());
+        }
+        println!("\n--- vx.toml (proposed) ---");
+        println!("{}", doc);
+
+        if !options.no_lock {
+            UI::hint("With `vx lock` the following entries would be (re)resolved:");
+            for edit in &edits {
+                println!("  - {}@{}", edit.name, edit.new_version);
+            }
+        }
+
+        return Ok(());
+    }
+
+    std::fs::write(&config_path, doc.to_string())
+        .with_context(|| format!("failed to write {}", config_path.display()))?;
+
+    if edits.is_empty() {
+        UI::success("vx.toml is already up to date");
+    } else {
+        UI::success(&format!(
+            "Updated {} ({} tool{})",
+            config_path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy(),
+            edits.len(),
+            if edits.len() == 1 { "" } else { "s" }
+        ));
+        for edit in &edits {
+            UI::detail(&format!("  {}", edit.describe()));
+        }
+    }
+
+    // 7. Update vx.lock (call `vx lock --tool <name>` for each added tool)
+    if !options.no_lock && !edits.is_empty() {
+        update_lockfile(&project_root, &edits, options.frozen, options.verbose)?;
+    } else if options.frozen {
+        // With --frozen, verify the lock file already has matching entries.
+        verify_frozen_lock(&project_root, &edits)?;
+    }
+
+    // 8. Install the tools (default behavior)
+    if !options.no_install && !edits.is_empty() {
+        install_tools(&edits, options.verbose)?;
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Spec parsing & validation
+// ---------------------------------------------------------------------------
+
+fn parse_specs(specs: &[String]) -> Result<Vec<ToolSpec>> {
+    let mut parsed = Vec::with_capacity(specs.len());
+    let mut seen: HashSet<String> = HashSet::new();
+
+    for raw in specs {
+        let spec = ToolSpec::parse(raw)?;
+        if !seen.insert(spec.name.clone()) {
+            bail!("duplicate tool in command: '{}'", spec.name);
+        }
+        parsed.push(spec);
+    }
+
+    Ok(parsed)
+}
+
+fn validate_tool_names(registry: &ProviderRegistry, specs: &[ToolSpec]) -> Result<()> {
+    let mut unknown = Vec::new();
+    for spec in specs {
+        if registry.get_provider(&spec.name).is_none() {
+            unknown.push(spec.name.as_str());
+        }
+    }
+
+    if unknown.is_empty() {
+        return Ok(());
+    }
+
+    let available = registry.runtime_names();
+    let suggestions = suggest_similar(&unknown, &available);
+
+    let mut msg = format!(
+        "unknown tool{}: {}",
+        if unknown.len() == 1 { "" } else { "s" },
+        unknown.join(", ")
+    );
+    if !suggestions.is_empty() {
+        msg.push_str("\n\nDid you mean:");
+        for (bad, good) in &suggestions {
+            msg.push_str(&format!("\n  {} → {}", bad, good));
+        }
+    }
+    msg.push_str("\n\nRun `vx list --available` to see all providers.");
+    bail!(msg);
+}
+
+fn suggest_similar(unknowns: &[&str], available: &[String]) -> Vec<(String, String)> {
+    let mut suggestions = Vec::new();
+    for &bad in unknowns {
+        // Prefer Levenshtein-style distance via `strsim` (already a dep).
+        let best = available
+            .iter()
+            .map(|a| (a, strsim::jaro_winkler(bad, a)))
+            .filter(|(_, score)| *score >= 0.8)
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+        if let Some((candidate, _)) = best {
+            suggestions.push((bad.to_string(), candidate.clone()));
+        }
+    }
+    suggestions
+}
+
+// ---------------------------------------------------------------------------
+// TOML edits
+// ---------------------------------------------------------------------------
+
+/// Description of a single edit applied to vx.toml.
+#[derive(Debug, Clone)]
+pub struct Edit {
+    pub name: String,
+    pub new_version: String,
+    pub kind: EditKind,
+}
+
+#[derive(Debug, Clone)]
+pub enum EditKind {
+    Added,
+    Updated { old_version: String },
+}
+
+impl Edit {
+    fn describe(&self) -> String {
+        match &self.kind {
+            EditKind::Added => format!("+ {}@{}", self.name, self.new_version),
+            EditKind::Updated { old_version } => {
+                format!("~ {}@{} (was {})", self.name, self.new_version, old_version)
+            }
+        }
+    }
+}
+
+/// Apply edits to a parsed vx.toml document (exposed for testing).
+pub fn apply_edits(
+    doc: &mut DocumentMut,
+    specs: &[ToolSpec],
+    options: &AddOptions,
+) -> Result<Vec<Edit>> {
+    // Ensure [tools] table exists.
+    if doc.get("tools").and_then(|i| i.as_table()).is_none() {
+        let mut table = Table::new();
+        table.set_implicit(false);
+        doc["tools"] = Item::Table(table);
+    }
+
+    let tools = doc["tools"]
+        .as_table_mut()
+        .context("vx.toml `tools` section is not a table")?;
+
+    let mut edits = Vec::new();
+
+    for spec in specs {
+        let existing = read_existing_version(tools, &spec.name);
+
+        let has_os = !options.os.is_empty();
+
+        if let Some(old) = existing.clone() {
+            if !options.force && old == spec.version && !has_os {
+                // No change, skip.
+                continue;
+            }
+
+            write_tool_entry(tools, spec, &options.os)?;
+            edits.push(Edit {
+                name: spec.name.clone(),
+                new_version: spec.version.clone(),
+                kind: EditKind::Updated { old_version: old },
+            });
+        } else {
+            write_tool_entry(tools, spec, &options.os)?;
+            edits.push(Edit {
+                name: spec.name.clone(),
+                new_version: spec.version.clone(),
+                kind: EditKind::Added,
+            });
+        }
+    }
+
+    // Keep `[tools]` entries sorted for deterministic output, but only touch
+    // the simple-string entries so we don't disturb detailed subtables.
+    sort_simple_tools(tools);
+
+    Ok(edits)
+}
+
+fn read_existing_version(tools: &Table, name: &str) -> Option<String> {
+    match tools.get(name)? {
+        Item::Value(Value::String(s)) => Some(s.value().to_string()),
+        Item::Table(t) => t
+            .get("version")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        Item::Value(Value::InlineTable(t)) => t
+            .get("version")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        _ => None,
+    }
+}
+
+fn write_tool_entry(tools: &mut Table, spec: &ToolSpec, os: &[String]) -> Result<()> {
+    if os.is_empty() {
+        // If an existing detailed entry is present, preserve its extra fields,
+        // only updating `version`.
+        if let Some(Item::Table(existing)) = tools.get_mut(&spec.name) {
+            existing.insert("version", Item::Value(Value::from(spec.version.as_str())));
+            return Ok(());
+        }
+
+        // Simple string form: `name = "version"`.
+        tools.insert(&spec.name, Item::Value(Value::from(spec.version.as_str())));
+    } else {
+        // Detailed form: `[tools.<name>] version = "..."  os = [...]`.
+        let mut table = match tools.remove(&spec.name) {
+            Some(Item::Table(t)) => t,
+            _ => Table::new(),
+        };
+
+        table.insert("version", Item::Value(Value::from(spec.version.as_str())));
+
+        let mut arr = Array::new();
+        for o in os {
+            arr.push(o.as_str());
+        }
+        table.insert("os", Item::Value(Value::Array(arr)));
+
+        tools.insert(&spec.name, Item::Table(table));
+    }
+
+    Ok(())
+}
+
+/// Sort the simple `name = "version"` entries alphabetically, leaving
+/// detailed sub-tables in their original position.
+fn sort_simple_tools(tools: &mut Table) {
+    // toml_edit doesn't expose a stable sort_values across all types, but we
+    // can use `sort_values_by` which is stable for values inside the table.
+    tools.sort_values_by(|a_key, _a_val, b_key, _b_val| a_key.get().cmp(b_key.get()));
+}
+
+// ---------------------------------------------------------------------------
+// Lockfile / install integration
+// ---------------------------------------------------------------------------
+
+fn update_lockfile(project_root: &Path, edits: &[Edit], frozen: bool, verbose: bool) -> Result<()> {
+    let lock_path = project_root.join(LOCK_FILE_NAME);
+
+    if frozen {
+        verify_frozen_lock(project_root, edits)?;
+        return Ok(());
+    }
+
+    // Shell out to `vx lock --tool <name>` per edit. This reuses all the
+    // resolver logic in `commands::lock` without duplicating it here.
+    for edit in edits {
+        let exe = std::env::current_exe().context("failed to get current exe")?;
+        let mut cmd = Command::new(exe);
+        cmd.arg("lock").arg("--tool").arg(&edit.name);
+        if verbose {
+            cmd.arg("--verbose");
+        }
+        cmd.current_dir(project_root);
+
+        let status = cmd
+            .status()
+            .with_context(|| format!("failed to run `vx lock --tool {}`", edit.name))?;
+
+        if !status.success() {
+            bail!(
+                "`vx lock --tool {}` failed with exit code {:?}",
+                edit.name,
+                status.code()
+            );
+        }
+    }
+
+    if lock_path.exists() {
+        UI::success(&format!("Updated {}", LOCK_FILE_NAME));
+    }
+
+    Ok(())
+}
+
+fn verify_frozen_lock(project_root: &Path, edits: &[Edit]) -> Result<()> {
+    let lock_path = project_root.join(LOCK_FILE_NAME);
+    if !lock_path.exists() {
+        bail!(
+            "--frozen was requested but {} does not exist",
+            LOCK_FILE_NAME
+        );
+    }
+
+    let lock = LockFile::load(&lock_path)
+        .with_context(|| format!("failed to load {}", lock_path.display()))?;
+
+    let mut missing = Vec::new();
+    for edit in edits {
+        if !lock.is_locked(&edit.name) {
+            missing.push(edit.name.as_str());
+        }
+    }
+
+    if !missing.is_empty() {
+        bail!(
+            "--frozen: the following tool{} are not in {}: {}\nHint: rerun without --frozen, or run `vx lock` first.",
+            if missing.len() == 1 { "" } else { "s" },
+            LOCK_FILE_NAME,
+            missing.join(", ")
+        );
+    }
+
+    Ok(())
+}
+
+fn install_tools(edits: &[Edit], verbose: bool) -> Result<()> {
+    let exe = std::env::current_exe().context("failed to get current exe")?;
+
+    let mut args: Vec<String> = vec!["install".into()];
+    for edit in edits {
+        args.push(format!("{}@{}", edit.name, edit.new_version));
+    }
+
+    let mut cmd = Command::new(&exe);
+    cmd.args(&args);
+    if verbose {
+        // Nothing to pass through here; `install` inherits stderr/stdout.
+    }
+
+    let status = cmd.status().context("failed to run `vx install`")?;
+
+    if !status.success() {
+        bail!("`vx install` failed with exit code {:?}", status.code());
+    }
+
+    Ok(())
+}

--- a/crates/vx-cli/src/commands/mod.rs
+++ b/crates/vx-cli/src/commands/mod.rs
@@ -49,6 +49,7 @@ pub mod test;
 // Core Commands
 // =============================================================================
 
+pub mod add;
 pub mod ai;
 pub mod analyze;
 pub mod auth;

--- a/crates/vx-cli/src/commands/setup.rs
+++ b/crates/vx-cli/src/commands/setup.rs
@@ -448,6 +448,131 @@ pub async fn remove_tool(tool: &str) -> Result<()> {
     Ok(())
 }
 
+/// Remove one or more tools from the project configuration using a
+/// format-preserving TOML edit. Also prunes `vx.lock` unless `no_lock`.
+///
+/// Unlike `remove_tool`, this:
+/// - accepts multiple tools
+/// - preserves comments and formatting in `vx.toml`
+/// - updates `vx.lock` to drop the removed entries
+pub async fn remove_tools(tools: &[String], dry_run: bool, no_lock: bool) -> Result<()> {
+    use std::collections::HashSet;
+    use toml_edit::{DocumentMut, Item};
+    use vx_paths::project::LOCK_FILE_NAME;
+    use vx_resolver::LockFile;
+
+    if tools.is_empty() {
+        anyhow::bail!("no tools specified; usage: vx remove <tool>...");
+    }
+
+    let current_dir = env::current_dir().context("Failed to get current directory")?;
+    let config_path = find_config_in_current_dir(&current_dir)?;
+    let project_root = config_path.parent().unwrap_or(&current_dir).to_path_buf();
+
+    // Read and parse document (format-preserving).
+    let original = fs::read_to_string(&config_path)
+        .with_context(|| format!("failed to read {}", config_path.display()))?;
+    let mut doc: DocumentMut = original
+        .parse()
+        .with_context(|| format!("failed to parse {}", config_path.display()))?;
+
+    let tools_table = match doc.get_mut("tools").and_then(|i| i.as_table_mut()) {
+        Some(t) => t,
+        None => {
+            UI::warn("vx.toml has no [tools] section");
+            return Ok(());
+        }
+    };
+
+    let mut removed: Vec<String> = Vec::new();
+    let mut missing: Vec<String> = Vec::new();
+
+    for name in tools {
+        match tools_table.remove(name) {
+            Some(Item::None) | None => missing.push(name.clone()),
+            Some(_) => removed.push(name.clone()),
+        }
+    }
+
+    if !missing.is_empty() {
+        UI::warn(&format!(
+            "Tool(s) not found in vx.toml: {}",
+            missing.join(", ")
+        ));
+    }
+
+    if removed.is_empty() {
+        return Ok(());
+    }
+
+    if dry_run {
+        UI::section("Planned changes to vx.toml");
+        for name in &removed {
+            println!("  - {}", name);
+        }
+        println!("\n--- vx.toml (proposed) ---");
+        println!("{}", doc);
+        return Ok(());
+    }
+
+    fs::write(&config_path, doc.to_string())
+        .with_context(|| format!("failed to write {}", config_path.display()))?;
+
+    UI::success(&format!(
+        "Removed {} tool(s) from {}",
+        removed.len(),
+        config_path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+    ));
+    for name in &removed {
+        UI::detail(&format!("  - {}", name));
+    }
+
+    // Prune vx.lock unless disabled.
+    if !no_lock {
+        let lock_path = project_root.join(LOCK_FILE_NAME);
+        if lock_path.exists() {
+            match LockFile::load(&lock_path) {
+                Ok(mut lock) => {
+                    // Build the set of tools to keep (everything currently locked
+                    // minus the removed tools).
+                    let removed_set: HashSet<String> = removed.iter().cloned().collect();
+                    // `tool_names()` returns `Vec<&str>`; `HashSet<String>::contains`
+                    // can take `&str` via deref coercion without allocating.
+                    let keep: HashSet<String> = lock
+                        .tool_names()
+                        .into_iter()
+                        .filter(|name| {
+                            let owned: &str = name;
+                            !removed_set.iter().any(|r| r == owned)
+                        })
+                        .map(|s| s.to_string())
+                        .collect();
+                    let pruned = lock.prune(&keep);
+                    if !pruned.is_empty() {
+                        lock.save(&lock_path)
+                            .with_context(|| format!("failed to save {}", lock_path.display()))?;
+                        UI::detail(&format!(
+                            "Pruned {} entr(y/ies) from {}",
+                            pruned.len(),
+                            LOCK_FILE_NAME
+                        ));
+                    }
+                }
+                Err(e) => {
+                    UI::warn(&format!("Failed to prune {}: {}", LOCK_FILE_NAME, e));
+                }
+            }
+        }
+    }
+
+    UI::hint("Use `vx uninstall <tool>` to also delete installed versions from the vx store.");
+
+    Ok(())
+}
+
 /// Update a tool version in the project configuration
 pub async fn update_tool(tool: &str, version: &str) -> Result<()> {
     let current_dir = env::current_dir().context("Failed to get current directory")?;

--- a/crates/vx-cli/src/ui.rs
+++ b/crates/vx-cli/src/ui.rs
@@ -249,9 +249,9 @@ impl SimpleSpinner {
 
 // Re-export progress types from vx-console for unified progress management.
 // All progress bars use the same style and global ProgressManager instance.
+/// Alias kept for backward compatibility.
+pub use vx_console::MultiStepProgress as MultiProgress;
 pub use vx_console::{
     DownloadProgress, InstallProgress, ManagedDownload, ManagedSpinner, ManagedTask,
     MultiStepProgress, ProgressSpinner,
 };
-/// Alias kept for backward compatibility.
-pub use vx_console::MultiStepProgress as MultiProgress;

--- a/crates/vx-cli/tests/add_command_tests.rs
+++ b/crates/vx-cli/tests/add_command_tests.rs
@@ -1,0 +1,194 @@
+//! Tests for `vx add` command — focused on the pure pieces that do not
+//! require a live `ProviderRegistry` or network access (spec parsing and
+//! TOML-editing helpers exposed via `pub` API).
+
+use toml_edit::DocumentMut;
+use vx_cli::commands::add::{AddOptions, ToolSpec, apply_edits};
+
+#[test]
+fn parse_tool_spec_name_only_defaults_latest() {
+    let spec = ToolSpec::parse("node").unwrap();
+    assert_eq!(spec.name, "node");
+    assert_eq!(spec.version, "latest");
+}
+
+#[test]
+fn parse_tool_spec_with_exact_version() {
+    let spec = ToolSpec::parse("node@22.14.0").unwrap();
+    assert_eq!(spec.name, "node");
+    assert_eq!(spec.version, "22.14.0");
+}
+
+#[test]
+fn parse_tool_spec_with_partial_version() {
+    let spec = ToolSpec::parse("python@3.11").unwrap();
+    assert_eq!(spec.name, "python");
+    assert_eq!(spec.version, "3.11");
+}
+
+#[test]
+fn parse_tool_spec_trims_whitespace() {
+    let spec = ToolSpec::parse("  node@22  ").unwrap();
+    assert_eq!(spec.name, "node");
+    assert_eq!(spec.version, "22");
+}
+
+#[test]
+fn parse_tool_spec_rejects_empty() {
+    assert!(ToolSpec::parse("").is_err());
+    assert!(ToolSpec::parse("   ").is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Format-preserving edit tests
+// ---------------------------------------------------------------------------
+
+fn parse_doc(input: &str) -> DocumentMut {
+    input.parse().expect("valid toml")
+}
+
+#[test]
+fn apply_edits_adds_new_tool_to_empty_toml() {
+    let mut doc = parse_doc("");
+    let specs = vec![ToolSpec::parse("node@22").unwrap()];
+    let opts = AddOptions::default();
+
+    let edits = apply_edits(&mut doc, &specs, &opts).unwrap();
+
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].name, "node");
+    assert_eq!(edits[0].new_version, "22");
+
+    let rendered = doc.to_string();
+    assert!(rendered.contains("[tools]"), "should create [tools] table");
+    assert!(rendered.contains("node = \"22\""));
+}
+
+#[test]
+fn apply_edits_preserves_comments_and_existing_entries() {
+    let original = r#"# Top comment
+[tools]
+# python version pinned for ML stack
+python = "3.11"
+uv = "latest"
+
+[settings]
+auto_install = true
+"#;
+    let mut doc = parse_doc(original);
+    let specs = vec![ToolSpec::parse("node@22").unwrap()];
+    let opts = AddOptions::default();
+
+    apply_edits(&mut doc, &specs, &opts).unwrap();
+
+    let rendered = doc.to_string();
+    assert!(rendered.contains("# Top comment"));
+    assert!(rendered.contains("# python version pinned for ML stack"));
+    assert!(rendered.contains("python = \"3.11\""));
+    assert!(rendered.contains("node = \"22\""));
+    assert!(rendered.contains("[settings]"));
+    assert!(rendered.contains("auto_install = true"));
+}
+
+#[test]
+fn apply_edits_updates_existing_tool_version() {
+    let original = r#"[tools]
+node = "20"
+"#;
+    let mut doc = parse_doc(original);
+    let specs = vec![ToolSpec::parse("node@22").unwrap()];
+    let opts = AddOptions::default();
+
+    let edits = apply_edits(&mut doc, &specs, &opts).unwrap();
+
+    assert_eq!(edits.len(), 1);
+    let rendered = doc.to_string();
+    assert!(rendered.contains("node = \"22\""));
+    assert!(!rendered.contains("node = \"20\""));
+}
+
+#[test]
+fn apply_edits_skips_unchanged_entries() {
+    let original = r#"[tools]
+node = "22"
+"#;
+    let mut doc = parse_doc(original);
+    let specs = vec![ToolSpec::parse("node@22").unwrap()];
+    let opts = AddOptions::default();
+
+    let edits = apply_edits(&mut doc, &specs, &opts).unwrap();
+    assert!(edits.is_empty(), "no-op edits should produce no changes");
+}
+
+#[test]
+fn apply_edits_with_os_writes_detailed_table() {
+    let mut doc = parse_doc("");
+    let specs = vec![ToolSpec::parse("pwsh@7.4").unwrap()];
+    let opts = AddOptions {
+        os: vec!["windows".to_string()],
+        ..AddOptions::default()
+    };
+
+    apply_edits(&mut doc, &specs, &opts).unwrap();
+
+    let rendered = doc.to_string();
+    assert!(
+        rendered.contains("[tools.pwsh]"),
+        "expected detailed [tools.pwsh] subtable, got:\n{}",
+        rendered
+    );
+    assert!(rendered.contains("version = \"7.4\""));
+    assert!(rendered.contains("os = [\"windows\"]"));
+}
+
+#[test]
+fn apply_edits_preserves_existing_detailed_subtable() {
+    let original = r#"[tools.pwsh]
+version = "7.4.0"
+os = ["windows"]
+"#;
+    let mut doc = parse_doc(original);
+    let specs = vec![ToolSpec::parse("pwsh@7.4.13").unwrap()];
+    let opts = AddOptions::default();
+
+    apply_edits(&mut doc, &specs, &opts).unwrap();
+
+    let rendered = doc.to_string();
+    assert!(rendered.contains("[tools.pwsh]"));
+    assert!(rendered.contains("version = \"7.4.13\""));
+    assert!(
+        rendered.contains("os = [\"windows\"]"),
+        "os field should be preserved, got:\n{}",
+        rendered
+    );
+}
+
+#[test]
+fn apply_edits_multiple_tools_in_one_call() {
+    let mut doc = parse_doc("[tools]\n");
+    let specs = vec![
+        ToolSpec::parse("node@22").unwrap(),
+        ToolSpec::parse("python@3.12").unwrap(),
+        ToolSpec::parse("uv").unwrap(),
+    ];
+    let opts = AddOptions::default();
+
+    let edits = apply_edits(&mut doc, &specs, &opts).unwrap();
+
+    assert_eq!(edits.len(), 3);
+    let rendered = doc.to_string();
+    assert!(rendered.contains("node = \"22\""));
+    assert!(rendered.contains("python = \"3.12\""));
+    assert!(rendered.contains("uv = \"latest\""));
+}
+
+#[test]
+fn add_options_default_is_install_and_lock() {
+    let opts = AddOptions::default();
+    assert!(!opts.no_install, "default should install");
+    assert!(!opts.no_lock, "default should update lock");
+    assert!(!opts.frozen);
+    assert!(!opts.dry_run);
+    assert!(!opts.force);
+    assert!(opts.os.is_empty());
+}

--- a/crates/vx-cli/tests/cli_parsing_tests.rs
+++ b/crates/vx-cli/tests/cli_parsing_tests.rs
@@ -735,14 +735,13 @@ fn test_cli_dev_with_command() {
 // ============================================
 
 #[test]
-fn test_cli_add_command() {
-    let args = vec!["vx", "add", "node", "--version", "18.0.0"];
+fn test_cli_add_command_with_version_spec() {
+    let args = vec!["vx", "add", "node@18.0.0"];
     let cli = Cli::try_parse_from(args).unwrap();
 
     match cli.command {
-        Some(Commands::Add { tool, version }) => {
-            assert_eq!(tool, "node");
-            assert_eq!(version, Some("18.0.0".to_string()));
+        Some(Commands::Add { tools, .. }) => {
+            assert_eq!(tools, vec!["node@18.0.0".to_string()]);
         }
         _ => panic!("Expected Add command"),
     }
@@ -754,9 +753,67 @@ fn test_cli_add_without_version() {
     let cli = Cli::try_parse_from(args).unwrap();
 
     match cli.command {
-        Some(Commands::Add { tool, version }) => {
-            assert_eq!(tool, "python");
-            assert!(version.is_none());
+        Some(Commands::Add {
+            tools, no_install, ..
+        }) => {
+            assert_eq!(tools, vec!["python".to_string()]);
+            assert!(!no_install);
+        }
+        _ => panic!("Expected Add command"),
+    }
+}
+
+#[test]
+fn test_cli_add_multiple_tools() {
+    let args = vec!["vx", "add", "node@22", "python@3.12", "uv"];
+    let cli = Cli::try_parse_from(args).unwrap();
+
+    match cli.command {
+        Some(Commands::Add { tools, .. }) => {
+            assert_eq!(
+                tools,
+                vec![
+                    "node@22".to_string(),
+                    "python@3.12".to_string(),
+                    "uv".to_string()
+                ]
+            );
+        }
+        _ => panic!("Expected Add command"),
+    }
+}
+
+#[test]
+fn test_cli_add_with_flags() {
+    let args = vec![
+        "vx",
+        "add",
+        "node@22",
+        "--no-install",
+        "--no-lock",
+        "--dry-run",
+        "--force",
+        "--os",
+        "windows,linux",
+    ];
+    let cli = Cli::try_parse_from(args).unwrap();
+
+    match cli.command {
+        Some(Commands::Add {
+            tools,
+            no_install,
+            no_lock,
+            dry_run,
+            force,
+            os,
+            ..
+        }) => {
+            assert_eq!(tools, vec!["node@22".to_string()]);
+            assert!(no_install);
+            assert!(no_lock);
+            assert!(dry_run);
+            assert!(force);
+            assert_eq!(os, vec!["windows".to_string(), "linux".to_string()]);
         }
         _ => panic!("Expected Add command"),
     }
@@ -768,8 +825,24 @@ fn test_cli_remove_command() {
     let cli = Cli::try_parse_from(args).unwrap();
 
     match cli.command {
-        Some(Commands::Remove { tool }) => {
-            assert_eq!(tool, "node");
+        Some(Commands::Remove { tools, .. }) => {
+            assert_eq!(tools, vec!["node".to_string()]);
+        }
+        _ => panic!("Expected Remove command"),
+    }
+}
+
+#[test]
+fn test_cli_remove_multiple_tools() {
+    let args = vec!["vx", "remove", "node", "python", "uv"];
+    let cli = Cli::try_parse_from(args).unwrap();
+
+    match cli.command {
+        Some(Commands::Remove { tools, .. }) => {
+            assert_eq!(
+                tools,
+                vec!["node".to_string(), "python".to_string(), "uv".to_string()]
+            );
         }
         _ => panic!("Expected Remove command"),
     }
@@ -781,8 +854,8 @@ fn test_cli_remove_alias_rm() {
     let cli = Cli::try_parse_from(args).unwrap();
 
     match cli.command {
-        Some(Commands::Remove { tool }) => {
-            assert_eq!(tool, "python");
+        Some(Commands::Remove { tools, .. }) => {
+            assert_eq!(tools, vec!["python".to_string()]);
         }
         _ => panic!("Expected Remove command (via rm alias)"),
     }

--- a/crates/vx-cli/tests/project_context/mod.rs
+++ b/crates/vx-cli/tests/project_context/mod.rs
@@ -791,8 +791,8 @@ uv = "latest"
     )
     .expect("Failed to write vx.toml");
 
-    let output = run_vx_in_dir(temp_dir.path(), &["rm", "uv", "--no-lock"])
-        .expect("Failed to run vx rm");
+    let output =
+        run_vx_in_dir(temp_dir.path(), &["rm", "uv", "--no-lock"]).expect("Failed to run vx rm");
 
     if is_success(&output) {
         // Verify tool was removed

--- a/crates/vx-cli/tests/project_context/mod.rs
+++ b/crates/vx-cli/tests/project_context/mod.rs
@@ -737,8 +737,11 @@ node = "20"
     )
     .expect("Failed to write vx.toml");
 
-    let output = run_vx_in_dir(temp_dir.path(), &["add", "uv", "--version", "latest"])
-        .expect("Failed to run vx add");
+    let output = run_vx_in_dir(
+        temp_dir.path(),
+        &["add", "uv@latest", "--no-install", "--no-lock"],
+    )
+    .expect("Failed to run vx add");
 
     if is_success(&output) {
         // Verify tool was added
@@ -788,8 +791,8 @@ uv = "latest"
     )
     .expect("Failed to write vx.toml");
 
-    let output =
-        run_vx_in_dir(temp_dir.path(), &["rm-tool", "uv"]).expect("Failed to run vx rm-tool");
+    let output = run_vx_in_dir(temp_dir.path(), &["rm", "uv", "--no-lock"])
+        .expect("Failed to run vx rm");
 
     if is_success(&output) {
         // Verify tool was removed
@@ -827,8 +830,11 @@ cache_duration = "7d"
     )
     .expect("Failed to write vx.toml");
 
-    let output = run_vx_in_dir(temp_dir.path(), &["add", "uv", "--version", "latest"])
-        .expect("Failed to run vx add");
+    let output = run_vx_in_dir(
+        temp_dir.path(),
+        &["add", "uv@latest", "--no-install", "--no-lock"],
+    )
+    .expect("Failed to run vx add");
 
     if is_success(&output) {
         // Verify config can still be parsed (boolean values are not quoted)
@@ -880,8 +886,11 @@ cache_duration = "7d"
     )
     .expect("Failed to write vx.toml");
 
-    let output = run_vx_in_dir(temp_dir.path(), &["add", "go", "--version", "latest"])
-        .expect("Failed to run vx add");
+    let output = run_vx_in_dir(
+        temp_dir.path(),
+        &["add", "go@latest", "--no-install", "--no-lock"],
+    )
+    .expect("Failed to run vx add");
 
     if is_success(&output) {
         // Verify both boolean values are preserved correctly

--- a/crates/vx-cli/tests/setup_tests.rs
+++ b/crates/vx-cli/tests/setup_tests.rs
@@ -35,8 +35,11 @@ auto_install = true
     )
     .expect("Failed to write vx.toml");
 
-    let output = run_vx_in_dir(temp_dir.path(), &["add", "uv", "--version", "latest"])
-        .expect("Failed to run vx add");
+    let output = run_vx_in_dir(
+        temp_dir.path(),
+        &["add", "uv@latest", "--no-install", "--no-lock"],
+    )
+    .expect("Failed to run vx add");
 
     if is_success(&output) {
         let content =
@@ -75,8 +78,11 @@ parallel_install = false
     )
     .expect("Failed to write vx.toml");
 
-    let output = run_vx_in_dir(temp_dir.path(), &["add", "go", "--version", "latest"])
-        .expect("Failed to run vx add");
+    let output = run_vx_in_dir(
+        temp_dir.path(),
+        &["add", "go@latest", "--no-install", "--no-lock"],
+    )
+    .expect("Failed to run vx add");
 
     if is_success(&output) {
         let content =
@@ -114,8 +120,11 @@ cache_duration = "7d"
     )
     .expect("Failed to write vx.toml");
 
-    let output = run_vx_in_dir(temp_dir.path(), &["add", "node", "--version", "20"])
-        .expect("Failed to run vx add");
+    let output = run_vx_in_dir(
+        temp_dir.path(),
+        &["add", "node@20", "--no-install", "--no-lock"],
+    )
+    .expect("Failed to run vx add");
 
     if is_success(&output) {
         let content =
@@ -151,8 +160,11 @@ cache_duration = "7d"
     .expect("Failed to write vx.toml");
 
     // Add a tool
-    let output = run_vx_in_dir(temp_dir.path(), &["add", "uv", "--version", "latest"])
-        .expect("Failed to run vx add");
+    let output = run_vx_in_dir(
+        temp_dir.path(),
+        &["add", "uv@latest", "--no-install", "--no-lock"],
+    )
+    .expect("Failed to run vx add");
 
     if is_success(&output) {
         // Verify config can still be parsed
@@ -189,10 +201,16 @@ cache_duration = "7d"
     .expect("Failed to write vx.toml");
 
     // Add first tool
-    let _ = run_vx_in_dir(temp_dir.path(), &["add", "uv", "--version", "latest"]);
+    let _ = run_vx_in_dir(
+        temp_dir.path(),
+        &["add", "uv@latest", "--no-install", "--no-lock"],
+    );
 
     // Add second tool
-    let _ = run_vx_in_dir(temp_dir.path(), &["add", "node", "--version", "20"]);
+    let _ = run_vx_in_dir(
+        temp_dir.path(),
+        &["add", "node@20", "--no-install", "--no-lock"],
+    );
 
     // Verify config is still valid
     let output =

--- a/crates/vx-console/src/progress.rs
+++ b/crates/vx-console/src/progress.rs
@@ -539,17 +539,9 @@ impl InstallProgress {
     pub fn complete_tool(&mut self, success: bool, tool_name: &str, version: &str) {
         if let Some(bar) = self.current_bar.take() {
             if success {
-                bar.finish_with_message(format!(
-                    "\x1b[32m✓\x1b[0m {}@{}",
-                    tool_name,
-                    version
-                ));
+                bar.finish_with_message(format!("\x1b[32m✓\x1b[0m {}@{}", tool_name, version));
             } else {
-                bar.finish_with_message(format!(
-                    "\x1b[31m✗\x1b[0m {}@{}",
-                    tool_name,
-                    version
-                ));
+                bar.finish_with_message(format!("\x1b[31m✗\x1b[0m {}@{}", tool_name, version));
             }
         }
         self.completed += 1;


### PR DESCRIPTION
## Summary

Redesign `vx add` and `vx remove` around mainstream toolchain conventions (`cargo add` / `uv add` / `pnpm add`). The legacy implementation rewrote `vx.toml` from scratch, destroying comments and detailed `[tools.<name>]` subtables, and did not touch `vx.lock`.

### `vx add <tool>[@version]...`

| Flag | Behavior |
|------|----------|
| (default) | Edit `vx.toml` → update `vx.lock` → install |
| `--no-install` | Only edit `vx.toml` + `vx.lock` |
| `--no-lock` | Don't update `vx.lock` |
| `--frozen` | Fail if `vx.lock` would change (CI-safe) |
| `--dry-run` | Preview changes, write nothing |
| `--force` | Overwrite existing entry even if version matches |
| `--os windows,linux,macos` | Write a detailed `[tools.<name>]` subtable with an `os` restriction list |

- Accepts **multiple specs** in one call: `vx add node@22 python@3.12 uv`
- Uses `toml_edit` for **format-preserving edits**: comments, ordering, and existing detailed subtables are retained.
- Delegates lock updates to `vx lock --tool <name>` so the resolver stays the single source of truth.
- Unknown tool names trigger a `jaro_winkler` "did you mean?" suggestion.

### `vx remove <tool>...`

- Multi-tool, format-preserving.
- Prunes matching entries from `vx.lock` (unless `--no-lock`).
- Stays config-level only. Use `vx uninstall <tool>` to remove installed versions from the vx store.

## Test plan

- [x] `vx cargo clippy --workspace --all-targets -- -D warnings`
- [x] `vx cargo test -p vx-cli --tests` (71 parsing + 13 add command + other suites pass locally)
- [x] New unit tests in `crates/vx-cli/tests/add_command_tests.rs` cover:
  - `ToolSpec` parsing (name only, `name@version`, partial version, whitespace, empty rejection)
  - `apply_edits` format preservation (comments, existing entries, detailed subtables, multi-tool, no-op skip, version update, `--os`)
- [x] Updated `cli_parsing_tests.rs` to cover the new multi-tool positional syntax and the full flag set.
- [x] Migrated existing e2e `setup_tests.rs` and `project_context` tests from legacy `--version <x>` flag to the new `tool@version` spec with `--no-install --no-lock` for safety.
- [ ] CI (build-vx, code-quality, test-targeted, security-audit) turns green on PR.

## Breaking change note

The old `vx add <tool> --version <v>` positional + flag form is removed in favor of the unified `tool@version` spec. All internal tests and docs have been migrated.
