### PR TITLE
chore(deps): batch update Renovate dependencies and actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,7 +58,7 @@ jobs:
         run: vx just docs-build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 

--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -248,7 +248,7 @@ jobs:
           find packages -type f \( -name "*.deb" -o -name "*.rpm" \)
 
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.check-release.outputs.version }}
           files: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
 dependencies = [
  "anstyle",
  "bstr",
@@ -482,21 +482,11 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
- "bzip2-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -593,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -615,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2099,6 +2089,12 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
 
 [[package]]
 name = "libc"
@@ -4459,9 +4455,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4488,7 +4484,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4505,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "indexmap",
  "regex",
@@ -4519,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4529,7 +4525,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4544,7 +4540,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4684,7 +4680,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4706,7 +4702,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4727,7 +4723,7 @@ dependencies = [
 
 [[package]]
 name = "vx-core"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "pretty_assertions",
@@ -4744,7 +4740,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4762,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "colored",
@@ -4784,7 +4780,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4806,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4839,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4857,7 +4853,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4880,7 +4876,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4902,14 +4898,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-output-filter"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "regex",
@@ -4922,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4941,7 +4937,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4966,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-7zip"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -4977,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-actionlint"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -4988,7 +4984,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-actrun"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -4999,7 +4995,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-atuin"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5010,7 +5006,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-awscli"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5021,7 +5017,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-azcli"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5032,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bash"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5043,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bat"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5054,7 +5050,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-biome"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5065,7 +5061,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bottom"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5076,7 +5072,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-brew"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5087,7 +5083,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-buf"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5098,7 +5094,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-buildcache"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5109,7 +5105,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-bun"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5120,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cargo-audit"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5131,7 +5127,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cargo-deny"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5142,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cargo-nextest"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5153,7 +5149,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ccache"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5164,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-chezmoi"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5175,7 +5171,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-choco"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5186,7 +5182,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cmake"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5197,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-conan"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5208,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-cosign"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5219,7 +5215,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ctlptl"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5230,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-curl"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5241,7 +5237,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dagu"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5252,7 +5248,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-delta"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5263,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-deno"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5274,7 +5270,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dive"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5285,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dotnet"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5296,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-duckdb"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5307,7 +5303,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-duf"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5318,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-dust"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5329,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-eza"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5340,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-fd"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5351,7 +5347,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ffmpeg"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5362,7 +5358,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-flux"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5373,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-fzf"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5384,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gcloud"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5395,7 +5391,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gh"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5406,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-git"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5417,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gitleaks"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5428,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-go"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5439,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-golangci-lint"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5450,7 +5446,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-goreleaser"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5461,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-gping"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5472,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-grpcurl"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5483,7 +5479,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-grype"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5494,7 +5490,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-hadolint"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5505,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-helix"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5516,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-helm"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5527,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-hyperfine"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5538,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-imagemagick"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5549,7 +5545,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-java"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5560,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-jj"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5571,7 +5567,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-jq"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5582,7 +5578,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-just"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5593,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-k3d"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5604,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-k9s"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5615,7 +5611,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kind"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5626,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kubectl"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5637,7 +5633,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-kustomize"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5648,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lazydocker"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5659,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lazygit"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5670,7 +5666,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lefthook"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5681,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-lima"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5692,7 +5688,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-make"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5703,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-maturin"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5714,7 +5710,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-meson"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5725,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-minikube"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5736,7 +5732,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-mise"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5747,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-msbuild"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5758,7 +5754,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-msvc"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5769,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nasm"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5780,7 +5776,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nerdctl"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5791,7 +5787,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ninja"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5802,7 +5798,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-node"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5813,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nuget"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5824,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-nx"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5835,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ollama"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5846,7 +5842,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pnpm"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5857,7 +5853,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-podman"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5868,7 +5864,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pre-commit"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5879,7 +5875,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-prek"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5890,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-protoc"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5901,7 +5897,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-pwsh"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5912,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-python"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5923,7 +5919,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rcedit"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5934,7 +5930,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-release-please"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5945,7 +5941,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rez"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5956,7 +5952,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ripgrep"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5967,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-ruff"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5978,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-rust"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -5989,7 +5985,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-sccache"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6000,7 +5996,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-sd"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6011,7 +6007,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-skaffold"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6022,7 +6018,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-spack"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6033,7 +6029,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-starship"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6044,7 +6040,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-syft"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6055,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-systemctl"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6066,7 +6062,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-task"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6077,7 +6073,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-tealdeer"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6088,7 +6084,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-terraform"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6099,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-tilt"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6110,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-tokei"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6121,7 +6117,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-trippy"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6132,7 +6128,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-trivy"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6143,7 +6139,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-turbo"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6154,7 +6150,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-usql"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6165,7 +6161,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-uv"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6176,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vcpkg"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6187,7 +6183,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vite"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6198,7 +6194,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-vscode"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6209,7 +6205,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-watchexec"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6220,7 +6216,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-winget"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6231,7 +6227,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-wix"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6242,7 +6238,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-xcodebuild"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6253,7 +6249,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-xh"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6264,7 +6260,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-xmake"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6275,7 +6271,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yarn"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6286,7 +6282,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yazi"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6297,7 +6293,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-yq"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6308,7 +6304,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zellij"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6319,7 +6315,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zig"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6330,7 +6326,7 @@ dependencies = [
 
 [[package]]
 name = "vx-provider-zoxide"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "rstest",
  "starlark",
@@ -6341,7 +6337,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6375,7 +6371,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6406,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "flate2",
@@ -6425,7 +6421,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6442,7 +6438,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6475,7 +6471,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6492,7 +6488,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "serde",
@@ -6510,11 +6506,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.8.30"
+version = "0.8.31"
 
 [[package]]
 name = "vx-starlark"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6544,7 +6540,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6567,7 +6563,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6585,7 +6581,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/vx-runtime-http/Cargo.toml
+++ b/crates/vx-runtime-http/Cargo.toml
@@ -43,7 +43,7 @@ flate2 = { workspace = true }
 xz2 = { workspace = true }
 zstd = { workspace = true }
 zip = { workspace = true }
-bzip2 = "0.5"
+bzip2 = "0.6"
 sevenz-rust = { version = "0.6", optional = true }
 
 # Internal dependencies

--- a/pkg/docker/Dockerfile
+++ b/pkg/docker/Dockerfile
@@ -4,7 +4,7 @@
 # ============================================
 # Stage 1: Build stage (optional, for source builds)
 # ============================================
-FROM rust:1.94.1-alpine AS builder
+FROM rust:1.95.0-alpine AS builder
 
 RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static pkgconfig
 


### PR DESCRIPTION
## Summary

This PR batch-updates multiple Renovate dependency and action upgrades that are safe to apply.

### Rust Dependencies
- **assert_cmd** `2.2.0` → `2.2.1` (closes #816)
- **bzip2** `0.5` → `0.6` (closes #800)
- **clap** `4.6.0` → `4.6.1` (closes #806)
- **uuid** `1.23.0` → `1.23.1` (closes #807)
- Sync `Cargo.lock` package versions with `Cargo.toml` (`0.8.30` → `0.8.31`)

### GitHub Actions
- **actions/upload-pages-artifact** `v4` → `v5` (closes #797)
- **softprops/action-gh-release** `v2` → `v3` (closes #792)

### Docker
- **rust** image `1.94.1-alpine` → `1.95.0-alpine` (closes #815)

### Not Included
- **hashbrown** `0.14` → `0.17` (#786) — **blocked**. The `raw` feature was removed in hashbrown 0.15+, but the starlark dependency chain (`allocative`, `dashmap`) still requires it. This upgrade cannot proceed until those upstream crates are updated.

### Related
- PR #621 (conda provider) should be rebased onto latest `main`; its previous Code Quality failure (`unused import: PathBuf` in `7zip/src/runtime.rs`) has already been fixed in `main`.

---