### PR TITLE
docs: update provider count (136 -> 137) and add witr documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ This entire flow is **automatic** — the user never needs to know about it.
 | See all CLI commands                 | [`docs/cli/`](docs/cli/)                         |
 | Follow unified syntax rules          | [`docs/guide/command-syntax-rules.md`](docs/guide/command-syntax-rules.md) |
 | Check project configuration          | [`Cargo.toml`](Cargo.toml) (workspace root)      |
-| See all 136 providers                | [`crates/vx-providers/`](crates/vx-providers/)   |
+| See all 137 providers                | [`crates/vx-providers/`](crates/vx-providers/)   |
 | Contribute to the project            | [`docs/advanced/contributing.md`](docs/advanced/contributing.md) |
 | Understand vx.toml configuration     | [`docs/config/vx-toml.md`](docs/config/vx-toml.md) |
 | Troubleshoot issues                  | [`docs/appendix/troubleshooting.md`](docs/appendix/troubleshooting.md) |
@@ -106,7 +106,7 @@ User Command: vx npm install
 7. **Check `vx.toml`** first to understand project tool requirements
 8. **New providers use Starlark DSL only** — No Rust code required for new tool definitions
 9. **Layer dependencies go downward only** — Never import from a higher architectural layer
-10. **Provider count is 136** — Update any docs that reference old counts (78, 73, 70+, 50+, 105, 122, 124, 126, 129, 131, 132, 135, etc.)
+10. **Provider count is 137** — Update any docs that reference old counts (78, 73, 70+, 50+, 105, 122, 124, 126, 129, 131, 132, 135, 136, etc.)
 
 ### Setup Commands
 
@@ -186,7 +186,7 @@ vx dev                         # Enter dev environment
 │  vx-manifest       (Provider manifest parsing)          │
 │  vx-args           (Argument parsing)                   │
 ├─────────────────────────────────────────────────────────┤
-│  vx-providers/*    (136 Providers — provider.star DSL)  │
+│  vx-providers/*    (137 Providers — provider.star DSL)  │
 │  vx-bridge         (Generic command bridge)             │
 └─────────────────────────────────────────────────────────┘
 ```
@@ -222,7 +222,7 @@ For the complete DSL reference — stdlib modules, context object fields, templa
 
 ## All Providers
 
-vx supports 136 providers across JavaScript, Python, Rust, Go, system tools, DevOps, security, cloud, .NET, C/C++, media, and more. See [`docs/tools/overview.md`](docs/tools/overview.md) for the complete list.
+vx supports 137 providers across JavaScript, Python, Rust, Go, system tools, DevOps, security, cloud, .NET, C/C++, media, and more. See [`docs/tools/overview.md`](docs/tools/overview.md) for the complete list.
 
 ## Decision Framework for AI Agents
 

--- a/docs/tools/overview.md
+++ b/docs/tools/overview.md
@@ -18,7 +18,7 @@ vx supports **137 tools** out of the box, spanning language runtimes, package ma
 | [AI/ML](#aiml-tools) | Ollama, usql | 2 |
 | [Scientific & HPC](#scientific--hpc) | Spack, Rez | 2 |
 | [Media](#media) | FFmpeg, ImageMagick | 2 |
-| [CLI Enhancements](#cli--terminal-enhancements) | jq, fzf, eza, duf, dust, sd, zoxide | 7+ |
+| [CLI Enhancements](#cli--terminal-enhancements) | jq, fzf, eza, duf, dust, sd, zoxide, witr | 8+ |
 | [System Tools](#system--terminal-tools) | curl, pwsh, NASM, x-cmd, 7zip, htop (bottom) | 6+ |
 | [Security](#security-tools) | cosign, grype, syft, trivy, git-leaks, age, sops | 7 |
 | [Windows-specific](#windows-specific) | choco, winget, rcedit, MSVC, Wix, vcpkg | 6 |
@@ -178,6 +178,7 @@ See [Build Cache Guide](./build-cache) for detailed documentation.
 | **dust** | Disk usage analyzer |
 | **sd** | Better sed (simple find & replace) |
 | **zoxide** | Smart cd replacement |
+| **witr** | Process introspection ("Why is this running?") | [Details →](./witr) |
 | **atuin** | Shell history sync |
 | **starship** | Cross-shell prompt |
 | **tealdeer** (tldr) | Simplified man pages |

--- a/docs/tools/witr.md
+++ b/docs/tools/witr.md
@@ -1,0 +1,66 @@
+# witr - Process Introspection Tool
+
+witr ("Why is this running?") is a process introspection tool that helps you understand what processes are running and why.
+
+## Quick Start
+
+```bash
+# Install witr
+vx install witr@latest
+
+# Check witr version
+vx witr --version
+
+# Use witr to introspect processes
+vx witr
+```
+
+## About witr
+
+witr helps you answer questions like:
+- Why is this process running?
+- What started this process?
+- What dependencies does this process have?
+
+## Installation
+
+witr is available for all platforms (Windows, macOS, Linux) via `vx`:
+
+```bash
+vx install witr@latest
+```
+
+vx downloads witr from the [vx-org/mirrors](https://github.com/vx-org/mirrors) repository, which provides pre-built binaries for:
+- Windows (amd64, arm64)
+- macOS (amd64, arm64)
+- Linux (amd64, arm64)
+
+## Usage Examples
+
+```bash
+# Basic usage
+vx witr
+
+# Check specific process
+vx witr <pid>
+
+# Verbose output
+vx witr --verbose
+```
+
+## Platform Support
+
+| Platform | Architectures | Binary Type |
+|----------|----------------|-------------|
+| Windows  | amd64, arm64   | `.zip` archive (contains `witr.exe`) |
+| macOS    | amd64, arm64   | Direct binary |
+| Linux    | amd64, arm64   | Direct binary |
+
+## Source
+
+- **Original repository**: [pranshuparmar/witr](https://github.com/pranshuparmar/witr)
+- **Mirror source**: [vx-org/mirrors](https://github.com/vx-org/mirrors) (GitHub Releases)
+
+## License
+
+MIT

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,6 +1,6 @@
 # vx
 
-> vx is a universal development tool manager — prefix any command with `vx` and it auto-installs the tool on first use. No manual setup, no version conflicts. 136 tools, one command prefix.
+> vx is a universal development tool manager — prefix any command with `vx` and it auto-installs the tool on first use. No manual setup, no version conflicts. 137 tools, one command prefix.
 
 vx eliminates the complexity of managing multiple language runtimes (Node.js, Python, Go, Rust, etc.) while maintaining zero learning curve. Built with Rust for performance, it supports direct execution, project environments via `vx.toml`, MCP integration, and AI-native development workflows. Providers are defined using Starlark DSL (`provider.star`) — a declarative, zero-compilation extension system.
 
@@ -20,7 +20,7 @@ vx eliminates the complexity of managing multiple language runtimes (Node.js, Py
 
 - **Zero Learning Curve**: Same commands you already know — just prefix with `vx`. No new syntax.
 - **Auto-Install on First Use**: Runtimes are downloaded and installed automatically when first needed.
-- **136 Tools**: Node.js, Python/UV, Go, Rust, Bun, Deno, Java, Zig, MSVC, CMake, and many more.
+- **137 Tools**: Node.js, Python/UV, Go, Rust, Bun, Deno, Java, Zig, MSVC, CMake, and many more.
 - **Project Environments**: Define tool requirements in `vx.toml`, then `vx setup` installs everything.
 - **Enhanced Script System**: `{{args}}` passthrough lets you pass complex flags directly to scripts.
 - **MCP Ready**: Replace `npx`/`uvx` with `vx` in MCP server configs — zero additional setup.
@@ -193,7 +193,7 @@ Replace `npx`/`uvx` with `vx` in any MCP server configuration:
 │  vx-core / vx-paths / vx-cache / vx-versions            │
 │  vx-manifest / vx-args   (Foundation layer)             │
 ├─────────────────────────────────────────────────────────┤
-│  vx-providers/*  (136 Providers — provider.star DSL)    │
+│  vx-providers/*  (137 Providers — provider.star DSL)    │
 └─────────────────────────────────────────────────────────┘
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,8 +1,8 @@
 # vx
 
-> vx is a universal development tool manager — prefix any command with `vx` and it auto-installs the tool on first use. No manual setup, no version conflicts. 136 tools, one command prefix.
+> vx is a universal development tool manager — prefix any command with `vx` and it auto-installs the tool on first use. No manual setup, no version conflicts. 137 tools, one command prefix.
 
-vx eliminates the complexity of managing multiple language runtimes (Node.js, Python, Go, Rust, etc.) while maintaining zero learning curve. Built with Rust for performance, it supports direct execution, project environments via `vx.toml`, MCP integration, and AI-native development workflows. Providers are defined using Starlark DSL (`provider.star`) — a declarative, zero-compilation approach that covers 136 tools.
+vx eliminates the complexity of managing multiple language runtimes (Node.js, Python, Go, Rust, etc.) while maintaining zero learning curve. Built with Rust for performance, it supports direct execution, project environments via `vx.toml`, MCP integration, and AI-native development workflows. Providers are defined using Starlark DSL (`provider.star`) — a declarative, zero-compilation approach that covers 137 tools.
 
 - **Install (Linux/macOS)**: `curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash`
 - **Install (Windows)**: `powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"`
@@ -46,7 +46,7 @@ vx analyze --json          # Project analysis as JSON
 ## Key Features
 
 - Zero learning curve — use the same commands you already know, just prefix with `vx`
-- Auto-installs runtimes on first use (Node.js, Python/UV, Go, Rust, Bun, Deno, and 136 tools in total)
+- Auto-installs runtimes on first use (Node.js, Python/UV, Go, Rust, Bun, Deno, and 137 tools in total)
 - Project environments via `vx.toml` with `vx setup` / `vx dev`
 - Enhanced script system with `{{args}}` passthrough for complex tool arguments
 - MCP (Model Context Protocol) ready — replace `npx`/`uvx` with `vx` in MCP configs
@@ -89,7 +89,7 @@ vx analyze --json          # Project analysis as JSON
 
 ## Tools Reference
 
-- [Tools Overview](https://github.com/loonghao/vx/blob/main/docs/tools/overview.md): All 136 supported tools
+- [Tools Overview](https://github.com/loonghao/vx/blob/main/docs/tools/overview.md): All 137 supported tools
 - [Node.js Tools](https://github.com/loonghao/vx/blob/main/docs/tools/nodejs.md): node, npm, npx, bun, deno
 - [Python Tools](https://github.com/loonghao/vx/blob/main/docs/tools/python.md): uv, uvx, python, pip
 - [Rust Tools](https://github.com/loonghao/vx/blob/main/docs/tools/rust.md): cargo, rustc, rustup


### PR DESCRIPTION
## Summary

- Update provider count from 136 to 137 in AGENTS.md, llms.txt, and llms-full.txt
- Add witr tool documentation (docs/tools/witr.md)
- Update docs/tools/overview.md to include witr in CLI & Terminal Enhancements

## Changes

- 
- Modified: AGENTS.md (4 locations)
- Modified: llms.txt (4 locations)
- Modified: llms-full.txt (3 locations)
- Modified: docs/tools/overview.md (added witr)
- Added: docs/tools/witr.md (new file)

## Testing

- [x] Documentation builds successfully
- [x] No broken links introduced
- [x] Provider count consistent across all docs (137)

## Screenshots

N/A (documentation only change)