### PR TITLE
docs: update provider count from 136 to 137

### DIFF
--- a/docs/advanced/contributing.md
+++ b/docs/advanced/contributing.md
@@ -166,7 +166,7 @@ vx/
 │   ├── vx-config/           # Configuration management
 │   ├── vx-console/          # Unified output and progress
 │   ├── vx-project-analyzer/ # Project detection
-│   └── vx-providers/        # 136 tool providers (provider.star)
+│   └── vx-providers/        # 137 tool providers (provider.star)
 ├── skills/                  # AI agent skill files (5 SKILL.md)
 ├── docs/                    # Documentation (English + Chinese)
 ├── tests/                   # Integration tests

--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -27,7 +27,7 @@
      └────────┬───────┘ └──────────┘ └──────────────┘
               │
      ┌────────▼───────┐
-     │ provider.star   │  136 Provider definitions
+     │ provider.star   │  137 Provider definitions
      │ files           │  (Starlark DSL)
      └────────────────┘
 ```
@@ -89,7 +89,7 @@
 
 | Directory | Purpose |
 |-----------|---------|
-| `crates/vx-providers/*` | 136 Provider definitions using `provider.star` Starlark DSL |
+| `crates/vx-providers/*` | 137 Provider definitions using `provider.star` Starlark DSL |
 | `vx-bridge` | Generic command bridge framework for providers |
 
 ## Data Flow: `vx node --version`

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -194,4 +194,4 @@ all = "just dev"
 - [Core Concepts](/guide/concepts) — Understand providers, runtimes, and versions
 - [Configuration](/guide/configuration) — Deep dive into `vx.toml`
 - [CLI Reference](/cli/overview) — Explore all available commands
-- [Supported Tools](/tools/overview) — See the full list of 136 tools
+- [Supported Tools](/tools/overview) — See the full list of 137 tools

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -50,7 +50,7 @@ vx uvx ruff check .      # Same as uvx ruff check, but auto-installed
 vx go build ./...        # Same as go build, but portable
 ```
 
-### 136 Tools Supported
+### 137 Tools Supported
 From language runtimes to DevOps tools, vx manages them all with a single interface. See the [full tool list](/tools/overview).
 
 ### Declarative Configuration


### PR DESCRIPTION
## Summary

This PR updates the provider count from 136 to 137 across all documentation files to match the actual number of providers (137 in \crates/vx-providers/\).

## Changes

- \docs/guide/index.md\: '136 Tools Supported' → '137 Tools Supported'
- \docs/advanced/contributing.md\: '136 tool providers' → '137'
- \docs/architecture/OVERVIEW.md\: '136 Provider definitions' → '137' (2 places)
- \docs/guide/getting-started.md\: '136 tools' → '137 tools'

## Checklist

- [x] All documentation now consistently references 137 providers
- [x] Commit author set to \loonghao <hal.long@outlook.com>\
- [ ] CI passes