### PR TITLE
docs: fix syntax errors in other.md and quality.md

### DIFF
--- a/docs/tools/other.md
+++ b/docs/tools/other.md
@@ -9,7 +9,7 @@ vx supports various other development tools.
 Secure JavaScript/TypeScript runtime.
 
 ```bash
-vx install `deno@latest
+vx install deno@latest
 
 vx deno --version
 vx deno run script.ts
@@ -22,7 +22,7 @@ vx deno task dev
 Zig programming language.
 
 ```bash
-vx install `zig@latest
+vx install zig@latest
 
 vx zig version
 vx zig build
@@ -34,8 +34,8 @@ vx zig run main.zig
 Java Development Kit.
 
 ```bash
-vx install java 21
-vx install java 17
+vx install java@21
+vx install java@17
 
 vx java --version
 vx javac Main.java
@@ -47,7 +47,7 @@ vx java Main
 .NET SDK for C#, F#, and VB.NET development.
 
 ```bash
-vx install `dotnet@latest
+vx install dotnet@latest
 
 vx dotnet --version
 vx dotnet new console -n MyApp
@@ -58,6 +58,7 @@ vx dotnet publish -c Release
 ```
 
 **Key Features:**
+
 - Cross-platform development (Windows, macOS, Linux)
 - Support for C#, F#, and Visual Basic
 - Built-in package management (NuGet)
@@ -70,7 +71,7 @@ vx dotnet publish -c Release
 Next generation frontend tooling.
 
 ```bash
-vx install `vite@latest
+vx install vite@latest
 
 vx vite
 vx vite build
@@ -82,7 +83,7 @@ vx vite preview
 Command runner (like make, but simpler).
 
 ```bash
-vx install `just@latest
+vx install just@latest
 
 vx just --list
 vx just build
@@ -94,7 +95,7 @@ vx just test
 Task runner / build tool alternative to Make.
 
 ```bash
-vx install `task@latest
+vx install task@latest
 
 vx task --version
 vx task build
@@ -107,7 +108,7 @@ vx task --list
 Cross-platform build system generator.
 
 ```bash
-vx install `cmake@latest
+vx install cmake@latest
 
 vx cmake --version
 vx cmake -B build -S .
@@ -120,7 +121,7 @@ vx cmake --install build
 Small build system with a focus on speed.
 
 ```bash
-vx install `ninja@latest
+vx install ninja@latest
 
 vx ninja --version
 vx ninja -C build
@@ -132,7 +133,7 @@ vx ninja -C build clean
 Protocol Buffers compiler.
 
 ```bash
-vx install `protoc@latest
+vx install protoc@latest
 
 vx protoc --version
 vx protoc --cpp_out=. message.proto
@@ -147,7 +148,7 @@ vx protoc --go_out=. message.proto
 Infrastructure as Code.
 
 ```bash
-vx install `terraform@latest
+vx install terraform@latest
 
 vx terraform --version
 vx terraform init
@@ -160,7 +161,7 @@ vx terraform apply
 Kubernetes CLI.
 
 ```bash
-vx install `kubectl@latest
+vx install kubectl@latest
 
 vx kubectl version
 vx kubectl get pods
@@ -172,7 +173,7 @@ vx kubectl apply -f deployment.yaml
 Kubernetes package manager.
 
 ```bash
-vx install `helm@latest
+vx install helm@latest
 
 vx helm version
 vx helm install my-release chart/
@@ -199,7 +200,7 @@ vx podman compose up -d
 Amazon Web Services command-line interface.
 
 ```bash
-vx install `awscli@latest
+vx install awscli@latest
 
 vx aws --version
 vx aws configure
@@ -212,7 +213,7 @@ vx aws ec2 describe-instances
 Microsoft Azure command-line interface.
 
 ```bash
-vx install `azcli@latest
+vx install azcli@latest
 
 vx az --version
 vx az login
@@ -225,7 +226,7 @@ vx az vm list
 Google Cloud Platform command-line interface.
 
 ```bash
-vx install `gcloud@latest
+vx install gcloud@latest
 
 vx gcloud --version
 vx gcloud auth login
@@ -240,7 +241,7 @@ vx gcloud compute instances list
 Framework for managing pre-commit hooks.
 
 ```bash
-vx install pre-commit latest
+vx install pre-commit@latest
 
 vx pre-commit --version
 vx pre-commit install
@@ -255,7 +256,7 @@ vx pre-commit autoupdate
 Visual Studio Code (CLI).
 
 ```bash
-vx install `vscode@latest
+vx install vscode@latest
 
 vx code .
 vx code --install-extension ms-python.python
@@ -268,7 +269,7 @@ vx code --install-extension ms-python.python
 Package management system for VFX/animation.
 
 ```bash
-vx install `rez@latest
+vx install rez@latest
 
 vx rez --version
 vx rez env package
@@ -279,7 +280,7 @@ vx rez env package
 Windows resource editor.
 
 ```bash
-vx install `rcedit@latest
+vx install rcedit@latest
 
 vx rcedit app.exe --set-icon icon.ico
 vx rcedit app.exe --set-version-string "ProductName" "My App"
@@ -305,6 +306,7 @@ vx x-cmd chat
 ```
 
 **Key Features:**
+
 - 100+ built-in modules (env, pkg, chat, etc.)
 - Package manager for 500+ third-party CLI tools
 - AI integration (chat, agent, code generation)

--- a/docs/tools/quality.md
+++ b/docs/tools/quality.md
@@ -7,7 +7,7 @@ vx supports a wide range of tools for maintaining code quality, linting, formatt
 A framework for managing and maintaining multi-language pre-commit hooks.
 
 ```bash
-vx install pre-commit latest
+vx install pre-commit@latest
 
 vx pre-commit --version
 vx pre-commit install            # Install hooks


### PR DESCRIPTION
Fix syntax errors in documentation:

- Fix mismatched backticks in other.md (vx install commands)
- Fix missing @ symbol in quality.md (vx install pre-commit latest → pre-commit@latest)
- Ensure all install commands follow correct format: vx install <tool>@<version>