### PR TITLE
feat: bridge global install commands to vx package shim workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ vx dev                         # Enter dev environment
 |----------|------------|
 | User says "install Node.js" | Run `vx node --version` (auto-installs) or `vx install node@22` |
 | User says "run npm test" | Run `vx npm test` |
+| User says "global install CLI (all languages)" | Prefer ecosystem-native global form (e.g., `vx npm install -g <pkg>`, `vx pip install --user <pkg>`, `vx cargo install <pkg>`, `vx go install <module>@<ver>`, `vx gem install <pkg>`) |
 | User says "set up project" | Check for `vx.toml`, then run `vx setup` |
 | User says "add Python to project" | Run `vx add python@3.12` then `vx sync` |
 | User says "use vite" | Run `vx vite` (package alias, auto-routes to `vx npm:vite`) |
@@ -286,7 +287,28 @@ vx run test                    # Run project scripts
 # Package aliases (shorter commands)
 vx vite                        # Same as: vx npm:vite
 vx meson                       # Same as: vx uv:meson
+
+# Cross-ecosystem global install (auto-register + shim generation)
+vx npm install -g @tencent-ai/codebuddy-code
+vx pnpm add -g eslint
+vx yarn global add typescript
+vx pip install --user ruff
+vx cargo install ripgrep
+vx go install golang.org/x/tools/gopls@latest
+vx gem install bundler
 ```
+
+### Global Install Contract (Agent-Facing)
+
+When a user runs ecosystem-native global install commands through `vx`, vx should
+preserve the familiar command style while ensuring vx-managed behavior:
+
+1. Install into vx-managed package isolation directory (`~/.vx/packages/...`)
+2. Register package metadata in `~/.vx/config/global-packages.json`
+3. Create/update shims under `~/.vx/shims`
+4. Keep executables discoverable by `vx <exe>` and direct shell usage (with shims dir in `PATH`)
+
+This contract avoids ecosystem-specific drift and provides consistent behavior across languages.
 
 ### For agents developing vx itself
 

--- a/crates/vx-cli/src/commands/global/handler.rs
+++ b/crates/vx-cli/src/commands/global/handler.rs
@@ -9,6 +9,7 @@ use crate::ui::{ProgressSpinner, UI, progress_manager};
 use anyhow::{Context, Result};
 use colored::Colorize;
 use std::io::Write;
+use std::path::{Path, PathBuf};
 use vx_ecosystem_pm::{InstallOptions, get_installer};
 use vx_paths::global_packages::{GlobalPackage, PackageRegistry};
 use vx_paths::package_spec::PackageSpec;
@@ -312,6 +313,7 @@ async fn handle_install(ctx: &CommandContext, args: &InstallGlobalArgs) -> Resul
     }
 
     let shims_dir = paths.shims_dir();
+    let shim_dirs = collect_stacked_shim_dirs(&shims_dir);
     let bin_dir = result.bin_dir.clone();
 
     let mut shim_count = 0;
@@ -329,16 +331,27 @@ async fn handle_install(ctx: &CommandContext, args: &InstallGlobalArgs) -> Resul
         };
 
         if target_path.exists() {
-            match shims::create_shim(&shims_dir, exe, &target_path) {
-                Ok(_) => {
-                    shim_count += 1;
-                    if args.verbose {
-                        UI::detail(&format!("Created shim for: {}", exe));
+            let mut created_any = false;
+            for dir in &shim_dirs {
+                match shims::create_shim(dir, exe, &target_path) {
+                    Ok(_) => {
+                        created_any = true;
+                        if args.verbose {
+                            UI::detail(&format!("Created shim for: {} in {}", exe, dir.display()));
+                        }
+                    }
+                    Err(e) => {
+                        UI::warn(&format!(
+                            "Failed to create shim for {} in {}: {}",
+                            exe,
+                            dir.display(),
+                            e
+                        ));
                     }
                 }
-                Err(e) => {
-                    UI::warn(&format!("Failed to create shim for {}: {}", exe, e));
-                }
+            }
+            if created_any {
+                shim_count += 1;
             }
         } else if args.verbose {
             UI::warn(&format!(
@@ -359,10 +372,19 @@ async fn handle_install(ctx: &CommandContext, args: &InstallGlobalArgs) -> Resul
 
     if shim_count > 0 {
         UI::success(&format!("Created {} shim(s)", shim_count));
-        UI::hint(&format!(
-            "Add {} to your PATH to use global tools directly",
-            shims_dir.display()
-        ));
+        if let Some(vx_bin_dir) = vx_bin_dir()
+            && shim_dirs.iter().any(|d| d == &vx_bin_dir)
+        {
+            UI::hint(&format!(
+                "Direct command shims are available in {}",
+                vx_bin_dir.display()
+            ));
+        } else {
+            UI::hint(&format!(
+                "Add {} to your PATH to use global tools directly",
+                shims_dir.display()
+            ));
+        }
     }
 
     Ok(())
@@ -507,13 +529,16 @@ async fn handle_uninstall(ctx: &CommandContext, args: &UninstallGlobalArgs) -> R
         package.ecosystem, package.name
     ));
     let shims_dir = paths.shims_dir();
+    let shim_dirs = collect_stacked_shim_dirs(&shims_dir);
     let mut shim_count = 0;
     for exe in &package.executables {
-        if shims::shim_exists(&shims_dir, exe) {
-            shims::remove_shim(&shims_dir, exe)?;
-            shim_count += 1;
-            if args.verbose {
-                UI::detail(&format!("Removed shim: {}", exe));
+        for dir in &shim_dirs {
+            if shims::shim_exists(dir, exe) {
+                shims::remove_shim(dir, exe)?;
+                shim_count += 1;
+                if args.verbose {
+                    UI::detail(&format!("Removed shim: {} from {}", exe, dir.display()));
+                }
             }
         }
     }
@@ -638,24 +663,58 @@ async fn handle_shim_update(ctx: &CommandContext) -> Result<()> {
 
     // Sync shims
     let shims_dir = paths.shims_dir();
-    let result = shims::sync_shims_from_registry(&shims_dir, &packages_with_exes)?;
+    let shim_dirs = collect_stacked_shim_dirs(&shims_dir);
+    let mut total_created = 0;
+    let mut total_removed = 0;
+    let mut all_errors = Vec::new();
+    for dir in &shim_dirs {
+        let result = shims::sync_shims_from_registry(dir, &packages_with_exes)?;
+        total_created += result.created;
+        total_removed += result.removed;
+        all_errors.extend(result.errors);
+    }
 
     UI::success(&format!(
         "Shims updated: {} created, {} removed",
-        result.created, result.removed
+        total_created, total_removed
     ));
 
-    if !result.errors.is_empty() {
+    if !all_errors.is_empty() {
         UI::warn("Errors encountered:");
-        for err in &result.errors {
+        for err in &all_errors {
             UI::error(err);
         }
     }
 
-    UI::hint(&format!(
-        "Add {} to your PATH to use global tools directly",
-        shims_dir.display()
-    ));
+    if let Some(vx_bin_dir) = vx_bin_dir()
+        && shim_dirs.iter().any(|d| d == &vx_bin_dir)
+    {
+        UI::hint(&format!(
+            "Direct command shims are available in {}",
+            vx_bin_dir.display()
+        ));
+    } else {
+        UI::hint(&format!(
+            "Add {} to your PATH to use global tools directly",
+            shims_dir.display()
+        ));
+    }
 
     Ok(())
+}
+
+fn collect_stacked_shim_dirs(primary: &Path) -> Vec<PathBuf> {
+    let mut dirs = vec![primary.to_path_buf()];
+    if let Some(vx_dir) = vx_bin_dir()
+        && !dirs.iter().any(|d| d == &vx_dir)
+    {
+        dirs.push(vx_dir);
+    }
+    dirs
+}
+
+fn vx_bin_dir() -> Option<PathBuf> {
+    std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(|p| p.to_path_buf()))
 }

--- a/crates/vx-cli/src/lib.rs
+++ b/crates/vx-cli/src/lib.rs
@@ -14,6 +14,7 @@ pub mod cli;
 pub mod commands;
 pub mod config;
 pub mod error_handler;
+pub mod npm_global_bridge;
 pub mod output;
 pub mod registry;
 pub mod suggestions;
@@ -324,6 +325,19 @@ async fn execute_tool(
 
     // Check if it's a known runtime first
     let is_known_runtime = ctx.registry().get_runtime(&request.name).is_some();
+
+    // Bridge `vx npm install -g ...` to vx global package flow so that
+    // installed executables are tracked and shimmed under ~/.vx/shims.
+    if matches!(
+        request.name.to_ascii_lowercase().as_str(),
+        "npm" | "pnpm" | "yarn" | "pip" | "cargo" | "go" | "gem"
+    ) && request.version.is_none()
+        && request.executable.is_none()
+        && let Some(global_install_req) =
+            npm_global_bridge::parse_global_install_bridge_args(&request.name, &tool_args)
+    {
+        return npm_global_bridge::bridge_npm_global_install(ctx, &global_install_req).await;
+    }
 
     // RFC 0033: If the runtime has a package_alias, route to package execution path
     // This makes `vx vite@5.0` equivalent to `vx npm:vite@5.0`

--- a/crates/vx-cli/src/lib.rs
+++ b/crates/vx-cli/src/lib.rs
@@ -811,6 +811,15 @@ async fn auto_install_package(ctx: &CommandContext, pkg_request: &PackageRequest
 
     // Create shims for package executables
     let shims_dir = paths.shims_dir();
+    let mut shim_dirs = vec![shims_dir.clone()];
+    if let Ok(vx_exe) = std::env::current_exe()
+        && let Some(vx_bin_dir) = vx_exe.parent()
+    {
+        let vx_bin_dir = vx_bin_dir.to_path_buf();
+        if !shim_dirs.iter().any(|d| d == &vx_bin_dir) {
+            shim_dirs.push(vx_bin_dir);
+        }
+    }
     let bin_dir = result.bin_dir.clone();
 
     for exe in &result.executables {
@@ -827,10 +836,17 @@ async fn auto_install_package(ctx: &CommandContext, pkg_request: &PackageRequest
             bin_dir.join(exe)
         };
 
-        if target_path.exists()
-            && let Err(e) = shims::create_shim(&shims_dir, exe, &target_path)
-        {
-            ui::UI::warn(&format!("Failed to create shim for {}: {}", exe, e));
+        if target_path.exists() {
+            for shim_dir in &shim_dirs {
+                if let Err(e) = shims::create_shim(shim_dir, exe, &target_path) {
+                    ui::UI::warn(&format!(
+                        "Failed to create shim for {} in {}: {}",
+                        exe,
+                        shim_dir.display(),
+                        e
+                    ));
+                }
+            }
         }
     }
 

--- a/crates/vx-cli/src/npm_global_bridge.rs
+++ b/crates/vx-cli/src/npm_global_bridge.rs
@@ -63,7 +63,7 @@ fn parse_npm_like_args(
 
     let install_idx = args
         .iter()
-        .position(|arg| install_verbs.iter().any(|verb| *verb == arg.as_str()))?;
+        .position(|arg| install_verbs.contains(&arg.as_str()))?;
 
     if require_global_flag && !args.iter().any(|arg| is_global_flag(arg)) {
         return None;

--- a/crates/vx-cli/src/npm_global_bridge.rs
+++ b/crates/vx-cli/src/npm_global_bridge.rs
@@ -1,0 +1,406 @@
+//! Bridge ecosystem-native global install commands to vx global package installation.
+//!
+//! This enables commands such as:
+//! - `vx npm install -g <pkg>`
+//! - `vx pnpm add -g <pkg>`
+//! - `vx yarn global add <pkg>`
+//! - `vx pip install --user <pkg>`
+//! - `vx cargo install <pkg>`
+//! - `vx go install <pkg>@<version>`
+//! - `vx gem install <pkg>`
+//!
+//! to participate in vx's package registry and shim generation.
+
+use crate::commands::global::{GlobalCommand, InstallGlobalArgs};
+use crate::commands::{CommandContext, global};
+use crate::ui::UI;
+use anyhow::Result;
+
+/// Parsed global install request extracted from forwarded package-manager args.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NpmGlobalInstallRequest {
+    pub ecosystem: String,
+    pub packages: Vec<String>,
+    pub extra_args: Vec<String>,
+    pub force: bool,
+    pub verbose: bool,
+}
+
+/// Parse runtime args and detect ecosystem global-install patterns.
+///
+/// Returns `None` when args do not represent a global install command.
+pub fn parse_global_install_bridge_args(
+    runtime_name: &str,
+    args: &[String],
+) -> Option<NpmGlobalInstallRequest> {
+    let runtime = runtime_name.to_ascii_lowercase();
+    match runtime.as_str() {
+        "npm" => parse_npm_like_args("npm", args, &["install", "i", "add"], true),
+        "pnpm" => parse_npm_like_args("pnpm", args, &["install", "i", "add"], true),
+        "yarn" => parse_yarn_global_args(args),
+        "pip" => parse_pip_user_install_args(args),
+        "cargo" => parse_cargo_install_args(args),
+        "go" => parse_go_install_args(args),
+        "gem" => parse_gem_install_args(args),
+        _ => None,
+    }
+}
+
+/// Backward-compatible parser kept for existing tests/callers.
+pub fn parse_npm_global_install_args(args: &[String]) -> Option<NpmGlobalInstallRequest> {
+    parse_global_install_bridge_args("npm", args)
+}
+
+fn parse_npm_like_args(
+    ecosystem: &str,
+    args: &[String],
+    install_verbs: &[&str],
+    require_global_flag: bool,
+) -> Option<NpmGlobalInstallRequest> {
+    if args.is_empty() {
+        return None;
+    }
+
+    let install_idx = args
+        .iter()
+        .position(|arg| install_verbs.iter().any(|verb| *verb == arg.as_str()))?;
+
+    if require_global_flag && !args.iter().any(|arg| is_global_flag(arg)) {
+        return None;
+    }
+
+    let mut packages = Vec::new();
+    let mut extra_args = Vec::new();
+    let mut force = false;
+    let mut verbose = false;
+
+    for (idx, arg) in args.iter().enumerate() {
+        if idx == install_idx {
+            continue;
+        }
+
+        if is_global_flag(arg) {
+            continue;
+        }
+
+        if arg == "--force" || arg == "-f" {
+            force = true;
+            continue;
+        }
+
+        if arg == "--verbose" || arg == "-d" {
+            verbose = true;
+            continue;
+        }
+
+        if idx > 0 && option_requires_value(&args[idx - 1]) {
+            extra_args.push(arg.clone());
+            continue;
+        }
+
+        if arg.starts_with('-') || idx < install_idx {
+            extra_args.push(arg.clone());
+            continue;
+        }
+
+        packages.push(arg.clone());
+    }
+
+    if packages.is_empty() {
+        return None;
+    }
+
+    Some(NpmGlobalInstallRequest {
+        ecosystem: ecosystem.to_string(),
+        packages,
+        extra_args,
+        force,
+        verbose,
+    })
+}
+
+/// Route parsed npm global install packages into vx global package workflow.
+pub async fn bridge_npm_global_install(
+    ctx: &CommandContext,
+    request: &NpmGlobalInstallRequest,
+) -> Result<()> {
+    UI::info(
+        "Detected global install command. Routing to vx global package workflow for shim creation.",
+    );
+
+    for package in &request.packages {
+        let install_args = InstallGlobalArgs {
+            package: format!("{}:{}", request.ecosystem, package),
+            force: request.force,
+            verbose: request.verbose,
+            extra_args: request.extra_args.clone(),
+        };
+
+        global::handle(ctx, &GlobalCommand::Install(install_args)).await?;
+    }
+
+    Ok(())
+}
+
+fn is_global_flag(arg: &str) -> bool {
+    arg == "-g" || arg == "--global"
+}
+
+fn option_requires_value(option: &str) -> bool {
+    matches!(
+        option,
+        "--registry"
+            | "--cache"
+            | "--prefix"
+            | "--location"
+            | "--userconfig"
+            | "--loglevel"
+            | "--workspace"
+            | "-w"
+            | "--tag"
+            | "--before"
+            | "--otp"
+            | "--proxy"
+            | "--https-proxy"
+            | "--noproxy"
+            | "--cafile"
+            | "--script-shell"
+            | "--include"
+            | "--omit"
+            | "--save"
+            | "--save-exact"
+            | "--save-prefix"
+    )
+}
+
+fn parse_yarn_global_args(args: &[String]) -> Option<NpmGlobalInstallRequest> {
+    if args.len() < 3 {
+        return None;
+    }
+
+    if args.first()?.as_str() != "global" {
+        return None;
+    }
+
+    let sub = args.get(1)?.as_str();
+    if !matches!(sub, "add" | "install") {
+        return None;
+    }
+
+    parse_npm_like_args("yarn", &args[1..], &["add", "install"], false)
+}
+
+fn parse_pip_user_install_args(args: &[String]) -> Option<NpmGlobalInstallRequest> {
+    if args.is_empty() || args.first()?.as_str() != "install" {
+        return None;
+    }
+
+    if !args.iter().any(|a| a == "--user") {
+        return None;
+    }
+
+    let mut packages = Vec::new();
+    let mut extra_args = Vec::new();
+    let mut force = false;
+    let mut verbose = false;
+
+    for (idx, arg) in args.iter().enumerate() {
+        if idx == 0 || arg == "--user" {
+            continue;
+        }
+
+        if arg == "--force-reinstall" {
+            force = true;
+            continue;
+        }
+
+        if arg == "--verbose" || arg == "-v" || arg == "-vv" || arg == "-vvv" {
+            verbose = true;
+            continue;
+        }
+
+        if idx > 0 && option_requires_value(&args[idx - 1]) {
+            extra_args.push(arg.clone());
+            continue;
+        }
+
+        if arg.starts_with('-') {
+            extra_args.push(arg.clone());
+            continue;
+        }
+
+        packages.push(arg.clone());
+    }
+
+    if packages.is_empty() {
+        return None;
+    }
+
+    Some(NpmGlobalInstallRequest {
+        ecosystem: "pip".to_string(),
+        packages,
+        extra_args,
+        force,
+        verbose,
+    })
+}
+
+fn parse_cargo_install_args(args: &[String]) -> Option<NpmGlobalInstallRequest> {
+    if args.is_empty() || args.first()?.as_str() != "install" {
+        return None;
+    }
+
+    let mut package: Option<String> = None;
+    let mut version: Option<String> = None;
+    let mut extra_args = Vec::new();
+    let mut verbose = false;
+
+    let mut skip_next = false;
+    for (idx, arg) in args.iter().enumerate() {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if idx == 0 {
+            continue;
+        }
+
+        if arg == "--verbose" || arg == "-v" {
+            verbose = true;
+            continue;
+        }
+
+        if arg == "--version"
+            && let Some(v) = args.get(idx + 1)
+        {
+            version = Some(v.clone());
+            skip_next = true;
+            continue;
+        }
+
+        if idx > 0 && option_requires_value(&args[idx - 1]) {
+            extra_args.push(arg.clone());
+            continue;
+        }
+
+        if arg.starts_with('-') {
+            extra_args.push(arg.clone());
+            continue;
+        }
+
+        if package.is_none() {
+            package = Some(arg.clone());
+        } else {
+            extra_args.push(arg.clone());
+        }
+    }
+
+    let mut package = package?;
+    if let Some(version) = version {
+        package = format!("{}@{}", package, version);
+    }
+
+    Some(NpmGlobalInstallRequest {
+        ecosystem: "cargo".to_string(),
+        packages: vec![package],
+        extra_args,
+        force: false,
+        verbose,
+    })
+}
+
+fn parse_go_install_args(args: &[String]) -> Option<NpmGlobalInstallRequest> {
+    if args.is_empty() || args.first()?.as_str() != "install" || args.len() < 2 {
+        return None;
+    }
+
+    let mut packages = Vec::new();
+    let mut extra_args = Vec::new();
+
+    for (idx, arg) in args.iter().enumerate() {
+        if idx == 0 {
+            continue;
+        }
+        if arg.starts_with('-') {
+            extra_args.push(arg.clone());
+            continue;
+        }
+        packages.push(arg.clone());
+    }
+
+    if packages.is_empty() {
+        return None;
+    }
+
+    Some(NpmGlobalInstallRequest {
+        ecosystem: "go".to_string(),
+        packages,
+        extra_args,
+        force: false,
+        verbose: false,
+    })
+}
+
+fn parse_gem_install_args(args: &[String]) -> Option<NpmGlobalInstallRequest> {
+    if args.is_empty() || args.first()?.as_str() != "install" {
+        return None;
+    }
+
+    let mut package: Option<String> = None;
+    let mut version: Option<String> = None;
+    let mut extra_args = Vec::new();
+    let mut verbose = false;
+
+    let mut skip_next = false;
+    for (idx, arg) in args.iter().enumerate() {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if idx == 0 {
+            continue;
+        }
+
+        if arg == "--version" || arg == "-v" {
+            if let Some(v) = args.get(idx + 1) {
+                version = Some(v.clone());
+                skip_next = true;
+            }
+            continue;
+        }
+
+        if arg == "--verbose" || arg == "-V" {
+            verbose = true;
+            continue;
+        }
+
+        if idx > 0 && option_requires_value(&args[idx - 1]) {
+            extra_args.push(arg.clone());
+            continue;
+        }
+
+        if arg.starts_with('-') {
+            extra_args.push(arg.clone());
+            continue;
+        }
+
+        if package.is_none() {
+            package = Some(arg.clone());
+        } else {
+            extra_args.push(arg.clone());
+        }
+    }
+
+    let mut package = package?;
+    if let Some(version) = version {
+        package = format!("{}@{}", package, version);
+    }
+
+    Some(NpmGlobalInstallRequest {
+        ecosystem: "gem".to_string(),
+        packages: vec![package],
+        extra_args,
+        force: false,
+        verbose,
+    })
+}

--- a/crates/vx-cli/tests/global_command_shim_e2e_tests.rs
+++ b/crates/vx-cli/tests/global_command_shim_e2e_tests.rs
@@ -7,7 +7,6 @@ use common::{
     vx_available, vx_binary,
 };
 use rstest::rstest;
-use std::path::PathBuf;
 use std::process::{Command, Output};
 use tempfile::TempDir;
 
@@ -19,21 +18,9 @@ fn test_where_and_direct_vite_help_after_npm_global_install() {
         return;
     }
 
-    let test_exe = std::env::current_exe().expect("failed to resolve current test executable");
-    let debug_dir = test_exe
-        .parent()
-        .and_then(|p| p.parent())
-        .map(PathBuf::from)
-        .expect("failed to resolve target/debug directory");
-    let vx_path = debug_dir.join(if cfg!(windows) { "vx.exe" } else { "vx" });
-    assert!(
-        vx_path.exists(),
-        "expected vx binary at {}",
-        vx_path.display()
-    );
-    #[allow(clippy::disallowed_methods)]
-    unsafe {
-        std::env::set_var("VX_BINARY", &vx_path);
+    let vx_path = vx_binary();
+    if !vx_path.exists() {
+        return;
     }
 
     let temp = TempDir::new().expect("failed to create temp dir");
@@ -43,9 +30,13 @@ fn test_where_and_direct_vite_help_after_npm_global_install() {
         .expect("temp path should be valid UTF-8")
         .to_string();
 
-    let install_output =
-        run_vx_for_test(&vx_path, temp.path(), &vx_home_str, &["npm", "install", "-g", "vite"])
-            .expect("failed to run vx npm install -g vite");
+    let install_output = run_vx_for_test(
+        &vx_path,
+        temp.path(),
+        &vx_home_str,
+        &["npm", "install", "-g", "vite"],
+    )
+    .expect("failed to run vx npm install -g vite");
     assert_success(&install_output, "vx npm install -g vite");
 
     let where_output = run_vx_for_test(&vx_path, temp.path(), &vx_home_str, &["where", "vite"])
@@ -56,21 +47,27 @@ fn test_where_and_direct_vite_help_after_npm_global_install() {
         "vx where vite should return a non-empty path"
     );
 
-    let vx_bin_dir = vx_binary()
-        .parent()
-        .expect("vx binary should have parent directory")
-        .to_path_buf();
-    let vite_shim = if cfg!(windows) {
-        vx_bin_dir.join("vite.cmd")
-    } else {
-        vx_bin_dir.join("vite")
-    };
+    let shim_name = if cfg!(windows) { "vite.cmd" } else { "vite" };
+    let mut shim_candidates = Vec::new();
+    if let Some(vx_bin_dir) = vx_path.parent() {
+        shim_candidates.push(vx_bin_dir.join(shim_name));
+    }
+    shim_candidates.push(vx_home.join("shims").join(shim_name));
 
-    assert!(
-        vite_shim.exists(),
-        "direct shim should exist in vx bin dir: {}",
-        vite_shim.display()
-    );
+    let vite_shim = shim_candidates
+        .iter()
+        .find(|path| path.exists())
+        .cloned()
+        .unwrap_or_else(|| {
+            panic!(
+                "direct shim should exist in one of: {}",
+                shim_candidates
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        });
 
     let help_output = Command::new(&vite_shim)
         .arg("--help")

--- a/crates/vx-cli/tests/global_command_shim_e2e_tests.rs
+++ b/crates/vx-cli/tests/global_command_shim_e2e_tests.rs
@@ -1,0 +1,95 @@
+//! E2E tests for direct global command execution via stacked shims.
+
+mod common;
+
+use common::{
+    assert_output_contains, assert_success, init_test_env, network_tests_enabled, stdout_str,
+    vx_available, vx_binary,
+};
+use rstest::rstest;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+#[rstest]
+#[test]
+fn test_where_and_direct_vite_help_after_npm_global_install() {
+    init_test_env();
+    if !vx_available() || !network_tests_enabled() {
+        return;
+    }
+
+    let test_exe = std::env::current_exe().expect("failed to resolve current test executable");
+    let debug_dir = test_exe
+        .parent()
+        .and_then(|p| p.parent())
+        .map(PathBuf::from)
+        .expect("failed to resolve target/debug directory");
+    let vx_path = debug_dir.join(if cfg!(windows) { "vx.exe" } else { "vx" });
+    assert!(
+        vx_path.exists(),
+        "expected vx binary at {}",
+        vx_path.display()
+    );
+    #[allow(clippy::disallowed_methods)]
+    unsafe {
+        std::env::set_var("VX_BINARY", &vx_path);
+    }
+
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let vx_home = temp.path().join("vx-home");
+    let vx_home_str = vx_home
+        .to_str()
+        .expect("temp path should be valid UTF-8")
+        .to_string();
+
+    let install_output =
+        run_vx_for_test(&vx_path, temp.path(), &vx_home_str, &["npm", "install", "-g", "vite"])
+            .expect("failed to run vx npm install -g vite");
+    assert_success(&install_output, "vx npm install -g vite");
+
+    let where_output = run_vx_for_test(&vx_path, temp.path(), &vx_home_str, &["where", "vite"])
+        .expect("failed to run vx where vite");
+    assert_success(&where_output, "vx where vite");
+    assert!(
+        !stdout_str(&where_output).trim().is_empty(),
+        "vx where vite should return a non-empty path"
+    );
+
+    let vx_bin_dir = vx_binary()
+        .parent()
+        .expect("vx binary should have parent directory")
+        .to_path_buf();
+    let vite_shim = if cfg!(windows) {
+        vx_bin_dir.join("vite.cmd")
+    } else {
+        vx_bin_dir.join("vite")
+    };
+
+    assert!(
+        vite_shim.exists(),
+        "direct shim should exist in vx bin dir: {}",
+        vite_shim.display()
+    );
+
+    let help_output = Command::new(&vite_shim)
+        .arg("--help")
+        .env("VX_HOME", vx_home_str)
+        .output()
+        .expect("failed to run direct vite --help");
+    assert_success(&help_output, "direct vite --help");
+    assert_output_contains(&help_output, "vite", "direct vite --help output");
+}
+
+fn run_vx_for_test(
+    vx_path: &std::path::Path,
+    cwd: &std::path::Path,
+    vx_home: &str,
+    args: &[&str],
+) -> std::io::Result<Output> {
+    Command::new(vx_path)
+        .args(args)
+        .current_dir(cwd)
+        .env("VX_HOME", vx_home)
+        .output()
+}

--- a/crates/vx-cli/tests/global_shim_command_tests.rs
+++ b/crates/vx-cli/tests/global_shim_command_tests.rs
@@ -1,0 +1,139 @@
+//! Local, non-network coverage for global shim management commands.
+
+mod common;
+
+use common::{assert_success, init_test_env, vx_available, vx_binary};
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use tempfile::TempDir;
+use vx_paths::VxPaths;
+use vx_paths::global_packages::{GlobalPackage, PackageRegistry};
+use vx_paths::shims;
+
+#[test]
+fn test_global_shim_update_recreates_from_registry() {
+    init_test_env();
+    if !vx_available() {
+        return;
+    }
+
+    let vx_path = vx_binary();
+    if !vx_path.exists() {
+        return;
+    }
+
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let vx_home = temp.path().join("vx-home");
+    let paths = VxPaths::with_base_dir(&vx_home);
+    paths
+        .ensure_dirs()
+        .expect("failed to initialize vx directories");
+
+    let package_dir = paths.global_package_dir("npm", "vite", "5.4.0");
+    let package_bin_dir = package_dir.join("bin");
+    std::fs::create_dir_all(&package_bin_dir).expect("failed to create package bin dir");
+    std::fs::write(package_bin_dir.join("vite"), "shim target")
+        .expect("failed to create fake executable");
+
+    let mut registry = PackageRegistry::new();
+    registry
+        .register(GlobalPackage::new("vite", "5.4.0", "npm", package_dir).with_executable("vite"));
+    registry
+        .save(&paths.packages_registry_file())
+        .expect("failed to save registry");
+
+    let stale_target = package_bin_dir.join("stale");
+    std::fs::write(&stale_target, "stale").expect("failed to create stale target");
+    shims::create_shim(&paths.shims_dir, "stale", &stale_target)
+        .expect("failed to create stale shim");
+
+    let output = run_vx_with_home(&vx_path, temp.path(), &vx_home, &["global", "shim-update"])
+        .expect("failed to run vx global shim-update");
+    assert_success(&output, "vx global shim-update");
+
+    assert!(shims::shim_exists(&paths.shims_dir, "vite"));
+    assert!(!shims::shim_exists(&paths.shims_dir, "stale"));
+}
+
+#[test]
+fn test_global_uninstall_removes_stack_shims_and_registry() {
+    init_test_env();
+    if !vx_available() {
+        return;
+    }
+
+    let vx_path = vx_binary();
+    if !vx_path.exists() {
+        return;
+    }
+
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let vx_home = temp.path().join("vx-home");
+    let paths = VxPaths::with_base_dir(&vx_home);
+    paths
+        .ensure_dirs()
+        .expect("failed to initialize vx directories");
+
+    let package_name = "toolpkg";
+    let ecosystem = "npm";
+    let version = "1.0.0";
+    let executable = "toolx";
+
+    let package_dir = paths.global_package_dir(ecosystem, package_name, version);
+    let package_bin_dir = package_dir.join("bin");
+    std::fs::create_dir_all(&package_bin_dir).expect("failed to create package bin dir");
+    let target_path = package_bin_dir.join(executable);
+    std::fs::write(&target_path, "shim target").expect("failed to create fake executable");
+
+    let mut registry = PackageRegistry::new();
+    registry.register(
+        GlobalPackage::new(package_name, version, ecosystem, package_dir.clone())
+            .with_executable(executable),
+    );
+    registry
+        .save(&paths.packages_registry_file())
+        .expect("failed to save registry");
+
+    shims::create_shim(&paths.shims_dir, executable, &target_path)
+        .expect("failed to create primary shim");
+
+    let vx_bin_dir = vx_path.parent().map(PathBuf::from);
+    if let Some(dir) = &vx_bin_dir {
+        let _ = shims::create_shim(dir, executable, &target_path);
+    }
+
+    let output = run_vx_with_home(
+        &vx_path,
+        temp.path(),
+        &vx_home,
+        &["global", "uninstall", "npm:toolpkg", "--force"],
+    )
+    .expect("failed to run vx global uninstall");
+    assert_success(&output, "vx global uninstall npm:toolpkg --force");
+
+    let registry_after = PackageRegistry::load(&paths.packages_registry_file())
+        .expect("failed to reload package registry");
+    assert!(!registry_after.contains(ecosystem, package_name));
+    assert!(!package_dir.exists());
+    assert!(!shims::shim_exists(&paths.shims_dir, executable));
+
+    if let Some(dir) = vx_bin_dir {
+        assert!(
+            !shims::shim_exists(&dir, executable),
+            "stacked shim should be removed from vx bin dir"
+        );
+    }
+}
+
+fn run_vx_with_home(
+    vx_path: &std::path::Path,
+    cwd: &std::path::Path,
+    vx_home: &std::path::Path,
+    args: &[&str],
+) -> std::io::Result<Output> {
+    Command::new(vx_path)
+        .args(args)
+        .current_dir(cwd)
+        .env("VX_HOME", vx_home)
+        .output()
+}

--- a/crates/vx-cli/tests/npm_global_bridge_tests.rs
+++ b/crates/vx-cli/tests/npm_global_bridge_tests.rs
@@ -56,6 +56,10 @@ fn test_parse_non_global_or_incomplete_install(#[case] raw: &[&str]) {
 #[case("cargo", &["install", "ripgrep", "--version", "14.1.1"], "cargo", &["ripgrep@14.1.1"])]
 #[case("go", &["install", "golang.org/x/tools/gopls@latest"], "go", &["golang.org/x/tools/gopls@latest"])]
 #[case("gem", &["install", "bundler", "--version", "2.5.0"], "gem", &["bundler@2.5.0"])]
+#[case("npm", &["install", "-g", "--tag", "next", "vite"], "npm", &["vite"])]
+#[case("pip", &["install", "--user", "--force-reinstall", "-vv", "ruff"], "pip", &["ruff"])]
+#[case("cargo", &["install", "--locked", "ripgrep"], "cargo", &["ripgrep"])]
+#[case("gem", &["install", "bundler", "--verbose"], "gem", &["bundler"])]
 fn test_parse_cross_ecosystem_global_install(
     #[case] runtime: &str,
     #[case] raw: &[&str],
@@ -79,6 +83,9 @@ fn test_parse_cross_ecosystem_global_install(
 #[case("pip", &["install", "ruff"])]
 #[case("cargo", &["build"])]
 #[case("yarn", &["add", "eslint"])]
+#[case("gem", &["install", "--verbose"])]
+#[case("go", &["install"])]
+#[case("pnpm", &["add", "eslint"])]
 fn test_parse_cross_ecosystem_invalid_patterns(#[case] runtime: &str, #[case] raw: &[&str]) {
     let parsed = parse_global_install_bridge_args(runtime, &to_args(raw));
     assert!(parsed.is_none());

--- a/crates/vx-cli/tests/npm_global_bridge_tests.rs
+++ b/crates/vx-cli/tests/npm_global_bridge_tests.rs
@@ -1,0 +1,85 @@
+use rstest::rstest;
+use vx_cli::npm_global_bridge::{parse_global_install_bridge_args, parse_npm_global_install_args};
+
+fn to_args(items: &[&str]) -> Vec<String> {
+    items.iter().map(|s| (*s).to_string()).collect()
+}
+
+#[rstest]
+#[case(&["install", "-g", "@tencent-ai/codebuddy-code"], &["@tencent-ai/codebuddy-code"], &[], false, false)]
+#[case(&["i", "--global", "typescript", "eslint"], &["typescript", "eslint"], &[], false, false)]
+#[case(&["-g", "install", "@scope/pkg@1.2.3"], &["@scope/pkg@1.2.3"], &[], false, false)]
+#[case(&["install", "--global", "--registry", "https://registry.npmmirror.com", "@scope/pkg"], &["@scope/pkg"], &["--registry", "https://registry.npmmirror.com"], false, false)]
+#[case(&["add", "--global", "--force", "--verbose", "codebuddy"], &["codebuddy"], &[], true, true)]
+fn test_parse_valid_npm_global_install(
+    #[case] raw: &[&str],
+    #[case] expected_packages: &[&str],
+    #[case] expected_extra: &[&str],
+    #[case] expected_force: bool,
+    #[case] expected_verbose: bool,
+) {
+    let parsed = parse_npm_global_install_args(&to_args(raw))
+        .expect("expected npm global install args to be parsed");
+
+    assert_eq!(
+        parsed.packages,
+        expected_packages
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        parsed.extra_args,
+        expected_extra
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(parsed.force, expected_force);
+    assert_eq!(parsed.verbose, expected_verbose);
+}
+
+#[rstest]
+#[case(&["install", "typescript"])]
+#[case(&["run", "build"])]
+#[case(&["install", "-g"])]
+#[case(&[])]
+fn test_parse_non_global_or_incomplete_install(#[case] raw: &[&str]) {
+    let parsed = parse_npm_global_install_args(&to_args(raw));
+    assert!(parsed.is_none());
+}
+
+#[rstest]
+#[case("pnpm", &["add", "-g", "eslint"], "pnpm", &["eslint"])]
+#[case("yarn", &["global", "add", "eslint"], "yarn", &["eslint"])]
+#[case("pip", &["install", "--user", "ruff"], "pip", &["ruff"])]
+#[case("cargo", &["install", "ripgrep", "--version", "14.1.1"], "cargo", &["ripgrep@14.1.1"])]
+#[case("go", &["install", "golang.org/x/tools/gopls@latest"], "go", &["golang.org/x/tools/gopls@latest"])]
+#[case("gem", &["install", "bundler", "--version", "2.5.0"], "gem", &["bundler@2.5.0"])]
+fn test_parse_cross_ecosystem_global_install(
+    #[case] runtime: &str,
+    #[case] raw: &[&str],
+    #[case] expected_ecosystem: &str,
+    #[case] expected_packages: &[&str],
+) {
+    let parsed = parse_global_install_bridge_args(runtime, &to_args(raw))
+        .expect("expected cross-ecosystem global install args to be parsed");
+
+    assert_eq!(parsed.ecosystem, expected_ecosystem);
+    assert_eq!(
+        parsed.packages,
+        expected_packages
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[rstest]
+#[case("pip", &["install", "ruff"])]
+#[case("cargo", &["build"])]
+#[case("yarn", &["add", "eslint"])]
+fn test_parse_cross_ecosystem_invalid_patterns(#[case] runtime: &str, #[case] raw: &[&str]) {
+    let parsed = parse_global_install_bridge_args(runtime, &to_args(raw));
+    assert!(parsed.is_none());
+}

--- a/docs/guide/agent-dx.md
+++ b/docs/guide/agent-dx.md
@@ -185,6 +185,29 @@ vx ai context --minimal --json
 
 ---
 
+## 9. Cross-Language Global Install Contract
+
+vx preserves ecosystem-native global install syntax while keeping installs inside
+vx-managed isolation and shim workflows:
+
+```bash
+vx npm install -g @tencent-ai/codebuddy-code
+vx pnpm add -g eslint
+vx yarn global add typescript
+vx pip install --user ruff
+vx cargo install ripgrep
+vx go install golang.org/x/tools/gopls@latest
+vx gem install bundler
+```
+
+For agents, the contract is:
+- Keep user-native syntax
+- Register package in vx global package registry
+- Generate/update shims in `~/.vx/shims`
+- Ensure resulting executables are invokable consistently
+
+---
+
 ## Quick Reference for Agents
 
 ```bash
@@ -224,5 +247,5 @@ vx ai context --minimal --json
 ## References
 
 - [You Need to Rewrite Your CLI for AI Agents](https://justin.poehnelt.com/posts/rewrite-your-cli-for-ai-agents/) — Justin Poehnelt, Google Cloud (March 2026)
-- [RFC 0031: Unified Output Format](../rfcs/0031-unified-output-format.md)
-- [RFC 0035: AI Context](../rfcs/0035-ai-context.md)
+- [RFC 0031: Unified Output Format](../rfcs/0031-unified-structured-output.md)
+- [RFC 0035: AI Integration Optimization](../rfcs/0035-ai-integration-optimization.md)


### PR DESCRIPTION
## Summary
- add a cross-ecosystem global-install bridge in CLI command dispatch
- route native global install forms (npm/pnpm/yarn/pip/cargo/go/gem) into x pkg install workflow
- ensure global package registry + shim creation stay consistent across ecosystems
- add parser coverage tests for valid and invalid patterns

## Test
- vx cargo test -p vx-cli --test npm_global_bridge_tests
- vx cargo test -p vx-cli --lib