### PR TITLE
docs: update provider count to 132 and add conda/micromamba/mamba

### DIFF
--- a/docs/tools/overview.md
+++ b/docs/tools/overview.md
@@ -50,6 +50,9 @@ vx supports **132 tools** out of the box, spanning language runtimes, package ma
 | **uvx** | Python | uv | [Details →](./python) |
 | **cargo** | Rust | rust | [Details →](./rust) |
 | **nuget** | .NET | — | [Details →](./build-tools) |
+| **conda** | Python/Multi-language | — | — |
+| **micromamba** | Conda-compatible | — | — |
+| **mamba** | Conda-compatible | — | — |
 | **conan** | C/C++ | — | — |
 | **vcpkg** | C/C++ | — | — |
 | **mise** | Multi-language | — | — |
@@ -268,11 +271,11 @@ vx install <tool>@<version>
 <tool> = "<version>"
 ```
 
-## Complete Tool List (129 Total)
+## Complete Tool List (132 Total)
 
 > **Note**: For detailed documentation, click the links above. For undocumented tools, please refer to the tool's official documentation.
 
-All 131 tools are immediately available with `vx <tool>`. No manual installation required — vx handles everything automatically.
+All 132 tools are immediately available with `vx <tool>`. No manual installation required — vx handles everything automatically.
 
 ## Custom Tools
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > vx is a universal development tool manager — prefix any command with `vx` and it auto-installs the tool on first use. No manual setup, no version conflicts. 132 tools, one command prefix.
 
-vx eliminates the complexity of managing multiple language runtimes (Node.js, Python, Go, Rust, etc.) while maintaining zero learning curve. Built with Rust for performance, it supports direct execution, project environments via `vx.toml`, MCP integration, and AI-native development workflows. Providers are defined using Starlark DSL (`provider.star`) — a declarative, zero-compilation approach that covers 129 tools.
+vx eliminates the complexity of managing multiple language runtimes (Node.js, Python, Go, Rust, etc.) while maintaining zero learning curve. Built with Rust for performance, it supports direct execution, project environments via `vx.toml`, MCP integration, and AI-native development workflows. Providers are defined using Starlark DSL (`provider.star`) — a declarative, zero-compilation approach that covers 132 tools.
 
 - **Install (Linux/macOS)**: `curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash`
 - **Install (Windows)**: `powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"`


### PR DESCRIPTION
## Summary
- Fix inconsistency in llms.txt (129 tools -> 132 tools)
- Add conda, micromamba, mamba to Package Managers table in docs/tools/overview.md
- Update tool count in docs/tools/overview.md (129 -> 132, 131 -> 132)

## Changes
- llms.txt: Fixed provider count inconsistency (line 5: 129 -> 132)
- docs/tools/overview.md: 
  - Added conda, micromamba, mamba to Package Managers table
  - Updated 'Complete Tool List' from 129 to 132
  - Updated 'All X tools' from 131 to 132

## Checklist
- [x] All 132 providers are now correctly documented
- [x] No broken links or formatting issues