### PR TITLE
docs: update version to v0.8.36 and provider count to 136

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -2,7 +2,7 @@
 
 ## Project
 
-vx is a universal development tool manager (Rust, 105 providers, Starlark DSL).
+vx is a universal development tool manager (Rust, 136 providers, Starlark DSL).
 Users prefix commands with `vx` and tools auto-install on first use.
 
 ## Rules

--- a/.cursorrules
+++ b/.cursorrules
@@ -2,7 +2,7 @@
 
 ## Project Context
 
-vx is a universal development tool manager written in Rust (v0.8.20, 105 providers).
+vx is a universal development tool manager written in Rust (v0.8.36, 136 providers).
 Users prefix commands with `vx` (e.g., `vx node --version`) and vx auto-installs tools.
 Providers are defined via Starlark DSL (`provider.star`) — no Rust code needed for new tools.
 
@@ -34,7 +34,7 @@ Providers are defined via Starlark DSL (`provider.star`) — no Rust code needed
 2. **Orchestration**: `vx-resolver`, `vx-setup`, `vx-project-analyzer`
 3. **Service**: `vx-runtime`, `vx-starlark`, `vx-installer`, `vx-config`, `vx-console`
 4. **Foundation**: `vx-core`, `vx-paths`, `vx-cache`, `vx-versions`, `vx-manifest`
-5. **Providers**: `vx-providers/*` — 105 Starlark DSL provider definitions
+5. **Providers**: `vx-providers/*` — 136 Starlark DSL provider definitions
 
 ## New Provider Template
 

--- a/.kiro/steering/vx-project.md
+++ b/.kiro/steering/vx-project.md
@@ -2,7 +2,7 @@
 
 ## Project Context
 
-vx is a **universal development tool manager** (v0.8.25, Rust, MIT) that ships 129 providers.
+vx is a **universal development tool manager** (v0.8.36, Rust, MIT) that ships 136 providers.
 Users prefix commands with `vx` and tools auto-install on first use. Providers use Starlark DSL.
 
 ## Critical Rules
@@ -58,7 +58,7 @@ CLI:           vx-cli (entry point)
 Orchestration: vx-resolver, vx-setup, vx-project-analyzer
 Service:       vx-runtime, vx-starlark, vx-installer, vx-config, vx-console
 Foundation:    vx-core, vx-paths, vx-cache, vx-versions, vx-manifest
-Providers:     vx-providers/* (122 Starlark DSL definitions)
+Providers:     vx-providers/* (136 Starlark DSL definitions)
 ```
 
 ## References

--- a/.trae/rules/vx-project.md
+++ b/.trae/rules/vx-project.md
@@ -2,7 +2,7 @@
 
 ## Project Context
 
-vx is a **universal development tool manager** (v0.8.25, Rust, MIT, 129 providers).
+vx is a **universal development tool manager** (v0.8.36, Rust, MIT, 136 providers).
 Users prefix commands with `vx` (e.g., `vx node --version`) and tools auto-install on first use.
 Providers are defined via Starlark DSL (`provider.star`) — no Rust code needed.
 
@@ -25,7 +25,7 @@ Providers are defined via Starlark DSL (`provider.star`) — no Rust code needed
 2. **Orchestration**: `vx-resolver`, `vx-setup`, `vx-project-analyzer`
 3. **Service**: `vx-runtime`, `vx-starlark`, `vx-installer`, `vx-config`, `vx-console`
 4. **Foundation**: `vx-core`, `vx-paths`, `vx-cache`, `vx-versions`, `vx-manifest`
-5. **Providers**: `vx-providers/*` — 122 Starlark DSL definitions
+5. **Providers**: `vx-providers/*` — 136 Starlark DSL definitions
 
 ## New Provider (copy-paste template)
 

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -2,7 +2,7 @@
 
 ## Project
 
-vx is a **universal development tool manager** (v0.8.20, Rust, MIT, 105 providers).
+vx is a **universal development tool manager** (v0.8.36, Rust, MIT, 136 providers).
 Users prefix commands with `vx` (e.g., `vx node --version`) and tools auto-install on first use.
 Providers are defined via Starlark DSL (`provider.star`) — no Rust code needed for new tools.
 
@@ -41,7 +41,7 @@ Providers are defined via Starlark DSL (`provider.star`) — no Rust code needed
 2. **Orchestration**: `vx-resolver`, `vx-setup`, `vx-project-analyzer`
 3. **Service**: `vx-runtime`, `vx-starlark`, `vx-installer`, `vx-config`, `vx-console`
 4. **Foundation**: `vx-core`, `vx-paths`, `vx-cache`, `vx-versions`, `vx-manifest`
-5. **Providers**: `vx-providers/*` (105 Starlark DSL definitions)
+5. **Providers**: `vx-providers/*` (136 Starlark DSL definitions)
 
 ## New Provider Template
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## What is vx?
 
-vx is a **zero-config universal development tool manager** (v0.8.35, MIT-licensed, written in Rust). Users prefix any command with `vx` (e.g., `vx node --version`, `vx cargo build`) and vx automatically installs, manages, and forwards to the correct tool version. vx currently ships **136 providers** covering language runtimes, build tools, DevOps CLIs, cloud platforms, and more — all defined via Starlark DSL (`provider.star`).
+vx is a **zero-config universal development tool manager** (v0.8.36, MIT-licensed, written in Rust). Users prefix any command with `vx` (e.g., `vx node --version`, `vx cargo build`) and vx automatically installs, manages, and forwards to the correct tool version. vx currently ships **136 providers** covering language runtimes, build tools, DevOps CLIs, cloud platforms, and more — all defined via Starlark DSL (`provider.star`).
 
 **Key insight for agents**: vx is a transparent proxy. The user writes the exact same commands they already know — just prepended with `vx`. There is **no new syntax to learn** for tool execution.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 
 ## Project
 
-vx is a **universal development tool manager** (v0.8.35, Rust, MIT). Users prefix any command with `vx` and tools auto-install on first use. 136 providers defined via Starlark DSL (`provider.star`).
+vx is a **universal development tool manager** (v0.8.36, Rust, MIT). Users prefix any command with `vx` and tools auto-install on first use. 136 providers defined via Starlark DSL (`provider.star`).
 
 ```bash
 vx node --version     # Auto-installs Node.js
@@ -89,7 +89,6 @@ environment      = _p["environment"]
 - **Don't suggest manual tool installation** — vx handles it. Say `vx node --version`, not "install Node.js first".
 - **Don't use `sudo` with vx** — it manages user-level installations under `~/.vx/`.
 - **Don't import upward** — Foundation crates cannot import from Service layer.
-- **Provider count is 105** — update any docs that reference old counts (78, 73, 70+, 50+).
 - **Provider count is 136** — update any docs that reference old counts (78, 73, 70+, 50+, 105, 122, 124, 126, 129, 131, 132, 135, etc.)
 - **Don't use `println!`** — always use `tracing::info!`, `tracing::debug!` etc.
 - **Don't write inline tests** — tests go in `crates/<name>/tests/`, never `#[cfg(test)]`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4433,7 +4433,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "indexmap",
  "regex",
@@ -4463,7 +4463,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4488,7 +4488,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4552,7 +4552,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4595,7 +4595,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4613,7 +4613,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "colored",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4657,7 +4657,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4731,7 +4731,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4753,14 +4753,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-output-filter"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "regex",
@@ -4774,7 +4774,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4793,7 +4793,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4818,7 +4818,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4852,7 +4852,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "flate2",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4968,7 +4968,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "serde",
@@ -4986,11 +4986,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.8.35"
+version = "0.8.36"
 
 [[package]]
 name = "vx-starlark"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5043,7 +5043,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5061,7 +5061,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,7 +5,7 @@
 
 ## Project
 
-vx is a **universal development tool manager** (v0.8.35, Rust, MIT). Users prefix any command with `vx` and tools auto-install on first use. 136 providers defined via Starlark DSL (`provider.star`).
+vx is a **universal development tool manager** (v0.8.36, Rust, MIT). Users prefix any command with `vx` and tools auto-install on first use. 136 providers defined via Starlark DSL (`provider.star`).
 
 ```bash
 vx node --version     # Auto-installs Node.js


### PR DESCRIPTION
## Summary\n\n- Update version from v0.8.35/v0.8.20/v0.8.25 to **v0.8.36** in AGENTS.md, CLAUDE.md, GEMINI.md, .cursorrules, .windsurfrules, .kiro/steering/vx-project.md, .trae/rules/vx-project.md\n- Update provider count from 105/122/129 to **136** in all AI agent config files\n- Remove contradictory provider count (105) in CLAUDE.md\n\n## Files Changed\n\n- ✅ AGENTS.md\n- ✅ CLAUDE.md  \n- ✅ GEMINI.md\n- ✅ .cursorrules (2 places)\n- ✅ .windsurfrules (2 places)\n- ✅ .clinerules\n- ✅ .kiro/steering/vx-project.md (2 places)\n- ✅ .trae/rules/vx-project.md (2 places)\n\n## Checklist\n\n- [x] All version numbers updated to v0.8.36\n- [x] All provider counts updated to 136\n- [x] No contradictory information remains\n- [ ] Wait for CI to pass\n- [ ] Merge to main