### PR TITLE
fix(ci): trigger Release workflow when release is created from update-pr job (v0.8.34 regression)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,6 +23,22 @@
 #    creation. Uses skip-github-pull-request to prevent creating new PRs.
 # 2. "update-pr" job (skips on release commits): Handles creating/updating
 #    release PRs for normal feature/fix commits.
+#
+# RACE CONDITION FIX (v0.8.34 regression, run 25286122285):
+# release-please-action@v5 can create the release (tag + GitHub Release) from
+# *either* job, because it always tags merged release PRs when it sees them —
+# independent of the skip-github-pull-request flag. Specifically, when a fix
+# commit's `update-pr` job starts running just after the release PR is merged,
+# it detects the merged PR and creates the release itself. The subsequent
+# `release` job (on the release commit) then reports releases_created=false
+# because the release already exists, and the "Trigger Release workflow" step
+# is skipped — so cargo-dist never runs for that version.
+#
+# Fix: Both jobs trigger the Release workflow when their release-please step
+# reports releases_created=true. Additionally, the `release` job has a fallback
+# that dispatches Release based on the tag derived from
+# .release-please-manifest.json when the release already exists (i.e. it was
+# created by a prior run), ensuring cargo-dist always runs once per release.
 
 name: Release Please
 
@@ -67,12 +83,46 @@ jobs:
             --repo "${{ github.repository }}" \
             --field "tag=${{ steps.release.outputs.tag_name }}"
 
+      # Fallback: the release may have been created by a prior `update-pr`
+      # run (race condition — see workflow header). In that case
+      # releases_created is 'false' but the release still needs cargo-dist
+      # to publish artifacts. Derive the tag from the manifest, verify the
+      # release exists, and dispatch Release if it does.
+      - name: Checkout repository
+        if: ${{ steps.release.outputs.releases_created != 'true' }}
+        uses: actions/checkout@v5
+
+      - name: Trigger Release workflow (fallback)
+        if: ${{ steps.release.outputs.releases_created != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version=$(jq -r '."."' .release-please-manifest.json)
+          if [ -z "$version" ] || [ "$version" = "null" ]; then
+            echo "::warning::Could not read version from .release-please-manifest.json; skipping fallback dispatch."
+            exit 0
+          fi
+          tag="v${version}"
+          echo "releases_created=false but commit is 'chore: release'; checking tag ${tag}..."
+          if ! gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::warning::Release ${tag} does not exist yet; nothing to dispatch."
+            exit 0
+          fi
+          echo "Release ${tag} already exists (likely created by a prior run). Dispatching Release workflow..."
+          gh workflow run release.yml \
+            --repo "${{ github.repository }}" \
+            --field "tag=${tag}"
+
   # Job 2: Create/update release PRs for normal commits
   # Skipped on release commits to prevent duplicate PRs (issue #713).
   update-pr:
     runs-on: ubuntu-latest
     if: >-
       !startsWith(github.event.head_commit.message, 'chore: release')
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v5
         id: release
@@ -80,3 +130,17 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # release-please-action can create a release here too (when it detects
+      # a just-merged release PR). Trigger cargo-dist in that case so that
+      # the subsequent `release` job isn't the sole path to Release dispatch.
+      - name: Trigger Release workflow
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Release created from update-pr job, triggering cargo-dist Release workflow..."
+          echo "Tag: ${{ steps.release.outputs.tag_name }}"
+          gh workflow run release.yml \
+            --repo "${{ github.repository }}" \
+            --field "tag=${{ steps.release.outputs.tag_name }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4433,7 +4433,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "indexmap",
  "regex",
@@ -4463,7 +4463,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4488,7 +4488,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4552,7 +4552,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4595,7 +4595,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4613,7 +4613,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "colored",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4657,7 +4657,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4731,7 +4731,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4753,14 +4753,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-output-filter"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "regex",
@@ -4773,7 +4773,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4792,7 +4792,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4851,7 +4851,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "flate2",
@@ -4900,7 +4900,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4917,7 +4917,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "serde",
@@ -4985,11 +4985,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.8.33"
+version = "0.8.34"
 
 [[package]]
 name = "vx-starlark"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5042,7 +5042,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5060,7 +5060,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## Summary

Fixes a race condition in `.github/workflows/release-please.yml` where the cargo-dist **Release** workflow is not triggered when the GitHub Release is created by the `update-pr` job instead of the `release` job.

This is the bug visible in [run 25286122285 / job 74130731556](https://github.com/loonghao/vx/actions/runs/25286122285/job/74130731556): v0.8.34 was tagged and published at 17:39:32 UTC but **Release workflow has not run since 2026-04-25** — v0.8.34 currently has **0 assets**.

## Root cause

`release-please-action@v5` creates the GitHub Release (tag + release notes) whenever it sees a merged release PR — **regardless of `skip-github-pull-request`**. Timeline for v0.8.34:

| Time (UTC) | Event |
|---|---|
| 17:39:14 | `97d0890b fix(all)…` pushed → triggers Release Please run `25286115297` |
| 17:39:32 | GitHub Release `v0.8.34` **created by that run's `update-pr` job** (`✔ Creating 1 releases for pull #838`) |
| 17:39:33 | PR #838 auto-merged → commit `0dce74b9` |
| 17:39:35 | `0dce74b9` pushed → triggers run `25286122285` (the failing one) |
| 17:40:30 | `release` job runs; release already exists → `releases_created=false` → **Trigger Release workflow step skipped** |

Because the `release` job is the only path that dispatches cargo-dist, any release created by an overlapping `update-pr` run ends up with no artifacts.

## Fix

Two changes in `release-please.yml`:

1. **`update-pr` job** also dispatches `release.yml` when its own `releases_created=true`. Whichever job creates the release now also triggers cargo-dist.
2. **`release` job** gets a fallback that, when `releases_created=false`, reads the tag from `.release-please-manifest.json`, verifies the GitHub Release exists, and dispatches `release.yml` for that tag. This covers the case where the release was already created by a prior `update-pr` run.

The workflow header comment now documents the race and points at the failing run so the context is visible on future audits.

## Immediate remediation (independent of this PR)

v0.8.34 still needs its cargo-dist artifacts. Once this PR is merged (or right now), run:

```bash
gh workflow run release.yml --repo loonghao/vx --field tag=v0.8.34
```

## Notes

- Pre-push hook auto-added a `workspace-hack` regen commit (cargo-hakari); content is generated and marked `[skip ci]`.
- No changes to `release.yml`, `release-please-config.json`, or `.release-please-manifest.json`.