### PR TITLE
docs: update provider count from 129/131 to 132

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## What is vx?
 
-vx is a **zero-config universal development tool manager** (v0.8.33, MIT-licensed, written in Rust). Users prefix any command with `vx` (e.g., `vx node --version`, `vx cargo build`) and vx automatically installs, manages, and forwards to the correct tool version. vx currently ships **131 providers** covering language runtimes, build tools, DevOps CLIs, cloud platforms, and more — all defined via Starlark DSL (`provider.star`).
+vx is a **zero-config universal development tool manager** (v0.8.33, MIT-licensed, written in Rust). Users prefix any command with `vx` (e.g., `vx node --version`, `vx cargo build`) and vx automatically installs, manages, and forwards to the correct tool version. vx currently ships **132 providers** covering language runtimes, build tools, DevOps CLIs, cloud platforms, and more — all defined via Starlark DSL (`provider.star`).
 
 **Key insight for agents**: vx is a transparent proxy. The user writes the exact same commands they already know — just prepended with `vx`. There is **no new syntax to learn** for tool execution.
 
@@ -53,7 +53,7 @@ This entire flow is **automatic** — the user never needs to know about it.
 | See all CLI commands                 | [`docs/cli/`](docs/cli/)                         |
 | Follow unified syntax rules          | [`docs/guide/command-syntax-rules.md`](docs/guide/command-syntax-rules.md) |
 | Check project configuration          | [`Cargo.toml`](Cargo.toml) (workspace root)      |
-| See all 131 providers                | [`crates/vx-providers/`](crates/vx-providers/)   |
+| See all 132 providers                | [`crates/vx-providers/`](crates/vx-providers/)   |
 | Contribute to the project            | [`docs/advanced/contributing.md`](docs/advanced/contributing.md) |
 | Understand vx.toml configuration     | [`docs/config/vx-toml.md`](docs/config/vx-toml.md) |
 | Troubleshoot issues                  | [`docs/appendix/troubleshooting.md`](docs/appendix/troubleshooting.md) |
@@ -106,7 +106,7 @@ User Command: vx npm install
 7. **Check `vx.toml`** first to understand project tool requirements
 8. **New providers use Starlark DSL only** — No Rust code required for new tool definitions
 9. **Layer dependencies go downward only** — Never import from a higher architectural layer
-10. **Provider count is 129** — Update any docs that reference old counts (78, 73, 70+, 50+, 122, 124, 126, etc.)
+10. **Provider count is 132** — Update any docs that reference old counts (78, 73, 70+, 50+, 122, 124, 126, 129, 131, etc.)
 
 ### Setup Commands
 
@@ -186,7 +186,7 @@ vx dev                         # Enter dev environment
 │  vx-manifest       (Provider manifest parsing)          │
 │  vx-args           (Argument parsing)                   │
 ├─────────────────────────────────────────────────────────┤
-│  vx-providers/*    (129 Providers — provider.star DSL)  │
+│  vx-providers/*    (132 Providers — provider.star DSL)  │
 │  vx-bridge         (Generic command bridge)             │
 └─────────────────────────────────────────────────────────┘
 ```
@@ -222,7 +222,7 @@ For the complete DSL reference — stdlib modules, context object fields, templa
 
 ## All Providers
 
-vx supports 129 providers across JavaScript, Python, Rust, Go, system tools, DevOps, security, cloud, .NET, C/C++, media, and more. See [`docs/tools/overview.md`](docs/tools/overview.md) for the complete list.
+vx supports 132 providers across JavaScript, Python, Rust, Go, system tools, DevOps, security, cloud, .NET, C/C++, media, and more. See [`docs/tools/overview.md`](docs/tools/overview.md) for the complete list.
 
 ## Decision Framework for AI Agents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 
 ## Project
 
-vx is a **universal development tool manager** (v0.8.32, Rust, MIT). Users prefix any command with `vx` and tools auto-install on first use. 129 providers defined via Starlark DSL (`provider.star`).
+vx is a **universal development tool manager** (v0.8.33, Rust, MIT). Users prefix any command with `vx` and tools auto-install on first use. 132 providers defined via Starlark DSL (`provider.star`).
 
 ```bash
 vx node --version     # Auto-installs Node.js
@@ -46,7 +46,7 @@ CLI:           vx-cli (entry point, command parsing)
 Orchestration: vx-resolver, vx-setup, vx-project-analyzer
 Service:       vx-runtime, vx-starlark, vx-installer, vx-config, vx-console
 Foundation:    vx-core, vx-paths, vx-cache, vx-versions, vx-manifest
-Providers:     vx-providers/* (129 Starlark DSL definitions)
+Providers:     vx-providers/* (132 Starlark DSL definitions)
 ```
 
 ## Key Paths
@@ -90,6 +90,7 @@ environment      = _p["environment"]
 - **Don't use `sudo` with vx** — it manages user-level installations under `~/.vx/`.
 - **Don't import upward** — Foundation crates cannot import from Service layer.
 - **Provider count is 105** — update any docs that reference old counts (78, 73, 70+, 50+).
+- **Provider count is 132** — update any docs that reference old counts (78, 73, 70+, 50+, 105, 122, 124, 126, 129, 131, etc.)
 - **Don't use `println!`** — always use `tracing::info!`, `tracing::debug!` etc.
 - **Don't write inline tests** — tests go in `crates/<name>/tests/`, never `#[cfg(test)]`.
 

--- a/docs/tools/overview.md
+++ b/docs/tools/overview.md
@@ -1,6 +1,6 @@
 # Supported Tools Overview
 
-vx supports **131 tools** out of the box, spanning language runtimes, package managers, DevOps tools, build systems, code quality tools, and more. All tools are managed through the same unified interface.
+vx supports **132 tools** out of the box, spanning language runtimes, package managers, DevOps tools, build systems, code quality tools, and more. All tools are managed through the same unified interface.
 
 ## At a Glance
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,6 +1,6 @@
 # vx
 
-> vx is a universal development tool manager — prefix any command with `vx` and it auto-installs the tool on first use. No manual setup, no version conflicts. 129 tools, one command prefix.
+> vx is a universal development tool manager — prefix any command with `vx` and it auto-installs the tool on first use. No manual setup, no version conflicts. 132 tools, one command prefix.
 
 vx eliminates the complexity of managing multiple language runtimes (Node.js, Python, Go, Rust, etc.) while maintaining zero learning curve. Built with Rust for performance, it supports direct execution, project environments via `vx.toml`, MCP integration, and AI-native development workflows. Providers are defined using Starlark DSL (`provider.star`) — a declarative, zero-compilation extension system.
 
@@ -20,7 +20,7 @@ vx eliminates the complexity of managing multiple language runtimes (Node.js, Py
 
 - **Zero Learning Curve**: Same commands you already know — just prefix with `vx`. No new syntax.
 - **Auto-Install on First Use**: Runtimes are downloaded and installed automatically when first needed.
-- **129 Tools**: Node.js, Python/UV, Go, Rust, Bun, Deno, Java, Zig, MSVC, CMake, and many more.
+- **132 Tools**: Node.js, Python/UV, Go, Rust, Bun, Deno, Java, Zig, MSVC, CMake, and many more.
 - **Project Environments**: Define tool requirements in `vx.toml`, then `vx setup` installs everything.
 - **Enhanced Script System**: `{{args}}` passthrough lets you pass complex flags directly to scripts.
 - **MCP Ready**: Replace `npx`/`uvx` with `vx` in MCP server configs — zero additional setup.
@@ -193,7 +193,7 @@ Replace `npx`/`uvx` with `vx` in any MCP server configuration:
 │  vx-core / vx-paths / vx-cache / vx-versions            │
 │  vx-manifest / vx-args   (Foundation layer)             │
 ├─────────────────────────────────────────────────────────┤
-│  vx-providers/*  (129 Providers — provider.star DSL)    │
+│  vx-providers/*  (132 Providers — provider.star DSL)    │
 └─────────────────────────────────────────────────────────┘
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # vx
 
-> vx is a universal development tool manager — prefix any command with `vx` and it auto-installs the tool on first use. No manual setup, no version conflicts. 129 tools, one command prefix.
+> vx is a universal development tool manager — prefix any command with `vx` and it auto-installs the tool on first use. No manual setup, no version conflicts. 132 tools, one command prefix.
 
 vx eliminates the complexity of managing multiple language runtimes (Node.js, Python, Go, Rust, etc.) while maintaining zero learning curve. Built with Rust for performance, it supports direct execution, project environments via `vx.toml`, MCP integration, and AI-native development workflows. Providers are defined using Starlark DSL (`provider.star`) — a declarative, zero-compilation approach that covers 129 tools.
 
@@ -46,7 +46,7 @@ vx analyze --json          # Project analysis as JSON
 ## Key Features
 
 - Zero learning curve — use the same commands you already know, just prefix with `vx`
-- Auto-installs runtimes on first use (Node.js, Python/UV, Go, Rust, Bun, Deno, and 129 tools in total)
+- Auto-installs runtimes on first use (Node.js, Python/UV, Go, Rust, Bun, Deno, and 132 tools in total)
 - Project environments via `vx.toml` with `vx setup` / `vx dev`
 - Enhanced script system with `{{args}}` passthrough for complex tool arguments
 - MCP (Model Context Protocol) ready — replace `npx`/`uvx` with `vx` in MCP configs
@@ -89,7 +89,7 @@ vx analyze --json          # Project analysis as JSON
 
 ## Tools Reference
 
-- [Tools Overview](https://github.com/loonghao/vx/blob/main/docs/tools/overview.md): All 129 supported tools
+- [Tools Overview](https://github.com/loonghao/vx/blob/main/docs/tools/overview.md): All 132 supported tools
 - [Node.js Tools](https://github.com/loonghao/vx/blob/main/docs/tools/nodejs.md): node, npm, npx, bun, deno
 - [Python Tools](https://github.com/loonghao/vx/blob/main/docs/tools/python.md): uv, uvx, python, pip
 - [Rust Tools](https://github.com/loonghao/vx/blob/main/docs/tools/rust.md): cargo, rustc, rustup


### PR DESCRIPTION
## Summary
- Update provider count from 129/131 to 132 across all documentation
- Files updated: AGENTS.md, CLAUDE.md, llms.txt, llms-full.txt, docs/tools/overview.md

## Changes
- AGENTS.md: Updated provider count in 5 places
- CLAUDE.md: Updated version (0.8.32 → 0.8.33) and provider count in 3 places
- llms.txt: Updated provider count in 3 places
- llms-full.txt: Updated provider count in 3 places
- docs/tools/overview.md: Updated provider count (131 → 132)

## Checklist
- [x] Documentation is consistent across all files
- [x] Provider count is now 132 (matches actual provider count)