### PR TITLE
docs: update version to v0.8.37

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@
 
 ## What is vx?
 
-vx is a **zero-config universal development tool manager** (v0.8.36, MIT-licensed, written in Rust). Users prefix any command with `vx` (e.g., `vx node --version`, `vx cargo build`) and vx automatically installs, manages, and forwards to the correct tool version. vx currently ships **137 providers** covering language runtimes, build tools, DevOps CLIs, cloud platforms, and more — all defined via Starlark DSL (`provider.star`).
+vx is a **zero-config universal development tool manager** (v0.8.37, MIT-licensed, written in Rust). Users prefix any command with `vx` (e.g., `vx node --version`, `vx cargo build`) and vx automatically installs, manages, and forwards to the correct tool version. vx currently ships **137 providers** covering language runtimes, build tools, DevOps CLIs, cloud platforms, and more — all defined via Starlark DSL (`provider.star`).
 
 **Key insight for agents**: vx is a transparent proxy. The user writes the exact same commands they already know — just prepended with `vx`. There is **no new syntax to learn** for tool execution.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4433,7 +4433,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "indexmap",
  "regex",
@@ -4463,7 +4463,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4488,7 +4488,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4552,7 +4552,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4595,7 +4595,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4613,7 +4613,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "colored",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4657,7 +4657,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4731,7 +4731,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4753,14 +4753,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-output-filter"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "regex",
@@ -4774,7 +4774,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4793,7 +4793,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4818,7 +4818,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4852,7 +4852,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "flate2",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4968,7 +4968,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "serde",
@@ -4986,11 +4986,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.8.36"
+version = "0.8.37"
 
 [[package]]
 name = "vx-starlark"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5043,7 +5043,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5061,7 +5061,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ Use vx in your CI/CD workflows:
 - run: vx npm test
 ```
 
-> **Note**: Use `@main` for latest, or pin to a specific release tag (e.g., `@vx-v0.8.36`). Check [releases](https://github.com/loonghao/vx/releases) for the latest version.
+> **Note**: Use `@main` for latest, or pin to a specific release tag (e.g., `@vx-v0.8.37`). Check [releases](https://github.com/loonghao/vx/releases) for the latest version.
 
 See [GitHub Action Guide](docs/guides/github-action.md) for full documentation.
 


### PR DESCRIPTION
Update outdated version numbers in documentation.

## Changes
- Updated version from v0.8.36 to v0.8.37 in AGENTS.md
- Updated version from v0.8.36 to v0.8.37 in README.md

## Checklist
- [x] Documentation is accurate
- [x] Version numbers are consistent
- [x] Ready for CI

This PR updates the version references to match the latest release v0.8.37.