### PR TITLE
docs: fix duplicate Critical Rules sections in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,8 @@ vx npx create-react-app x  # Auto-installs Node.js + runs npx
 
 ### Critical Rules for AI Agents (MUST Follow)
 
+**For AI Agents using vx (in projects)**:
+
 1. **Always use `vx` prefix** — Never suggest `npm install`, always `vx npm install`
 2. **Never suggest manual tool installation** — vx handles it automatically
 3. **Use correct terminology** — Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
@@ -123,9 +125,9 @@ User Command: vx npm install
 
 **Key principle**: vx never modifies commands — it only ensures the right tool version is available, then transparently forwards the command.
 
-## Critical Rules for AI Agents
+## Critical Rules for AI Agents (Developing vx)
 
-**These rules MUST be followed when working on or with vx:**
+**These rules MUST be followed when working ON vx (developing vx itself):**
 
 1. **Always use `vx` prefix** — Never suggest `npm install`, always `vx npm install`
 2. **Never suggest manual tool installation** — vx handles it automatically


### PR DESCRIPTION
## Summary
- Fixed duplicate 'Critical Rules for AI Agents' sections in AGENTS.md
- First section now clearly labeled as 'For AI Agents using vx (in projects)'
- Second section now clearly labeled as 'For AI Agents (Developing vx)'
- This makes AGENTS.md a better map for progressive disclosure

## Changes
- Modified first Critical Rules section to add 'For AI Agents using vx (in projects):'
- Renamed second Critical Rules section from 'Critical Rules for AI Agents' to 'Critical Rules for AI Agents (Developing vx)'
- Updated descriptions to clarify the target audience

## Why
AGENTS.md should be a map for progressive disclosure. Having two sections with similar titles was confusing. Now it's clear that the first section is for AI agents using vx in projects, and the second section is for AI agents developing vx itself.

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Branch name follows &lt;type&gt;/&lt;short-description&gt; format
- [x] Changes are focused on documentation only