### PR TITLE
fix: avoid msvc repair for unrelated commands

### DIFF
--- a/crates/vx-resolver/src/executor/environment.rs
+++ b/crates/vx-resolver/src/executor/environment.rs
@@ -8,7 +8,7 @@
 use crate::{Resolver, ResolverConfig, Result};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, trace, warn};
 use vx_runtime::{ProviderRegistry, RuntimeContext};
 
 use super::bin_dir_cache;
@@ -446,19 +446,23 @@ impl<'a> EnvironmentManager<'a> {
             }
         }
 
-        // Inject companion tools' prepare_environment() from vx.toml
+        // Inject companion tools' prepare_environment() from vx.toml when they
+        // are already available.
         //
-        // When vx.toml specifies tools like [tools.msvc], ALL other tool executions
-        // (vx node, vx cmake, vx cargo, vx dotnet, etc.) will have MSVC's marker
-        // environment variables (VCINSTALLDIR, VCToolsInstallDir, VX_MSVC_*, etc.)
-        // injected. This enables any tool that needs a C/C++ compiler to discover
-        // the vx-managed MSVC installation — including node-gyp, cmake, meson,
-        // cargo (for C dependencies via cc crate), dotnet native AOT, etc.
+        // When vx.toml specifies tools like [tools.msvc], other executions can
+        // have MSVC's marker environment variables (VCINSTALLDIR,
+        // VCToolsInstallDir, VX_MSVC_*, etc.) injected. This enables tools that
+        // need a C/C++ compiler to discover an existing vx-managed MSVC
+        // installation.
         //
         // This only calls prepare_environment() (not execution_environment()), so it
         // injects discovery/marker variables without polluting LIB/INCLUDE/PATH.
+        // It must not install or repair companions while preparing an unrelated
+        // command: a successful `vx git --version` should not emit MSVC repair
+        // failures just because the project declares msvc.
         //
         // See: https://github.com/loonghao/vx/issues/573
+        // See: https://github.com/loonghao/vx/issues/889
         if let Some(project_config) = self.project_config {
             let companion_tools = project_config.get_companion_tools(runtime_name);
             debug!(
@@ -481,7 +485,10 @@ impl<'a> EnvironmentManager<'a> {
                     }
                 };
 
-                // Check if the companion tool is installed
+                // Check if the companion tool is installed. Environment
+                // preparation is intentionally side-effect-free for companions:
+                // missing or broken companions are skipped instead of
+                // auto-installed/repaired here.
                 let companion_installed_version = match companion_runtime
                     .installed_versions(context)
                     .await
@@ -499,120 +506,39 @@ impl<'a> EnvironmentManager<'a> {
                             .find_matching_version(companion_name, companion_version, &versions)
                             .unwrap_or_else(|| versions[0].clone());
 
-                        // Check if the companion tool has component requirements (e.g., MSVC Spectre)
-                        // that might be missing from the existing installation.
-                        // If so, go through ensure_version_installed to trigger component installation.
-                        let has_components = self
+                        // Component requirements (for example MSVC Spectre) are
+                        // honored when the companion is installed explicitly or
+                        // invoked directly. Do not repair them from the
+                        // unrelated command's environment preparation path.
+                        let has_install_options = self
                             .project_config
                             .and_then(|pc| {
                                 pc.get_install_options(companion_name)
-                                    .map(|opts| opts.contains_key("VX_MSVC_COMPONENTS"))
+                                    .map(|opts| !opts.is_empty())
                             })
                             .unwrap_or(false);
 
-                        if has_components {
-                            // Fast-path: check if component installation was already attempted.
-                            // If so, skip the expensive ensure_version_installed call entirely.
-                            // The marker file is written by MsvcRuntime::install() after the
-                            // first installation attempt, preventing repeated downloads/extractions.
-                            let component_already_attempted = self
-                                .context
-                                .map(|ctx| {
-                                    let store_dir = ctx
-                                        .paths
-                                        .version_store_dir(companion_name, &matched_version);
-                                    store_dir.join(".component-install-attempted").exists()
-                                })
-                                .unwrap_or(false);
-
-                            if component_already_attempted {
-                                debug!(
-                                    "Companion {} component installation already attempted, skipping integrity check",
-                                    companion_name
-                                );
-                                matched_version
-                            } else {
-                                debug!(
-                                    "Companion {} has component requirements, verifying installation integrity...",
-                                    companion_name
-                                );
-                                let mut install_mgr = super::installation::InstallationManager::new(
-                                    self.config,
-                                    self.resolver,
-                                    self.registry,
-                                    self.context,
-                                );
-                                if let Some(project_config) = self.project_config {
-                                    install_mgr = install_mgr.with_project_config(project_config);
-                                }
-                                match install_mgr
-                                    .ensure_version_installed(companion_name, &matched_version)
-                                    .await
-                                {
-                                    Ok(Some(result)) => {
-                                        debug!(
-                                            "Companion {} component check complete (version: {})",
-                                            companion_name, result.version
-                                        );
-                                        result.version
-                                    }
-                                    Ok(None) => matched_version,
-                                    Err(e) => {
-                                        warn!(
-                                            "Failed to verify companion {} components: {}",
-                                            companion_name, e
-                                        );
-                                        matched_version
-                                    }
-                                }
-                            }
-                        } else {
-                            matched_version
+                        if has_install_options {
+                            debug!(
+                                "Companion {} has install options; deferring install/repair until it is invoked directly",
+                                companion_name
+                            );
                         }
+                        matched_version
                     }
-                    Ok(_) | Err(_) => {
-                        // Companion not installed — try auto-install
-                        info!(
-                            "Companion {} is not installed. Auto-installing {}@{} ...",
-                            companion_name, companion_name, companion_version
+                    Ok(_) => {
+                        debug!(
+                            "Companion {} is not installed; skipping environment injection for primary {}",
+                            companion_name, runtime_name
                         );
-                        let mut install_mgr = super::installation::InstallationManager::new(
-                            self.config,
-                            self.resolver,
-                            self.registry,
-                            self.context,
+                        continue;
+                    }
+                    Err(e) => {
+                        debug!(
+                            "Could not inspect companion {} installation state: {}; skipping environment injection for primary {}",
+                            companion_name, e, runtime_name
                         );
-                        // Pass project_config so install_options (e.g., MSVC components)
-                        // from vx.toml are injected into RuntimeContext during installation
-                        if let Some(project_config) = self.project_config {
-                            install_mgr = install_mgr.with_project_config(project_config);
-                        }
-                        // Use ensure_version_installed which goes through the unified
-                        // version resolution path (runtime.resolve_version()), checks
-                        // if already installed, and returns a consistent version string.
-                        match install_mgr
-                            .ensure_version_installed(companion_name, companion_version)
-                            .await
-                        {
-                            Ok(Some(result)) => {
-                                info!(
-                                    "Auto-installed companion {}@{}",
-                                    companion_name, result.version
-                                );
-                                result.version
-                            }
-                            Ok(None) => {
-                                debug!(
-                                    "  Companion {} could not be installed (no registry/context), skipping",
-                                    companion_name
-                                );
-                                continue;
-                            }
-                            Err(e) => {
-                                warn!("Failed to auto-install companion {}: {}", companion_name, e);
-                                continue;
-                            }
-                        }
+                        continue;
                     }
                 };
 

--- a/crates/vx-resolver/src/executor/project_config.rs
+++ b/crates/vx-resolver/src/executor/project_config.rs
@@ -58,6 +58,18 @@ impl ProjectToolsConfig {
         }
     }
 
+    /// Create a ProjectToolsConfig with install options (for testing)
+    pub fn from_tools_with_install_options(
+        tools: HashMap<String, String>,
+        tool_install_options: HashMap<String, InstallEnvVars>,
+    ) -> Self {
+        Self {
+            tools,
+            locked_tools: HashMap::new(),
+            tool_install_options,
+        }
+    }
+
     /// Load project configuration from vx.toml and vx.lock in current directory or parent directories
     ///
     /// This loads both files from the same directory where vx.toml is found.

--- a/crates/vx-resolver/tests/prepare_stage_tests.rs
+++ b/crates/vx-resolver/tests/prepare_stage_tests.rs
@@ -1,20 +1,24 @@
 //! Tests for PrepareStage proxy execution fallback behavior.
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 
 use anyhow::Result;
 use async_trait::async_trait;
 use tempfile::tempdir;
 use vx_manifest::ProviderManifest;
 use vx_resolver::{
-    ExecutionConfig, ExecutionPlan, PlannedRuntime, PrepareStage, Resolver, ResolverConfig,
-    RuntimeMap, Stage,
+    ExecutionConfig, ExecutionPlan, PlannedRuntime, PrepareStage, ProjectToolsConfig, Resolver,
+    ResolverConfig, RuntimeMap, Stage,
 };
 use vx_runtime::{
-    ExecutionContext, ExecutionPrep, Provider, ProviderRegistry, Runtime, RuntimeContext,
-    VersionInfo,
+    ExecutionContext, ExecutionPrep, InstallResult, Provider, ProviderRegistry, Runtime,
+    RuntimeContext, VersionInfo, mock_context,
 };
 
 struct BundledRuntime {
@@ -44,6 +48,54 @@ impl Runtime for BundledRuntime {
         Ok(ExecutionPrep::proxy_ready()
             .with_prefix("tool")
             .with_prefix("run"))
+    }
+}
+
+struct CountingRuntime {
+    name: &'static str,
+    executable: &'static str,
+    installed_versions: Vec<String>,
+    install_count: Arc<AtomicUsize>,
+    prepare_count: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Runtime for CountingRuntime {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn executable_name(&self) -> &str {
+        self.executable
+    }
+
+    async fn fetch_versions(&self, _ctx: &RuntimeContext) -> Result<Vec<VersionInfo>> {
+        Ok(vec![VersionInfo::new("system")])
+    }
+
+    async fn installed_versions(&self, _ctx: &RuntimeContext) -> Result<Vec<String>> {
+        Ok(self.installed_versions.clone())
+    }
+
+    async fn install(&self, version: &str, _ctx: &RuntimeContext) -> Result<InstallResult> {
+        self.install_count.fetch_add(1, Ordering::SeqCst);
+        Ok(InstallResult::success(
+            PathBuf::from("unused-install"),
+            PathBuf::from("unused-executable"),
+            version.to_string(),
+        ))
+    }
+
+    async fn prepare_environment(
+        &self,
+        version: &str,
+        _ctx: &RuntimeContext,
+    ) -> Result<HashMap<String, String>> {
+        self.prepare_count.fetch_add(1, Ordering::SeqCst);
+        Ok(HashMap::from([(
+            "VX_COMPANION_MARKER".to_string(),
+            version.to_string(),
+        )]))
     }
 }
 
@@ -138,4 +190,97 @@ async fn prepare_stage_uses_runtime_executable_name_for_system_path_fallback() {
 
     assert_eq!(prepared.executable, mock_executable);
     assert_eq!(prepared.command_prefix, vec!["tool", "run"]);
+}
+
+#[tokio::test]
+async fn prepare_stage_skips_missing_companion_without_auto_installing() {
+    let config = ResolverConfig::default();
+    let runtime_map = RuntimeMap::empty();
+    let resolver = Resolver::new(config.clone(), runtime_map).expect("resolver should build");
+    let registry = ProviderRegistry::new();
+    let context = mock_context();
+    let install_count = Arc::new(AtomicUsize::new(0));
+    let prepare_count = Arc::new(AtomicUsize::new(0));
+
+    registry.register(Arc::new(TestProvider {
+        runtimes: vec![
+            Arc::new(BundledRuntime {
+                name: "git",
+                executable: "git",
+            }),
+            Arc::new(CountingRuntime {
+                name: "msvc",
+                executable: "cl",
+                installed_versions: Vec::new(),
+                install_count: install_count.clone(),
+                prepare_count: prepare_count.clone(),
+            }),
+        ],
+    }));
+
+    let project_config =
+        ProjectToolsConfig::from_tools(HashMap::from([("msvc".to_string(), "14.42".to_string())]));
+    let stage = PrepareStage::new(&resolver, &config, Some(&registry), Some(&context))
+        .with_project_config(&project_config);
+    let plan = ExecutionPlan::new(
+        PlannedRuntime::installed("git", "2.51.0".to_string(), PathBuf::from("/usr/bin/git")),
+        ExecutionConfig::default(),
+    );
+
+    let prepared = stage
+        .execute(plan)
+        .await
+        .expect("missing companion should not fail unrelated command preparation");
+
+    assert_eq!(install_count.load(Ordering::SeqCst), 0);
+    assert_eq!(prepare_count.load(Ordering::SeqCst), 0);
+    assert!(!prepared.env.contains_key("VX_COMPANION_MARKER"));
+}
+
+#[tokio::test]
+async fn prepare_stage_injects_already_installed_companion_environment() {
+    let config = ResolverConfig::default();
+    let runtime_map = RuntimeMap::empty();
+    let resolver = Resolver::new(config.clone(), runtime_map).expect("resolver should build");
+    let registry = ProviderRegistry::new();
+    let context = mock_context();
+    let install_count = Arc::new(AtomicUsize::new(0));
+    let prepare_count = Arc::new(AtomicUsize::new(0));
+
+    registry.register(Arc::new(TestProvider {
+        runtimes: vec![
+            Arc::new(BundledRuntime {
+                name: "git",
+                executable: "git",
+            }),
+            Arc::new(CountingRuntime {
+                name: "msvc",
+                executable: "cl",
+                installed_versions: vec!["system".to_string()],
+                install_count: install_count.clone(),
+                prepare_count: prepare_count.clone(),
+            }),
+        ],
+    }));
+
+    let project_config =
+        ProjectToolsConfig::from_tools(HashMap::from([("msvc".to_string(), "14.42".to_string())]));
+    let stage = PrepareStage::new(&resolver, &config, Some(&registry), Some(&context))
+        .with_project_config(&project_config);
+    let plan = ExecutionPlan::new(
+        PlannedRuntime::installed("git", "2.51.0".to_string(), PathBuf::from("/usr/bin/git")),
+        ExecutionConfig::default(),
+    );
+
+    let prepared = stage
+        .execute(plan)
+        .await
+        .expect("installed companion should inject environment");
+
+    assert_eq!(install_count.load(Ordering::SeqCst), 0);
+    assert_eq!(prepare_count.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        prepared.env.get("VX_COMPANION_MARKER").map(String::as_str),
+        Some("system")
+    );
 }

--- a/crates/vx-resolver/tests/prepare_stage_tests.rs
+++ b/crates/vx-resolver/tests/prepare_stage_tests.rs
@@ -8,7 +8,7 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
 };
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use tempfile::tempdir;
 use vx_manifest::ProviderManifest;
@@ -55,6 +55,7 @@ struct CountingRuntime {
     name: &'static str,
     executable: &'static str,
     installed_versions: Vec<String>,
+    installed_error: Option<&'static str>,
     install_count: Arc<AtomicUsize>,
     prepare_count: Arc<AtomicUsize>,
 }
@@ -74,6 +75,9 @@ impl Runtime for CountingRuntime {
     }
 
     async fn installed_versions(&self, _ctx: &RuntimeContext) -> Result<Vec<String>> {
+        if let Some(message) = self.installed_error {
+            return Err(anyhow!(message));
+        }
         Ok(self.installed_versions.clone())
     }
 
@@ -212,6 +216,7 @@ async fn prepare_stage_skips_missing_companion_without_auto_installing() {
                 name: "msvc",
                 executable: "cl",
                 installed_versions: Vec::new(),
+                installed_error: None,
                 install_count: install_count.clone(),
                 prepare_count: prepare_count.clone(),
             }),
@@ -257,6 +262,7 @@ async fn prepare_stage_injects_already_installed_companion_environment() {
                 name: "msvc",
                 executable: "cl",
                 installed_versions: vec!["system".to_string()],
+                installed_error: None,
                 install_count: install_count.clone(),
                 prepare_count: prepare_count.clone(),
             }),
@@ -283,4 +289,55 @@ async fn prepare_stage_injects_already_installed_companion_environment() {
         prepared.env.get("VX_COMPANION_MARKER").map(String::as_str),
         Some("system")
     );
+}
+
+#[tokio::test]
+async fn prepare_stage_skips_broken_companion_with_install_options_without_repairing() {
+    let config = ResolverConfig::default();
+    let runtime_map = RuntimeMap::empty();
+    let resolver = Resolver::new(config.clone(), runtime_map).expect("resolver should build");
+    let registry = ProviderRegistry::new();
+    let context = mock_context();
+    let install_count = Arc::new(AtomicUsize::new(0));
+    let prepare_count = Arc::new(AtomicUsize::new(0));
+
+    registry.register(Arc::new(TestProvider {
+        runtimes: vec![
+            Arc::new(BundledRuntime {
+                name: "git",
+                executable: "git",
+            }),
+            Arc::new(CountingRuntime {
+                name: "msvc",
+                executable: "cl",
+                installed_versions: Vec::new(),
+                installed_error: Some("msvc system directory exists but executable not found"),
+                install_count: install_count.clone(),
+                prepare_count: prepare_count.clone(),
+            }),
+        ],
+    }));
+
+    let project_config = ProjectToolsConfig::from_tools_with_install_options(
+        HashMap::from([("msvc".to_string(), "14.42".to_string())]),
+        HashMap::from([(
+            "msvc".to_string(),
+            HashMap::from([("VX_MSVC_COMPONENTS".to_string(), "spectre".to_string())]),
+        )]),
+    );
+    let stage = PrepareStage::new(&resolver, &config, Some(&registry), Some(&context))
+        .with_project_config(&project_config);
+    let plan = ExecutionPlan::new(
+        PlannedRuntime::installed("git", "2.51.0".to_string(), PathBuf::from("/usr/bin/git")),
+        ExecutionConfig::default(),
+    );
+
+    let prepared = stage
+        .execute(plan)
+        .await
+        .expect("broken companion should not fail unrelated command preparation");
+
+    assert_eq!(install_count.load(Ordering::SeqCst), 0);
+    assert_eq!(prepare_count.load(Ordering::SeqCst), 0);
+    assert!(!prepared.env.contains_key("VX_COMPANION_MARKER"));
 }

--- a/docs/cli/self-update.md
+++ b/docs/cli/self-update.md
@@ -70,4 +70,4 @@ export VX_NO_UPDATE_CHECK=1
 
 - [`overview`](./overview) - CLI overview
 - [`install`](./install) - Install tools
-- [`version`](../commands) - Show vx version
+- [`version`](./commands#version) - Show vx version

--- a/docs/tools/build-tools.md
+++ b/docs/tools/build-tools.md
@@ -146,10 +146,15 @@ sdk_version = "10.0.22621"
 
 **Using MSVC with other tools (companion tool injection):**
 
-When `vx.toml` includes MSVC, vx automatically injects MSVC discovery environment variables
-(`VCINSTALLDIR`, `VCToolsInstallDir`, `GYP_MSVS_VERSION`, etc.) into **all** subprocess
-environments — not just MSVC tools. This allows any tool that needs a C/C++ compiler to
-discover the vx-managed MSVC installation without a full Visual Studio installation.
+When `vx.toml` includes MSVC and the MSVC companion runtime is already installed/available,
+vx injects MSVC discovery environment variables (`VCINSTALLDIR`, `VCToolsInstallDir`,
+`GYP_MSVS_VERSION`, etc.) into subprocess environments, not just MSVC tools. This allows
+tools that need a C/C++ compiler to discover the vx-managed MSVC installation without a
+full Visual Studio installation.
+
+If MSVC is missing or the existing installation needs repair, unrelated commands skip this
+companion injection instead of installing or repairing MSVC during command startup. Run
+`vx setup` or `vx install msvc@14.42` first when those discovery variables are required.
 
 Supported scenarios include:
 - **node-gyp** / **Electron**: `vx npx node-gyp rebuild`
@@ -159,7 +164,7 @@ Supported scenarios include:
 - **Meson**: `vx meson setup build`
 
 ```toml
-# vx.toml — MSVC env vars are injected for ALL tools listed here
+# vx.toml - MSVC env vars are injected when the companion is installed
 [tools]
 node = "22"
 cmake = "3.28"
@@ -180,17 +185,18 @@ vx cmake -B build -G "Ninja"
 # Cargo cc crate finds MSVC for C dependencies
 vx cargo build
 
-# Verify environment variables are set from any tool
+# After vx setup or vx install msvc@14.42, verify the variables from any tool
 vx node -e "console.log('VCINSTALLDIR:', process.env.VCINSTALLDIR)"
-# Output: VCINSTALLDIR: C:\Users\you\.vx\store\msvc\14.42\VC\
+# Output when MSVC is available: VCINSTALLDIR: C:\Users\you\.vx\store\msvc\14.42\VC\
 ```
 
 **How companion tool injection works:**
 
 vx uses a "companion tools" mechanism: when executing any tool (e.g., `vx node`, `vx cmake`),
-vx also calls `prepare_environment()` for all other tools defined in `vx.toml`.
-This injects discovery/marker environment variables without polluting the full
-compilation environment (LIB/INCLUDE/PATH).
+vx also calls `prepare_environment()` for available companion tools defined in `vx.toml`.
+This injects discovery/marker environment variables without polluting the full compilation
+environment (LIB/INCLUDE/PATH). Missing or broken companions are skipped for unrelated
+commands; install or repair them explicitly with `vx setup` or `vx install msvc@14.42`.
 
 Environment variables injected by MSVC companion:
 

--- a/docs/tools/worktrunk.md
+++ b/docs/tools/worktrunk.md
@@ -144,5 +144,5 @@ auto_cleanup = true
 
 ## Related
 
-- [`AGENTS.md`](../AGENTS) - Multi-Agent Development section
+- [`AGENTS.md`](https://github.com/loonghao/vx/blob/main/AGENTS.md#multi-agent-development-vx-wt) - Multi-Agent Development section
 - [Git Worktree Documentation](https://git-scm.com/docs/git-worktree)


### PR DESCRIPTION
## Summary
- make companion runtime environment preparation side-effect-free for unrelated commands
- skip missing or broken companions instead of auto-installing or repairing them during prepare
- add regression coverage for missing and already-installed companions

## Validation
- vx cargo test -p vx-resolver
- vx cargo build -p vx
- local smoke: temp project with msvc in vx.toml + target/debug/vx.exe git --version

Closes #889