### PR TITLE
docs: update Rust version to 1.95.0+ and fix RFC count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 |-------------|-----------|
 | Understand what vx is | [What is vx? (below)](#what-is-vx) |
 | Learn architecture | [`docs/architecture/OVERVIEW.md`](docs/architecture/OVERVIEW.md) |
-| Read design decisions (RFCs) | [`docs/rfcs/`](docs/rfcs/) — 50+ RFCs |
+| Read design decisions (RFCs) | [`docs/rfcs/`](docs/rfcs/) — 40+ RFCs |
 | Add a new Provider (tool) | [`docs/guide/creating-provider.md`](docs/guide/creating-provider.md) |
 | Understand provider.star DSL | [`docs/guide/provider-star-reference.md`](docs/guide/provider-star-reference.md) |
 | Run CI tasks locally | [justfile](justfile) — `vx just --list` |
@@ -76,7 +76,7 @@ This entire flow is **automatic** — the user never needs to know about it.
 | If you need to…                    | Start here                                       |
 |-------------------------------------|--------------------------------------------------|
 | Understand the architecture          | [`docs/architecture/OVERVIEW.md`](docs/architecture/OVERVIEW.md) |
-| Read design decisions (RFCs)         | [`docs/rfcs/`](docs/rfcs/) — 50 RFCs             |
+| Read design decisions (RFCs)         | [`docs/rfcs/`](docs/rfcs/) — 40 RFCs             |
 | Learn coding conventions             | [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md)     |
 | Add a new Provider (tool)            | [`docs/guide/creating-provider.md`](docs/guide/creating-provider.md) |
 | Understand provider.star DSL fully   | [`docs/guide/provider-star-reference.md`](docs/guide/provider-star-reference.md) |
@@ -440,7 +440,7 @@ crates/vx-starlark/stdlib/   # Starlark standard library
 
 ### Code Style
 
-- **Language**: Rust (edition 2024, MSRV 1.93+)
+- **Language**: Rust (edition 2024, MSRV 1.95.0+)
 - **Formatting**: `vx cargo fmt` before committing
 - **Linting**: `clippy` with `-D warnings`
 - **Logging**: `tracing::info!` — never `println!`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ vx just quick
 
 ## Prerequisites
 
-- **Rust 1.93+** (managed by vx itself: `vx cargo --version`)
+- **Rust 1.95.0+** (managed by vx itself: `vx cargo --version`)
 - **Git**
 - **just** (task runner, managed by vx: `vx just --list`)
 

--- a/docs/advanced/contributing.md
+++ b/docs/advanced/contributing.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to vx!
 
 ### Prerequisites
 :
-- Rust 1.93+ (Edition 2024)
+- Rust 1.95.0+ (Edition 2024)
 - Git
 
 ### Clone and Build

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7,7 +7,7 @@ vx eliminates the complexity of managing multiple language runtimes (Node.js, Py
 - **Install (Linux/macOS)**: `curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash`
 - **Install (Windows)**: `powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"`
 - **Platforms**: Windows, macOS, Linux (x86_64, aarch64)
-- **Language**: Rust 1.93+, **License**: MIT
+- **Language**: Rust 1.95.0+, **License**: MIT
 - **Repository**: https://github.com/loonghao/vx
 - **GitHub Action**: `loonghao/vx@main`
 - **AI Agent Entry Point**: [AGENTS.md](https://github.com/loonghao/vx/blob/main/AGENTS.md)
@@ -31,7 +31,7 @@ vx eliminates the complexity of managing multiple language runtimes (Node.js, Py
 
 ## Technical Stack
 
-- **Core**: Rust 1.93+, async/await with Tokio
+- **Core**: Rust 1.95.0+, async/await with Tokio
 - **Provider DSL**: Starlark (Python-like) via `provider.star` — declarative, zero-compilation
 - **Architecture**: 5-layer system with strict downward-only dependency rule
 - **Starlark Stdlib**: 14 modules (runtime, platform, env, layout, permissions, system_install, etc.)

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@ vx eliminates the complexity of managing multiple language runtimes (Node.js, Py
 - **Install (Linux/macOS)**: `curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash`
 - **Install (Windows)**: `powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"`
 - **Platforms**: Windows, macOS, Linux (x86_64, aarch64)
-- **Language**: Rust 1.93+
+- **Language**: Rust 1.95.0+
 - **License**: MIT
 - **Repository**: https://github.com/loonghao/vx
 - **Releases**: https://github.com/loonghao/vx/releases


### PR DESCRIPTION
## Summary\n\n- Updated Rust version requirement from 1.93+ to 1.95.0+ in 6 files\n- Fixed RFC count from 50+ to 40+ in AGENTS.md\n- Ensures documentation consistency with Cargo.toml\n\n## Changes\n\n| File | Change |\n|------|--------|\n| AGENTS.md | Rust 1.95.0+, RFC 40+ |\n| CONTRIBUTING.md | Rust 1.95.0+ |\n| docs/advanced/contributing.md | Rust 1.95.0+ |\n| llms.txt | Rust 1.95.0+ |\n| llms-full.txt | Rust 1.95.0+ (2 locations) |\n\n## Checklist\n\n- [x] Documentation is consistent with Cargo.toml\n- [x] No new functionality (docs only)\n- [x] Ready for CI