### PR TITLE
fix: handle rust toolchain versions in path selection

### DIFF
--- a/crates/vx-resolver/src/executor/environment.rs
+++ b/crates/vx-resolver/src/executor/environment.rs
@@ -947,6 +947,21 @@ impl<'a> EnvironmentManager<'a> {
                 }
             }
 
+            if ProjectToolsConfig::is_toolchain_managed_runtime_version(
+                runtime_name,
+                requested_version,
+            ) {
+                let mut versions = installed_versions.to_vec();
+                versions.sort_by(|a, b| self.compare_versions(a, b));
+                if let Some(latest) = versions.last() {
+                    trace!(
+                        "Using {} store version {} for requested toolchain {} from vx.toml",
+                        runtime_name, latest, requested_version
+                    );
+                    return Some(latest.clone());
+                }
+            }
+
             let matching_version =
                 self.find_matching_version(runtime_name, requested_version, installed_versions);
 

--- a/crates/vx-resolver/src/executor/project_config.rs
+++ b/crates/vx-resolver/src/executor/project_config.rs
@@ -191,6 +191,14 @@ impl ProjectToolsConfig {
         self.get_version(primary)
     }
 
+    /// Check whether a requested version belongs to a toolchain managed by another runtime.
+    ///
+    /// Rust is installed through `rustup`, so the vx store version is the rustup installer
+    /// version while project configuration may request a Rust compiler/toolchain version.
+    pub fn is_toolchain_managed_runtime_version(tool: &str, version: &str) -> bool {
+        Self::is_rust_toolchain_runtime(tool) && Self::is_rust_toolchain_version(version)
+    }
+
     /// Get companion tools from vx.toml that should have their `prepare_environment()`
     /// called when executing any other tool.
     ///
@@ -347,5 +355,26 @@ impl ProjectToolsConfig {
             // Everything else (including pnpm, yarn, bun, uv, etc.) should NOT fall back
             _ => None,
         }
+    }
+
+    fn is_rust_toolchain_runtime(tool: &str) -> bool {
+        matches!(tool, "rust" | "cargo" | "rustc" | "rustfmt" | "clippy")
+    }
+
+    fn is_rust_toolchain_version(version: &str) -> bool {
+        if matches!(version, "stable" | "beta" | "nightly") {
+            return true;
+        }
+
+        if version.starts_with("nightly-") || version.starts_with("beta-") {
+            return true;
+        }
+
+        let trimmed = version.trim_start_matches('v');
+        let mut parts = trimmed.split(['.', '-']);
+        let major = parts.next().and_then(|part| part.parse::<u64>().ok());
+        let minor = parts.next().and_then(|part| part.parse::<u64>().ok());
+
+        matches!((major, minor), (Some(1), Some(minor)) if minor >= 30)
     }
 }

--- a/crates/vx-resolver/tests/project_config_tests.rs
+++ b/crates/vx-resolver/tests/project_config_tests.rs
@@ -134,6 +134,31 @@ fn test_version_with_fallback_bundled() {
     assert_eq!(config.get_version_with_fallback("pnpm"), None);
 }
 
+#[rstest]
+#[case("rust", "1.95.0")]
+#[case("cargo", "1.95.0")]
+#[case("rustc", "stable")]
+#[case("rustfmt", "beta")]
+#[case("clippy", "nightly-2026-05-18")]
+fn test_rust_compiler_versions_are_toolchain_managed(#[case] tool: &str, #[case] version: &str) {
+    assert!(ProjectToolsConfig::is_toolchain_managed_runtime_version(
+        tool, version
+    ));
+}
+
+#[rstest]
+#[case("rust", "1.29.0")]
+#[case("rustup", "1.95.0")]
+#[case("node", "24.0.0")]
+fn test_non_rust_toolchain_versions_are_not_toolchain_managed(
+    #[case] tool: &str,
+    #[case] version: &str,
+) {
+    assert!(!ProjectToolsConfig::is_toolchain_managed_runtime_version(
+        tool, version
+    ));
+}
+
 // =============================================================================
 // Version Priority tests: vx.lock > vx.toml
 // =============================================================================


### PR DESCRIPTION
## Summary
- Treat Rust compiler/toolchain versions as rustup-managed when selecting vx store paths
- Avoid warning that a Rust toolchain version is missing from the rustup-versioned store
- Add regression coverage for Rust toolchain version detection

## Tests
- vx cargo fmt --all -- --check
- vx cargo test -p vx-resolver --test project_config_tests
- vx cargo test -p vx-resolver
- vx cargo clippy -p vx-resolver --all-targets -- -D warnings