### PR TITLE
docs: update media.md and witr.md with vx-org/mirrors download source

### DIFF
--- a/docs/tools/media.md
+++ b/docs/tools/media.md
@@ -6,6 +6,12 @@ vx supports media processing tools for audio, video, and image manipulation.
 
 A complete, cross-platform solution to record, convert and stream audio and video.
 
+**Download Source:**
+- **Windows/Linux**: Downloaded from [vx-org/mirrors](https://github.com/vx-org/mirrors) GitHub Releases (static builds by BtbN)
+- **macOS**: Installed via system package managers (brew, apt, etc.)
+
+The `vx-org/mirrors` repository provides a permanent archive of FFmpeg static builds for all versions, ensuring reliable downloads.
+
 ```bash
 vx install `ffmpeg@latest
 

--- a/docs/tools/witr.md
+++ b/docs/tools/witr.md
@@ -21,6 +21,7 @@ witr helps you answer questions like:
 - Why is this process running?
 - What started this process?
 - What dependencies does this process have?
+- What is the process ancestry (parent/child relationships)?
 
 ## Installation
 
@@ -30,31 +31,60 @@ witr is available for all platforms (Windows, macOS, Linux) via `vx`:
 vx install witr@latest
 ```
 
-vx downloads witr from the [vx-org/mirrors](https://github.com/vx-org/mirrors) repository, which provides pre-built binaries for:
-- Windows (amd64, arm64)
-- macOS (amd64, arm64)
-- Linux (amd64, arm64)
+vx downloads witr from the [vx-org/mirrors](https://github.com/vx-org/mirrors) repository (GitHub Releases), which provides pre-built binaries for:
+- Windows (amd64, arm64) - `.zip` archive containing `witr.exe`
+- macOS (amd64, arm64) - Direct binary
+- Linux (amd64, arm64) - Direct binary
+
+**Note**: The `vx-org/mirrors` repository provides a permanent archive of witr binaries, ensuring reliable downloads.
 
 ## Usage Examples
 
 ```bash
-# Basic usage
+# Basic usage - list all processes
 vx witr
 
-# Check specific process
-vx witr <pid>
+# Check specific process by name
+vx witr nginx
 
-# Verbose output
-vx witr --verbose
+# Look up by PID
+vx witr --pid 1234
+
+# Find process listening on a port
+vx witr --port 5432
+
+# Show full process ancestry (tree view)
+vx witr postgres --tree
+
+# Show warnings (suspicious env, arguments, parents)
+vx witr docker --warnings
+
+# JSON output for scripting
+vx witr chrome --json
+```
+
+## Integration with vx
+
+witr is integrated into vx as a companion tool for process introspection. You can use it to debug running processes and understand "why is this running?":
+
+```bash
+# Find which process is using a specific port
+vx witr --port 8080
+
+# Check if a specific tool is running
+vx witr node
+
+# Inspect vx-managed tool processes
+vx witr python
 ```
 
 ## Platform Support
 
-| Platform | Architectures | Binary Type |
-|----------|----------------|-------------|
-| Windows  | amd64, arm64   | `.zip` archive (contains `witr.exe`) |
-| macOS    | amd64, arm64   | Direct binary |
-| Linux    | amd64, arm64   | Direct binary |
+| Platform | Architectures | Binary Type | Download Source |
+|----------|----------------|-------------|-----------------|
+| Windows  | amd64, arm64   | `.zip` archive (contains `witr.exe`) | vx-org/mirrors |
+| macOS    | amd64, arm64   | Direct binary | vx-org/mirrors |
+| Linux    | amd64, arm64   | Direct binary | vx-org/mirrors |
 
 ## Source
 


### PR DESCRIPTION
## Summary

- Update docs/tools/media.md: add download source description for FFmpeg (vx-org/mirrors for Windows/Linux)
- Update docs/tools/witr.md: add more detailed usage examples and clarify download source
- Improve documentation to help agents better understand the project

## Changes

1. **docs/tools/media.md**:
   - Added "Download Source" section
   - Clarified that Windows/Linux use vx-org/mirrors, macOS uses system_install

2. **docs/tools/witr.md**:
   - Added more usage examples (--pid, --port, --tree, --warnings, --json)
   - Clarified download source (vx-org/mirrors for all platforms)
   - Added "Integration with vx" section

## Testing

- [x] Documentation builds successfully
- [x] All links are valid
- [x] No broken references

## Related Issues

None
