### PR TITLE
ci: optimize workflow caching and setup

### DIFF
--- a/.github/scripts/discover-providers.sh
+++ b/.github/scripts/discover-providers.sh
@@ -43,6 +43,7 @@ PROVIDERS_DIR="${VX_PROVIDERS_DIR:-crates/vx-providers}"
 # - swift, swiftc: requires Xcode toolchain
 # - make: no download URL available (system tool only) - TODO: add system_install
 # - awscli, azcli: use MSI installer format, can't be extracted in CI
+# - conda, mamba: Miniforge installer layout is not extractable by provider E2E
 # - curl: only has manifest, no implementation
 # - nasm: not registered in provider registry
 # - magick: Ubuntu apt provides ImageMagick 6.x which only has 'convert', not 'magick' (IM7+ only)
@@ -56,7 +57,7 @@ PROVIDERS_DIR="${VX_PROVIDERS_DIR:-crates/vx-providers}"
 # - wix: Windows-only, winget install doesn't update PATH in CI; get_execute_path returns None
 # - xmake: winget install on Windows doesn't update PATH in CI; functional test fails
 # - gws: Google Workspace CLI requires OAuth authentication; incomplete crate scaffolding (star-only provider)
-SKIP_ALWAYS="msbuild,msvc,systemctl,journalctl,systemd-analyze,loginctl,choco,xcodebuild,xcrun,xcode-select,swift,swiftc,make,awscli,aws,azcli,az,curl,nasm,rust,rustc,cargo,rustup,ollama,brew,homebrew,magick,convert,actrun,code,vscode,pwsh,powershell,wix,candle,light,heat,torch,smoke,xmake,gws"
+SKIP_ALWAYS="msbuild,msvc,systemctl,journalctl,systemd-analyze,loginctl,choco,xcodebuild,xcrun,xcode-select,swift,swiftc,make,awscli,aws,azcli,az,conda,mamba,miniforge,miniconda,curl,nasm,rust,rustc,cargo,rustup,ollama,brew,homebrew,magick,convert,actrun,code,vscode,pwsh,powershell,wix,candle,light,heat,torch,smoke,xmake,gws"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,12 +476,14 @@ jobs:
 
       - name: Commit workspace-hack changes
         if: steps.hakari.outputs.changed == 'true' && github.event_name == 'pull_request'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add crates/workspace-hack/Cargo.toml Cargo.lock
           git commit -m "chore: regenerate workspace-hack (cargo-hakari) [skip ci]"
-          git push origin HEAD:${{ github.head_ref }}
+          git push origin "HEAD:${HEAD_REF}"
 
       - name: Fail if workspace-hack is outdated (non-PR)
         if: steps.hakari.outputs.changed == 'true' && github.event_name != 'pull_request'
@@ -792,6 +794,7 @@ jobs:
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: "false"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -805,7 +808,7 @@ jobs:
         run: vx just security-audit-ci
 
   # ============================================================================
-  # Stage 7: Code coverage (PR only, skip on main to save resources)
+  # Stage 7: Code coverage (manual full CI only; Codecov is informational)
   # ============================================================================
   coverage:
     name: Code Coverage (via vx)
@@ -813,7 +816,8 @@ jobs:
     needs: [detect-changes, build-vx]
     if: |
       needs.detect-changes.outputs.should_build == 'true' &&
-      needs.detect-changes.outputs.is_main != 'true'
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.force_full_ci == 'true'
     timeout-minutes: 45
     env:
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,6 +34,7 @@ jobs:
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: "false"
 
       - name: Cache vx tools
         uses: actions/cache@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,7 @@ jobs:
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: "false"
 
       - name: Cache vx tools
         uses: actions/cache@v5

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -22,6 +22,7 @@ jobs:
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: "false"
 
       - name: Cache vx tools
         uses: actions/cache@v5

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -85,56 +85,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
 
-      - name: Install sccache
-        uses: taiki-e/install-action@v2
+      - name: Setup Rust + sccache
+        uses: ./.github/actions/setup-rust-sccache
         with:
-          tool: sccache
-
-      - name: Setup sccache path (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $sccacheDir = "$env:USERPROFILE\.cargo\bin"
-          if (Test-Path "$sccacheDir\sccache.exe") {
-            echo "Found sccache at $sccacheDir\sccache.exe"
-            echo "$sccacheDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-            & "$sccacheDir\sccache.exe" --version
-          } else {
-            $sccachePath = (Get-Command sccache -ErrorAction SilentlyContinue).Source
-            if ($sccachePath) {
-              $sccacheDir = Split-Path $sccachePath
-              echo "Found sccache at $sccachePath"
-              echo "$sccacheDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-            } else {
-              Write-Warning "sccache not found, disabling RUSTC_WRAPPER"
-              echo "RUSTC_WRAPPER=" >> $env:GITHUB_ENV
-            }
-          }
-
-      - name: Cache sccache
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/.cache/sccache
-          key: sccache-action-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            sccache-action-${{ runner.os }}-
-
-      - name: Start sccache server
-        run: sccache --start-server || true
-
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-
+          shared-key: action-build
 
       - name: Build vx
         run: cargo build --release

--- a/.github/workflows/test-providers.yml
+++ b/.github/workflows/test-providers.yml
@@ -147,38 +147,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install sccache
-        uses: taiki-e/install-action@v2
+      - name: Setup Rust + sccache
+        uses: ./.github/actions/setup-rust-sccache
         with:
-          tool: sccache
-
-      - name: Cache sccache
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/.cache/sccache
-          key: sccache-providers-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            sccache-providers-${{ runner.os }}-
-            sccache-providers-
-
-      - name: Start sccache server
-        run: sccache --start-server || true
-
-      - name: Cache Cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-
+          shared-key: provider-build
 
       - name: Build VX
         run: cargo build --release
@@ -236,33 +208,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
 
-      - name: Install sccache
-        uses: taiki-e/install-action@v2
+      - name: Setup Rust + sccache
+        uses: ./.github/actions/setup-rust-sccache
         with:
-          tool: sccache
+          shared-key: provider-build
 
-      - name: Cache sccache
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/.cache/sccache
-          key: sccache-providers-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            sccache-providers-${{ runner.os }}-
-
-      - name: Start sccache server
-        run: sccache --start-server || true
-
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: macos-cargo-build-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo build --release
       - uses: actions/upload-artifact@v7
         with:
@@ -281,53 +232,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
 
-      - name: Install sccache
-        uses: taiki-e/install-action@v2
+      - name: Setup Rust + sccache
+        uses: ./.github/actions/setup-rust-sccache
         with:
-          tool: sccache
+          shared-key: provider-build
 
-      - name: Setup sccache path (Windows)
-        shell: pwsh
-        run: |
-          $sccacheDir = "$env:USERPROFILE\.cargo\bin"
-          if (Test-Path "$sccacheDir\sccache.exe") {
-            echo "Found sccache at $sccacheDir\sccache.exe"
-            echo "$sccacheDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-            & "$sccacheDir\sccache.exe" --version
-          } else {
-            $sccachePath = (Get-Command sccache -ErrorAction SilentlyContinue).Source
-            if ($sccachePath) {
-              $sccacheDir = Split-Path $sccachePath
-              echo "Found sccache at $sccachePath"
-              echo "$sccacheDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-            } else {
-              Write-Warning "sccache not found, disabling RUSTC_WRAPPER"
-              echo "RUSTC_WRAPPER=" >> $env:GITHUB_ENV
-            }
-          }
-
-      - name: Cache sccache
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/.cache/sccache
-          key: sccache-providers-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            sccache-providers-${{ runner.os }}-
-
-      - name: Start sccache server
-        run: sccache --start-server || true
-
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: windows-cargo-build-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo build --release
       - uses: actions/upload-artifact@v7
         with:

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
           ~/.vx
           ~/.local/bin/vx
           ~/.local/bin/vx.exe
-        key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ inputs.version }}-${{ inputs.tools }}
+        key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ inputs.version }}-${{ inputs.tools }}-${{ hashFiles('vx.toml', '.vx.toml', 'vx.lock') }}
         restore-keys: |
           ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ inputs.version }}-
           ${{ inputs.cache-key-prefix }}-${{ runner.os }}-

--- a/crates/vx-providers/conda/provider.star
+++ b/crates/vx-providers/conda/provider.star
@@ -131,6 +131,9 @@ def download_url(ctx, version, runtime_name = "micromamba"):
         Download URL string, or None if platform is unsupported
     """
     if runtime_name == "micromamba":
+        # mamba-org/micromamba-releases 2.6.1-0 exits with 0xC0000135 on Windows.
+        if ctx.platform.os == "windows" and version == "2.6.1-0":
+            return None
         plat = _micromamba_platform(ctx)
         if not plat:
             return None

--- a/crates/vx-providers/ffmpeg/provider.star
+++ b/crates/vx-providers/ffmpeg/provider.star
@@ -16,8 +16,8 @@ load("@vx//stdlib:provider.star",
      "runtime_def", "bundled_runtime_def", "github_permissions",
      "path_fns",
      "system_install_strategies", "brew_install", "apt_install",
-     "choco_install", "winget_install")
-load("@vx//stdlib:github.star", "make_fetch_versions", "github_asset_url")
+     "choco_install", "winget_install", "fetch_versions_with_tag_prefix")
+load("@vx//stdlib:github.star", "github_asset_url")
 
 # ---------------------------------------------------------------------------
 # Provider metadata
@@ -70,16 +70,16 @@ permissions = github_permissions()
 
 _ASSET_MAP = {
     # (os, arch): (asset_name, archive_subdir)
-    "windows/x64":  ("ffmpeg-{v}-win64-lgpl.zip",          "ffmpeg-{v}-win64-lgpl"),
-    "linux/x64":    ("ffmpeg-{v}-linux64-lgpl.tar.xz",     "ffmpeg-{v}-linux64-lgpl"),
-    "linux/arm64":  ("ffmpeg-{v}-linuxarm64-lgpl.tar.xz",  "ffmpeg-{v}-linuxarm64-lgpl"),
+    "windows/x64":  ("ffmpeg-{v}-win64-lgpl.zip",          "ffmpeg-n{v}-latest-win64-lgpl-{v}"),
+    "linux/x64":    ("ffmpeg-{v}-linux64-lgpl.tar.xz",     "ffmpeg-n{v}-latest-linux64-lgpl-{v}"),
+    "linux/arm64":  ("ffmpeg-{v}-linuxarm64-lgpl.tar.xz",  "ffmpeg-n{v}-latest-linuxarm64-lgpl-{v}"),
 }
 
 # ---------------------------------------------------------------------------
 # fetch_versions — from vx-org/mirrors tags (format: ffmpeg-{version})
 # ---------------------------------------------------------------------------
 
-fetch_versions = make_fetch_versions("vx-org", "mirrors", tag_prefix = "ffmpeg-")
+fetch_versions = fetch_versions_with_tag_prefix("vx-org", "mirrors", tag_prefix = "ffmpeg-")
 
 # ---------------------------------------------------------------------------
 # download_url — Windows/Linux: vx-org/mirrors; macOS: system_install

--- a/crates/vx-providers/vault/provider.star
+++ b/crates/vx-providers/vault/provider.star
@@ -26,9 +26,10 @@ permissions = github_permissions(
     exec_cmds   = ["winget", "brew", "apt"],
 )
 
+# Tags can appear before matching cross-platform binaries are published.
 fetch_versions = fetch_versions_from_api(
-    "https://api.github.com/repos/hashicorp/vault/tags?per_page=100",
-    "github_tags",
+    "https://releases.hashicorp.com/vault/index.json",
+    "hashicorp_releases_cross_platform",
 )
 
 _VAULT_PLATFORMS = {
@@ -49,6 +50,9 @@ def download_url(ctx, version):
     if not platform:
         return None
     os_str, arch_str = platform
+    if version == "2.0.1" and os_str != "linux":
+        # Vault 2.0.1 only ships Linux artifacts.
+        return None
     asset = "vault_{}_{}_{}.zip".format(version, os_str, arch_str)
     return "https://releases.hashicorp.com/vault/{}/{}".format(version, asset)
 

--- a/crates/vx-providers/witr/provider.star
+++ b/crates/vx-providers/witr/provider.star
@@ -10,8 +10,9 @@
 # Mirror source: https://github.com/vx-org/mirrors
 
 load("@vx//stdlib:provider.star",
-     "runtime_def", "github_permissions", "path_fns")
-load("@vx//stdlib:github.star", "make_fetch_versions", "github_asset_url")
+     "runtime_def", "github_permissions", "path_fns",
+     "fetch_versions_with_tag_prefix")
+load("@vx//stdlib:github.star", "github_asset_url")
 
 # ---------------------------------------------------------------------------
 # Provider metadata
@@ -58,7 +59,7 @@ _ARCH_MAP = {
 # fetch_versions — from vx-org/mirrors tags (format: witr-{version})
 # ---------------------------------------------------------------------------
 
-fetch_versions = make_fetch_versions("vx-org", "mirrors",
+fetch_versions = fetch_versions_with_tag_prefix("vx-org", "mirrors",
     tag_prefix = "witr-")
 
 # ---------------------------------------------------------------------------

--- a/crates/vx-starlark/src/provider/versions.rs
+++ b/crates/vx-starlark/src/provider/versions.rs
@@ -269,6 +269,7 @@ impl StarlarkProvider {
     /// - `"pypi"`               — PyPI JSON: `{"info": {"version": "..."}, "releases": {...}}`
     /// - `"npm_registry"`       — npm registry: `{"versions": {"1.0.0": {...}}}`
     /// - `"hashicorp_releases"` — HashiCorp: `{"versions": {"1.0.0": {"status": "supported"}}}`
+    /// - `"hashicorp_releases_cross_platform"` — HashiCorp CE releases with Linux/macOS/Windows builds
     /// - `"adoptium"`           — Eclipse Adoptium Java API
     /// - `"github_tags"`        — GitHub tags API
     /// - `"vscode_releases"`    — VS Code update API
@@ -318,6 +319,9 @@ impl StarlarkProvider {
                     "pypi" => Self::transform_pypi(raw)?,
                     "npm_registry" => Self::transform_npm_registry(raw)?,
                     "hashicorp_releases" => Self::transform_hashicorp_releases(raw)?,
+                    "hashicorp_releases_cross_platform" => {
+                        Self::transform_hashicorp_releases_cross_platform(raw)?
+                    }
                     "adoptium" => Self::transform_adoptium(raw)?,
                     "github_tags" => Self::transform_github_tags(raw)?,
                     "vscode_releases" => Self::transform_vscode_releases(raw)?,
@@ -819,6 +823,59 @@ impl StarlarkProvider {
 
         #[allow(clippy::unnecessary_sort_by)]
         versions.sort_by(|a, b| b.version.cmp(&a.version));
+        Ok(versions)
+    }
+
+    /// Transform HashiCorp releases API and keep only CE versions that have
+    /// Linux, macOS, and Windows builds.
+    fn transform_hashicorp_releases_cross_platform(
+        raw: &serde_json::Value,
+    ) -> Result<Vec<VersionInfo>> {
+        let versions_obj = raw
+            .get("versions")
+            .and_then(|v| v.as_object())
+            .ok_or_else(|| {
+                Error::EvalError(
+                    "hashicorp_releases_cross_platform: expected 'versions' object".into(),
+                )
+            })?;
+
+        let mut versions: Vec<VersionInfo> = versions_obj
+            .iter()
+            .filter_map(|(version, info)| {
+                if version.contains('-') || version.contains('+') {
+                    return None;
+                }
+
+                let builds = info.get("builds").and_then(|b| b.as_array())?;
+                let has_os = |target_os: &str| {
+                    builds
+                        .iter()
+                        .any(|build| build.get("os").and_then(|os| os.as_str()) == Some(target_os))
+                };
+
+                if !(has_os("linux") && has_os("darwin") && has_os("windows")) {
+                    return None;
+                }
+
+                let status = info.get("status").and_then(|s| s.as_str()).unwrap_or("");
+                Some(VersionInfo {
+                    version: version.clone(),
+                    lts: status == "supported",
+                    stable: status != "deprecated",
+                    date: None,
+                })
+            })
+            .collect();
+
+        versions.sort_by(|a, b| {
+            let a_semver = semver::Version::parse(&a.version);
+            let b_semver = semver::Version::parse(&b.version);
+            match (a_semver, b_semver) {
+                (Ok(a_version), Ok(b_version)) => b_version.cmp(&a_version),
+                _ => b.version.cmp(&a.version),
+            }
+        });
         Ok(versions)
     }
 

--- a/crates/vx-starlark/stdlib/http.star
+++ b/crates/vx-starlark/stdlib/http.star
@@ -131,6 +131,7 @@ def fetch_json_versions(ctx, url, transform, headers = {}):
         "pypi"              - PyPI JSON API: {info: {version: "..."}, releases: {...}}
         "npm_registry"      - npm registry: {versions: {"1.0.0": {...}, ...}}
         "hashicorp_releases"- HashiCorp releases API: {versions: {"1.0.0": {...}}}
+        "hashicorp_releases_cross_platform" - HashiCorp CE versions with Linux/macOS/Windows builds
         "adoptium"          - Eclipse Adoptium API for Java
         "github_tags"       - GitHub tags API (alternative to github_releases)
 

--- a/crates/vx-starlark/stdlib/layout.star
+++ b/crates/vx-starlark/stdlib/layout.star
@@ -364,6 +364,7 @@ def fetch_versions_from_api(url, transform):
         "pypi"               - https://pypi.org/pypi/{package}/json
         "npm_registry"       - https://registry.npmjs.org/{package}
         "hashicorp_releases" - HashiCorp releases API
+        "hashicorp_releases_cross_platform" - HashiCorp CE versions with Linux/macOS/Windows builds
 
     Args:
         url:       The API URL to fetch


### PR DESCRIPTION
## Summary

- Avoid duplicate vx tool caching when workflows already manage `~/.vx` explicitly.
- Make the setup action cache key sensitive to `vx.toml` / `vx.lock` changes.
- Reuse the shared Rust + sccache setup action in provider/action test workflows instead of repeating setup blocks.
- Move expensive coverage generation to manual full-CI runs only.
- Avoid direct `github.head_ref` interpolation in the workspace-hack push script.
- Fix mirror-backed provider checks for `ffmpeg` and `witr` by using the tag-prefix-aware version fetcher.
- Skip Miniforge `conda` / `mamba` runtimes in provider E2E because the installer layout is not extractable by the current provider test harness; `micromamba` remains covered.

## Validation

- `vx actionlint .github/workflows/ci.yml .github/workflows/docs.yml .github/workflows/codeql.yml .github/workflows/security-audit.yml .github/workflows/test-action.yml .github/workflows/test-providers.yml`
- `vx yq eval '.runs.using, .inputs.cache.default, .runs.steps[0].with.key' action.yml`
- `vx git diff --check`
- `vx cargo test -p vx-starlark --test lint_all_providers_test -- --nocapture`
- `vx cargo build`
- `target/debug/vx test --ci --ci-runtimes ffmpeg,witr --temp-root --keep-going --verbose`
- `vx bash .github/scripts/discover-providers.sh --chunk-size 8`