### PR TITLE
fix: correct RFC count and update Rust version badge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 |-------------|-----------|
 | Understand what vx is | [What is vx? (below)](#what-is-vx) |
 | Learn architecture | [`docs/architecture/OVERVIEW.md`](docs/architecture/OVERVIEW.md) |
-| Read design decisions (RFCs) | [`docs/rfcs/`](docs/rfcs/) — 40+ RFCs |
+| Read design decisions (RFCs) | [`docs/rfcs/`](docs/rfcs/) — 50+ RFCs |
 | Add a new Provider (tool) | [`docs/guide/creating-provider.md`](docs/guide/creating-provider.md) |
 | Understand provider.star DSL | [`docs/guide/provider-star-reference.md`](docs/guide/provider-star-reference.md) |
 | Run CI tasks locally | [justfile](justfile) — `vx just --list` |
@@ -76,7 +76,7 @@ This entire flow is **automatic** — the user never needs to know about it.
 | If you need to…                    | Start here                                       |
 |-------------------------------------|--------------------------------------------------|
 | Understand the architecture          | [`docs/architecture/OVERVIEW.md`](docs/architecture/OVERVIEW.md) |
-| Read design decisions (RFCs)         | [`docs/rfcs/`](docs/rfcs/) — 40 RFCs             |
+| Read design decisions (RFCs)         | [`docs/rfcs/`](docs/rfcs/) — 50+ RFCs             |
 | Learn coding conventions             | [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md)     |
 | Add a new Provider (tool)            | [`docs/guide/creating-provider.md`](docs/guide/creating-provider.md) |
 | Understand provider.star DSL fully   | [`docs/guide/provider-star-reference.md`](docs/guide/provider-star-reference.md) |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [中文文档](README_zh.md) | [📖 Documentation](https://docs.rs/vx) | [🚀 Quick Start](#-quick-start) | [💡 Examples](#-real-world-examples)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Rust](https://img.shields.io/badge/rust-1.93+-blue.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.95.0+-blue.svg)](https://www.rust-lang.org)
 [![Test](https://github.com/loonghao/vx/workflows/Test/badge.svg)](https://github.com/loonghao/vx/actions)
 [![Release](https://github.com/loonghao/vx/workflows/Release/badge.svg)](https://github.com/loonghao/vx/actions)
 [![codecov](https://codecov.io/gh/loonghao/vx/branch/main/graph/badge.svg)](https://codecov.io/gh/loonghao/vx)


### PR DESCRIPTION
## What was done:

1. **Corrected RFC count** in `AGENTS.md` (2 locations):
   - Changed from `40+ RFCs` to `50+ RFCs` (actual count: 51 RFCs in `docs/rfcs/`)

2. **Updated Rust version badge** in `README.md`:
   - Changed from `1.93+` to `1.95.0+` (matches `Cargo.toml`)

## Changes:
- `AGENTS.md`: 2 locations updated (lines 15, 79)
- `README.md`: 1 location updated (line 12)

## Verification:
- [x] RFC count matches actual files in `docs/rfcs/` (51 files → `50+`)
- [x] Rust version matches `Cargo.toml` (`rust-version = "1.95.0"`)
- [x] No other outdated version references found in `llms.txt` or `llms-full.txt`
