### PR TITLE
feat: track output token savings

### DIFF
--- a/.agents/skills/vx-best-practices/SKILL.md
+++ b/.agents/skills/vx-best-practices/SKILL.md
@@ -46,6 +46,29 @@ git add vx.lock
 git commit -m "chore: update dependencies"
 ```
 
+### 4. Keep Agent Work Small and Observable
+
+When an AI agent uses vx, optimize for correctness, speed, judgment, and token
+efficiency:
+
+- Read enough surrounding code to understand the local pattern, then stop exploring.
+- Prefer targeted searches, focused file sections, scoped diffs, selected JSON fields, and capped logs.
+- Make the smallest maintainable change that solves the request.
+- Reuse existing project helpers before creating new abstractions.
+- Avoid single-use wrappers, speculative architecture, and unrelated cleanup.
+- Validate according to risk: focused tests for narrow changes, broader checks for shared behavior.
+- Preserve evidence from the actual command, CI job, or runtime surface when debugging.
+
+For large or unknown output, scope first and filter through vx-managed tools:
+
+```bash
+vx rg -n -m 20 "SearchTerm" src
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx gh pr view 123 --json title,state,files
+vx gh run view 456 --log | vx rg -n -m 50 "error|failed|panic"
+```
+
 ## Project Setup
 
 ### Initial Setup

--- a/.agents/skills/vx-commands/SKILL.md
+++ b/.agents/skills/vx-commands/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: vx-commands
-description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --output-format toon for token-optimized output."
 ---
 
 # VX Command Reference
 
-> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+> **Quick rule**: All vx commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
 
 ## Structured Output Commands (AI-Optimized)
 
-All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+All commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens).
 
 ### Project Analysis
 
@@ -108,7 +108,7 @@ vx list --json
 
 ### TOON Format (Token-Optimized)
 ```bash
-vx list --format toon
+vx list --output-format toon
 # Output:
 # runtimes[50]{name,installed,description}:
 #   node,true,Node.js runtime
@@ -190,7 +190,7 @@ vx cache clean              # Clean cache
 
 ```bash
 --json                      # JSON output
---format <text|json|toon>   # Output format
+--output-format <text|json|toon>   # Output format
 --verbose                   # Verbose output
 --debug                     # Debug output
 --use-system-path           # Use system PATH

--- a/.agents/skills/vx-usage/SKILL.md
+++ b/.agents/skills/vx-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vx-usage
-description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 105 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, Git/GitHub operations, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 137 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
 ---
 
 # VX - Universal Development Tool Manager
@@ -36,7 +36,101 @@ vx npx create-react-app app   # Run npx
 vx cargo test                 # Run cargo
 vx just build                 # Run just (task runner)
 vx git status                 # Run git
+vx gh pr status               # Run GitHub CLI
 ```
+
+### Git and GitHub for Codex
+
+When Codex or another AI agent works in a vx-managed repository, use vx-managed
+Git and GitHub CLI commands. Do not run bare `git` or bare `gh`.
+
+```bash
+vx git status --short --branch
+vx git fetch origin main
+vx git checkout -B fix/example origin/main
+vx git diff --stat
+vx git add path/to/file
+vx git commit -m "fix: example"
+
+vx gh issue view 123
+vx gh pr view 456 --json title,state,headRefName
+vx gh pr checks 456
+vx gh run view 789 --log
+```
+
+### Token-Efficient Agent Workflows
+
+vx is not just an installation wrapper. For agents, it is the stable way to use
+fast search, structured GitHub queries, JSON filters, and scoped diffs without
+spending tokens on irrelevant output.
+
+Prefer narrow, structured commands before broad dumps:
+
+```bash
+# Search and file discovery
+vx rg -n --glob '!target/**' --glob '!node_modules/**' "OutputRenderer"
+vx rg --files -g '*.rs' -g '!target/**'
+vx fd provider.star crates/vx-providers
+
+# Git context with small output first
+vx git status --short --branch
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx git grep -n "CommandOutput" origin/main -- crates/vx-cli
+
+# GitHub context with selected fields
+vx gh issue view 123 --json title,state,labels,body
+vx gh pr view 456 --json title,state,headRefName,baseRefName,files
+vx gh pr checks 456 --json name,state,conclusion,link
+vx gh run view 789 --log | vx rg -n "error|failed|panic|warning"
+
+# Structured filtering
+vx jq -r '.files[].path' pr.json
+vx yq '.jobs | keys' .github/workflows/ci.yml
+```
+
+Token-saving defaults for agents:
+- Start with `vx rg`, `vx fd`, `vx git diff --stat`, and `vx git diff --name-only`; open full files or full diffs only after locating the relevant surface.
+- Use `vx gh --json ...` with selected fields, and add `--jq` when a small projection is enough.
+- Use vx structured output flags when the vx command supports them: `--json`, `--fields`, `--toon`, or `--output-format toon`.
+- For forwarded runtimes like `vx node`, `vx cargo`, or `vx npm`, use that tool's own quiet, JSON, or filtering flags when available.
+- Pipe large logs through vx-managed filters such as `vx rg`, `vx jq`, or `vx yq` before reading them.
+
+### Agent Operating Principles
+
+vx skills should help agents make small, correct, maintainable changes with
+bounded context. Treat vx as a token-aware execution layer, not just a command
+prefix.
+
+Use this loop for coding tasks:
+1. Inspect the narrowest relevant file, symbol, diff, log, or test output first.
+2. Prefer existing project patterns over new helpers or abstractions.
+3. Make the smallest maintainable change that solves the actual request.
+4. Validate with the cheapest useful scoped command for the risk involved.
+5. Summarize only what changed, what was checked, and any remaining risk.
+
+Context discipline:
+- Scope before printing. Search paths first, then open focused file sections.
+- Avoid dumping full files, broad diffs, generated output, or full CI logs unless the task truly requires them.
+- For unknown or potentially huge output, cap and filter with vx-managed tools.
+- Do not cap instruction files, skill files, or agent policy files; read the relevant one fully unless it is unexpectedly huge.
+- If capped output is insufficient, narrow the query before increasing the cap.
+
+Examples:
+
+```bash
+vx rg -n -m 20 "render_token_savings|OutputRenderer" crates/vx-cli crates/vx-metrics
+vx git diff --stat origin/main...HEAD
+vx git diff --name-only origin/main...HEAD
+vx gh run view 789 --log | vx rg -n -m 50 "error|failed|panic"
+vx metrics tokens --last 20 --json
+```
+
+Validation discipline:
+- Use focused checks first, such as `vx cargo test -p vx-cli --test cli_parsing_tests <case>`.
+- Run broader checks only when the touched surface or release risk justifies it.
+- Prefer evidence from the actual failing command, CI job, or runtime behavior over speculative fixes.
+- Do not add wrappers, maps, helper files, or validation layers unless they clearly reduce real complexity.
 
 ### Tool Management
 ```bash
@@ -82,14 +176,14 @@ rust = "1.80"       # Specific version
 just = "*"          # Any version
 
 [scripts]
-dev = "npm run dev"
-test = "cargo test"
-lint = "npm run lint && cargo clippy"
-build = "just build"
+dev = "vx npm run dev"
+test = "vx cargo test"
+lint = "vx npm run lint && vx cargo clippy"
+build = "vx just build"
 
 [hooks]
 pre_commit = ["vx run lint"]
-post_setup = ["npm install"]
+post_setup = ["vx npm install"]
 ```
 
 ## Using `--with` for Multi-Runtime
@@ -195,7 +289,7 @@ vx msvc@14.40 cl main.cpp
 | lib | `vx msvc lib` | Library manager |
 | nmake | `vx msvc nmake` | Make utility |
 
-## Supported Tools (105 Providers)
+## Supported Tools (137 Providers)
 
 | Category | Tools |
 |----------|-------|
@@ -203,12 +297,12 @@ vx msvc@14.40 cl main.cpp
 | **JS Tooling** | oxlint, biome |
 | **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
 | **Rust** | cargo, rustc, rustup |
-| **Go** | go, gofmt, gws |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
 | **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
 | **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
-| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, conan, vcpkg, spack |
-| **DevOps** | kubectl, helm, podman, terraform, hadolint, dagu, actionlint |
-| **Security** | gitleaks, trivy |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
 | **Cloud CLI** | awscli, azcli, gcloud |
 | **.NET** | dotnet, msbuild, nuget |
 | **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
@@ -219,11 +313,12 @@ vx msvc@14.40 cl main.cpp
 | **Container** | dive |
 | **Config Mgmt** | chezmoi, mise |
 | **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
 | **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
 
 ## Provider System (Starlark DSL)
 
-All 105 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+All 137 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
 
 vx uses a **two-phase execution model** (inspired by Buck2):
 1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
@@ -304,13 +399,17 @@ Key modules:
 2. **Use `vx just`** instead of `just` for task runner commands
 3. **Use `vx npm`** instead of `npm` directly
 4. **Use `vx cargo`** instead of `cargo` directly
-5. **Check `vx.toml`** first to understand project tool requirements
-6. **Use `vx run <script>`** for project-defined scripts
-7. **Never suggest manual tool installation** - vx handles it automatically
-8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
-9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
-10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
-11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+5. **Use `vx git`** instead of `git` for repository operations
+6. **Use `vx gh`** instead of `gh` for GitHub issue, PR, checks, and workflow operations
+7. **Use `vx rg`, `vx fd`, `vx jq`, and `vx yq`** for scoped search and structured filtering
+8. **Prefer token-efficient output**: `--json`, selected fields, `--jq`, `--toon`, `--output-format toon`, and narrow globs
+9. **Check `vx.toml`** first to understand project tool requirements
+10. **Use `vx run <script>`** for project-defined scripts
+11. **Never suggest manual tool installation** - vx handles it automatically
+12. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+13. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+14. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+15. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
 
 ## Version Resolution Priority
 

--- a/.claude/skills/vx-best-practices/SKILL.md
+++ b/.claude/skills/vx-best-practices/SKILL.md
@@ -46,6 +46,29 @@ git add vx.lock
 git commit -m "chore: update dependencies"
 ```
 
+### 4. Keep Agent Work Small and Observable
+
+When an AI agent uses vx, optimize for correctness, speed, judgment, and token
+efficiency:
+
+- Read enough surrounding code to understand the local pattern, then stop exploring.
+- Prefer targeted searches, focused file sections, scoped diffs, selected JSON fields, and capped logs.
+- Make the smallest maintainable change that solves the request.
+- Reuse existing project helpers before creating new abstractions.
+- Avoid single-use wrappers, speculative architecture, and unrelated cleanup.
+- Validate according to risk: focused tests for narrow changes, broader checks for shared behavior.
+- Preserve evidence from the actual command, CI job, or runtime surface when debugging.
+
+For large or unknown output, scope first and filter through vx-managed tools:
+
+```bash
+vx rg -n -m 20 "SearchTerm" src
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx gh pr view 123 --json title,state,files
+vx gh run view 456 --log | vx rg -n -m 50 "error|failed|panic"
+```
+
 ## Project Setup
 
 ### Initial Setup

--- a/.claude/skills/vx-commands/SKILL.md
+++ b/.claude/skills/vx-commands/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: vx-commands
-description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --output-format toon for token-optimized output."
 ---
 
 # VX Command Reference
 
-> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+> **Quick rule**: All vx commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
 
 ## Structured Output Commands (AI-Optimized)
 
-All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+All commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens).
 
 ### Project Analysis
 
@@ -108,7 +108,7 @@ vx list --json
 
 ### TOON Format (Token-Optimized)
 ```bash
-vx list --format toon
+vx list --output-format toon
 # Output:
 # runtimes[50]{name,installed,description}:
 #   node,true,Node.js runtime
@@ -190,7 +190,7 @@ vx cache clean              # Clean cache
 
 ```bash
 --json                      # JSON output
---format <text|json|toon>   # Output format
+--output-format <text|json|toon>   # Output format
 --verbose                   # Verbose output
 --debug                     # Debug output
 --use-system-path           # Use system PATH

--- a/.claude/skills/vx-usage/SKILL.md
+++ b/.claude/skills/vx-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vx-usage
-description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 105 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, Git/GitHub operations, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 137 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
 ---
 
 # VX - Universal Development Tool Manager
@@ -36,7 +36,101 @@ vx npx create-react-app app   # Run npx
 vx cargo test                 # Run cargo
 vx just build                 # Run just (task runner)
 vx git status                 # Run git
+vx gh pr status               # Run GitHub CLI
 ```
+
+### Git and GitHub for Codex
+
+When Codex or another AI agent works in a vx-managed repository, use vx-managed
+Git and GitHub CLI commands. Do not run bare `git` or bare `gh`.
+
+```bash
+vx git status --short --branch
+vx git fetch origin main
+vx git checkout -B fix/example origin/main
+vx git diff --stat
+vx git add path/to/file
+vx git commit -m "fix: example"
+
+vx gh issue view 123
+vx gh pr view 456 --json title,state,headRefName
+vx gh pr checks 456
+vx gh run view 789 --log
+```
+
+### Token-Efficient Agent Workflows
+
+vx is not just an installation wrapper. For agents, it is the stable way to use
+fast search, structured GitHub queries, JSON filters, and scoped diffs without
+spending tokens on irrelevant output.
+
+Prefer narrow, structured commands before broad dumps:
+
+```bash
+# Search and file discovery
+vx rg -n --glob '!target/**' --glob '!node_modules/**' "OutputRenderer"
+vx rg --files -g '*.rs' -g '!target/**'
+vx fd provider.star crates/vx-providers
+
+# Git context with small output first
+vx git status --short --branch
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx git grep -n "CommandOutput" origin/main -- crates/vx-cli
+
+# GitHub context with selected fields
+vx gh issue view 123 --json title,state,labels,body
+vx gh pr view 456 --json title,state,headRefName,baseRefName,files
+vx gh pr checks 456 --json name,state,conclusion,link
+vx gh run view 789 --log | vx rg -n "error|failed|panic|warning"
+
+# Structured filtering
+vx jq -r '.files[].path' pr.json
+vx yq '.jobs | keys' .github/workflows/ci.yml
+```
+
+Token-saving defaults for agents:
+- Start with `vx rg`, `vx fd`, `vx git diff --stat`, and `vx git diff --name-only`; open full files or full diffs only after locating the relevant surface.
+- Use `vx gh --json ...` with selected fields, and add `--jq` when a small projection is enough.
+- Use vx structured output flags when the vx command supports them: `--json`, `--fields`, `--toon`, or `--output-format toon`.
+- For forwarded runtimes like `vx node`, `vx cargo`, or `vx npm`, use that tool's own quiet, JSON, or filtering flags when available.
+- Pipe large logs through vx-managed filters such as `vx rg`, `vx jq`, or `vx yq` before reading them.
+
+### Agent Operating Principles
+
+vx skills should help agents make small, correct, maintainable changes with
+bounded context. Treat vx as a token-aware execution layer, not just a command
+prefix.
+
+Use this loop for coding tasks:
+1. Inspect the narrowest relevant file, symbol, diff, log, or test output first.
+2. Prefer existing project patterns over new helpers or abstractions.
+3. Make the smallest maintainable change that solves the actual request.
+4. Validate with the cheapest useful scoped command for the risk involved.
+5. Summarize only what changed, what was checked, and any remaining risk.
+
+Context discipline:
+- Scope before printing. Search paths first, then open focused file sections.
+- Avoid dumping full files, broad diffs, generated output, or full CI logs unless the task truly requires them.
+- For unknown or potentially huge output, cap and filter with vx-managed tools.
+- Do not cap instruction files, skill files, or agent policy files; read the relevant one fully unless it is unexpectedly huge.
+- If capped output is insufficient, narrow the query before increasing the cap.
+
+Examples:
+
+```bash
+vx rg -n -m 20 "render_token_savings|OutputRenderer" crates/vx-cli crates/vx-metrics
+vx git diff --stat origin/main...HEAD
+vx git diff --name-only origin/main...HEAD
+vx gh run view 789 --log | vx rg -n -m 50 "error|failed|panic"
+vx metrics tokens --last 20 --json
+```
+
+Validation discipline:
+- Use focused checks first, such as `vx cargo test -p vx-cli --test cli_parsing_tests <case>`.
+- Run broader checks only when the touched surface or release risk justifies it.
+- Prefer evidence from the actual failing command, CI job, or runtime behavior over speculative fixes.
+- Do not add wrappers, maps, helper files, or validation layers unless they clearly reduce real complexity.
 
 ### Tool Management
 ```bash
@@ -82,14 +176,14 @@ rust = "1.80"       # Specific version
 just = "*"          # Any version
 
 [scripts]
-dev = "npm run dev"
-test = "cargo test"
-lint = "npm run lint && cargo clippy"
-build = "just build"
+dev = "vx npm run dev"
+test = "vx cargo test"
+lint = "vx npm run lint && vx cargo clippy"
+build = "vx just build"
 
 [hooks]
 pre_commit = ["vx run lint"]
-post_setup = ["npm install"]
+post_setup = ["vx npm install"]
 ```
 
 ## Using `--with` for Multi-Runtime
@@ -195,7 +289,7 @@ vx msvc@14.40 cl main.cpp
 | lib | `vx msvc lib` | Library manager |
 | nmake | `vx msvc nmake` | Make utility |
 
-## Supported Tools (105 Providers)
+## Supported Tools (137 Providers)
 
 | Category | Tools |
 |----------|-------|
@@ -203,12 +297,12 @@ vx msvc@14.40 cl main.cpp
 | **JS Tooling** | oxlint, biome |
 | **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
 | **Rust** | cargo, rustc, rustup |
-| **Go** | go, gofmt, gws |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
 | **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
 | **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
-| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, conan, vcpkg, spack |
-| **DevOps** | kubectl, helm, podman, terraform, hadolint, dagu, actionlint |
-| **Security** | gitleaks, trivy |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
 | **Cloud CLI** | awscli, azcli, gcloud |
 | **.NET** | dotnet, msbuild, nuget |
 | **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
@@ -219,11 +313,12 @@ vx msvc@14.40 cl main.cpp
 | **Container** | dive |
 | **Config Mgmt** | chezmoi, mise |
 | **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
 | **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
 
 ## Provider System (Starlark DSL)
 
-All 105 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+All 137 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
 
 vx uses a **two-phase execution model** (inspired by Buck2):
 1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
@@ -304,13 +399,17 @@ Key modules:
 2. **Use `vx just`** instead of `just` for task runner commands
 3. **Use `vx npm`** instead of `npm` directly
 4. **Use `vx cargo`** instead of `cargo` directly
-5. **Check `vx.toml`** first to understand project tool requirements
-6. **Use `vx run <script>`** for project-defined scripts
-7. **Never suggest manual tool installation** - vx handles it automatically
-8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
-9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
-10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
-11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+5. **Use `vx git`** instead of `git` for repository operations
+6. **Use `vx gh`** instead of `gh` for GitHub issue, PR, checks, and workflow operations
+7. **Use `vx rg`, `vx fd`, `vx jq`, and `vx yq`** for scoped search and structured filtering
+8. **Prefer token-efficient output**: `--json`, selected fields, `--jq`, `--toon`, `--output-format toon`, and narrow globs
+9. **Check `vx.toml`** first to understand project tool requirements
+10. **Use `vx run <script>`** for project-defined scripts
+11. **Never suggest manual tool installation** - vx handles it automatically
+12. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+13. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+14. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+15. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
 
 ## Version Resolution Priority
 

--- a/.cline/skills/vx-best-practices/SKILL.md
+++ b/.cline/skills/vx-best-practices/SKILL.md
@@ -46,6 +46,29 @@ git add vx.lock
 git commit -m "chore: update dependencies"
 ```
 
+### 4. Keep Agent Work Small and Observable
+
+When an AI agent uses vx, optimize for correctness, speed, judgment, and token
+efficiency:
+
+- Read enough surrounding code to understand the local pattern, then stop exploring.
+- Prefer targeted searches, focused file sections, scoped diffs, selected JSON fields, and capped logs.
+- Make the smallest maintainable change that solves the request.
+- Reuse existing project helpers before creating new abstractions.
+- Avoid single-use wrappers, speculative architecture, and unrelated cleanup.
+- Validate according to risk: focused tests for narrow changes, broader checks for shared behavior.
+- Preserve evidence from the actual command, CI job, or runtime surface when debugging.
+
+For large or unknown output, scope first and filter through vx-managed tools:
+
+```bash
+vx rg -n -m 20 "SearchTerm" src
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx gh pr view 123 --json title,state,files
+vx gh run view 456 --log | vx rg -n -m 50 "error|failed|panic"
+```
+
 ## Project Setup
 
 ### Initial Setup

--- a/.cline/skills/vx-commands/SKILL.md
+++ b/.cline/skills/vx-commands/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: vx-commands
-description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --output-format toon for token-optimized output."
 ---
 
 # VX Command Reference
 
-> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+> **Quick rule**: All vx commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
 
 ## Structured Output Commands (AI-Optimized)
 
-All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+All commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens).
 
 ### Project Analysis
 
@@ -108,7 +108,7 @@ vx list --json
 
 ### TOON Format (Token-Optimized)
 ```bash
-vx list --format toon
+vx list --output-format toon
 # Output:
 # runtimes[50]{name,installed,description}:
 #   node,true,Node.js runtime
@@ -190,7 +190,7 @@ vx cache clean              # Clean cache
 
 ```bash
 --json                      # JSON output
---format <text|json|toon>   # Output format
+--output-format <text|json|toon>   # Output format
 --verbose                   # Verbose output
 --debug                     # Debug output
 --use-system-path           # Use system PATH

--- a/.cline/skills/vx-usage/SKILL.md
+++ b/.cline/skills/vx-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vx-usage
-description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 105 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, Git/GitHub operations, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 137 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
 ---
 
 # VX - Universal Development Tool Manager
@@ -36,7 +36,101 @@ vx npx create-react-app app   # Run npx
 vx cargo test                 # Run cargo
 vx just build                 # Run just (task runner)
 vx git status                 # Run git
+vx gh pr status               # Run GitHub CLI
 ```
+
+### Git and GitHub for Codex
+
+When Codex or another AI agent works in a vx-managed repository, use vx-managed
+Git and GitHub CLI commands. Do not run bare `git` or bare `gh`.
+
+```bash
+vx git status --short --branch
+vx git fetch origin main
+vx git checkout -B fix/example origin/main
+vx git diff --stat
+vx git add path/to/file
+vx git commit -m "fix: example"
+
+vx gh issue view 123
+vx gh pr view 456 --json title,state,headRefName
+vx gh pr checks 456
+vx gh run view 789 --log
+```
+
+### Token-Efficient Agent Workflows
+
+vx is not just an installation wrapper. For agents, it is the stable way to use
+fast search, structured GitHub queries, JSON filters, and scoped diffs without
+spending tokens on irrelevant output.
+
+Prefer narrow, structured commands before broad dumps:
+
+```bash
+# Search and file discovery
+vx rg -n --glob '!target/**' --glob '!node_modules/**' "OutputRenderer"
+vx rg --files -g '*.rs' -g '!target/**'
+vx fd provider.star crates/vx-providers
+
+# Git context with small output first
+vx git status --short --branch
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx git grep -n "CommandOutput" origin/main -- crates/vx-cli
+
+# GitHub context with selected fields
+vx gh issue view 123 --json title,state,labels,body
+vx gh pr view 456 --json title,state,headRefName,baseRefName,files
+vx gh pr checks 456 --json name,state,conclusion,link
+vx gh run view 789 --log | vx rg -n "error|failed|panic|warning"
+
+# Structured filtering
+vx jq -r '.files[].path' pr.json
+vx yq '.jobs | keys' .github/workflows/ci.yml
+```
+
+Token-saving defaults for agents:
+- Start with `vx rg`, `vx fd`, `vx git diff --stat`, and `vx git diff --name-only`; open full files or full diffs only after locating the relevant surface.
+- Use `vx gh --json ...` with selected fields, and add `--jq` when a small projection is enough.
+- Use vx structured output flags when the vx command supports them: `--json`, `--fields`, `--toon`, or `--output-format toon`.
+- For forwarded runtimes like `vx node`, `vx cargo`, or `vx npm`, use that tool's own quiet, JSON, or filtering flags when available.
+- Pipe large logs through vx-managed filters such as `vx rg`, `vx jq`, or `vx yq` before reading them.
+
+### Agent Operating Principles
+
+vx skills should help agents make small, correct, maintainable changes with
+bounded context. Treat vx as a token-aware execution layer, not just a command
+prefix.
+
+Use this loop for coding tasks:
+1. Inspect the narrowest relevant file, symbol, diff, log, or test output first.
+2. Prefer existing project patterns over new helpers or abstractions.
+3. Make the smallest maintainable change that solves the actual request.
+4. Validate with the cheapest useful scoped command for the risk involved.
+5. Summarize only what changed, what was checked, and any remaining risk.
+
+Context discipline:
+- Scope before printing. Search paths first, then open focused file sections.
+- Avoid dumping full files, broad diffs, generated output, or full CI logs unless the task truly requires them.
+- For unknown or potentially huge output, cap and filter with vx-managed tools.
+- Do not cap instruction files, skill files, or agent policy files; read the relevant one fully unless it is unexpectedly huge.
+- If capped output is insufficient, narrow the query before increasing the cap.
+
+Examples:
+
+```bash
+vx rg -n -m 20 "render_token_savings|OutputRenderer" crates/vx-cli crates/vx-metrics
+vx git diff --stat origin/main...HEAD
+vx git diff --name-only origin/main...HEAD
+vx gh run view 789 --log | vx rg -n -m 50 "error|failed|panic"
+vx metrics tokens --last 20 --json
+```
+
+Validation discipline:
+- Use focused checks first, such as `vx cargo test -p vx-cli --test cli_parsing_tests <case>`.
+- Run broader checks only when the touched surface or release risk justifies it.
+- Prefer evidence from the actual failing command, CI job, or runtime behavior over speculative fixes.
+- Do not add wrappers, maps, helper files, or validation layers unless they clearly reduce real complexity.
 
 ### Tool Management
 ```bash
@@ -82,14 +176,14 @@ rust = "1.80"       # Specific version
 just = "*"          # Any version
 
 [scripts]
-dev = "npm run dev"
-test = "cargo test"
-lint = "npm run lint && cargo clippy"
-build = "just build"
+dev = "vx npm run dev"
+test = "vx cargo test"
+lint = "vx npm run lint && vx cargo clippy"
+build = "vx just build"
 
 [hooks]
 pre_commit = ["vx run lint"]
-post_setup = ["npm install"]
+post_setup = ["vx npm install"]
 ```
 
 ## Using `--with` for Multi-Runtime
@@ -195,7 +289,7 @@ vx msvc@14.40 cl main.cpp
 | lib | `vx msvc lib` | Library manager |
 | nmake | `vx msvc nmake` | Make utility |
 
-## Supported Tools (105 Providers)
+## Supported Tools (137 Providers)
 
 | Category | Tools |
 |----------|-------|
@@ -203,12 +297,12 @@ vx msvc@14.40 cl main.cpp
 | **JS Tooling** | oxlint, biome |
 | **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
 | **Rust** | cargo, rustc, rustup |
-| **Go** | go, gofmt, gws |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
 | **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
 | **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
-| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, conan, vcpkg, spack |
-| **DevOps** | kubectl, helm, podman, terraform, hadolint, dagu, actionlint |
-| **Security** | gitleaks, trivy |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
 | **Cloud CLI** | awscli, azcli, gcloud |
 | **.NET** | dotnet, msbuild, nuget |
 | **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
@@ -219,11 +313,12 @@ vx msvc@14.40 cl main.cpp
 | **Container** | dive |
 | **Config Mgmt** | chezmoi, mise |
 | **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
 | **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
 
 ## Provider System (Starlark DSL)
 
-All 105 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+All 137 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
 
 vx uses a **two-phase execution model** (inspired by Buck2):
 1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
@@ -304,13 +399,17 @@ Key modules:
 2. **Use `vx just`** instead of `just` for task runner commands
 3. **Use `vx npm`** instead of `npm` directly
 4. **Use `vx cargo`** instead of `cargo` directly
-5. **Check `vx.toml`** first to understand project tool requirements
-6. **Use `vx run <script>`** for project-defined scripts
-7. **Never suggest manual tool installation** - vx handles it automatically
-8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
-9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
-10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
-11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+5. **Use `vx git`** instead of `git` for repository operations
+6. **Use `vx gh`** instead of `gh` for GitHub issue, PR, checks, and workflow operations
+7. **Use `vx rg`, `vx fd`, `vx jq`, and `vx yq`** for scoped search and structured filtering
+8. **Prefer token-efficient output**: `--json`, selected fields, `--jq`, `--toon`, `--output-format toon`, and narrow globs
+9. **Check `vx.toml`** first to understand project tool requirements
+10. **Use `vx run <script>`** for project-defined scripts
+11. **Never suggest manual tool installation** - vx handles it automatically
+12. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+13. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+14. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+15. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
 
 ## Version Resolution Priority
 

--- a/.codebuddy/skills/vx-best-practices/SKILL.md
+++ b/.codebuddy/skills/vx-best-practices/SKILL.md
@@ -46,6 +46,29 @@ git add vx.lock
 git commit -m "chore: update dependencies"
 ```
 
+### 4. Keep Agent Work Small and Observable
+
+When an AI agent uses vx, optimize for correctness, speed, judgment, and token
+efficiency:
+
+- Read enough surrounding code to understand the local pattern, then stop exploring.
+- Prefer targeted searches, focused file sections, scoped diffs, selected JSON fields, and capped logs.
+- Make the smallest maintainable change that solves the request.
+- Reuse existing project helpers before creating new abstractions.
+- Avoid single-use wrappers, speculative architecture, and unrelated cleanup.
+- Validate according to risk: focused tests for narrow changes, broader checks for shared behavior.
+- Preserve evidence from the actual command, CI job, or runtime surface when debugging.
+
+For large or unknown output, scope first and filter through vx-managed tools:
+
+```bash
+vx rg -n -m 20 "SearchTerm" src
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx gh pr view 123 --json title,state,files
+vx gh run view 456 --log | vx rg -n -m 50 "error|failed|panic"
+```
+
 ## Project Setup
 
 ### Initial Setup

--- a/.codebuddy/skills/vx-commands/SKILL.md
+++ b/.codebuddy/skills/vx-commands/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: vx-commands
-description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --output-format toon for token-optimized output."
 ---
 
 # VX Command Reference
 
-> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+> **Quick rule**: All vx commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
 
 ## Structured Output Commands (AI-Optimized)
 
-All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+All commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens).
 
 ### Project Analysis
 
@@ -108,7 +108,7 @@ vx list --json
 
 ### TOON Format (Token-Optimized)
 ```bash
-vx list --format toon
+vx list --output-format toon
 # Output:
 # runtimes[50]{name,installed,description}:
 #   node,true,Node.js runtime
@@ -190,7 +190,7 @@ vx cache clean              # Clean cache
 
 ```bash
 --json                      # JSON output
---format <text|json|toon>   # Output format
+--output-format <text|json|toon>   # Output format
 --verbose                   # Verbose output
 --debug                     # Debug output
 --use-system-path           # Use system PATH

--- a/.codebuddy/skills/vx-usage/SKILL.md
+++ b/.codebuddy/skills/vx-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vx-usage
-description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 105 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, Git/GitHub operations, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 137 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
 ---
 
 # VX - Universal Development Tool Manager
@@ -36,7 +36,101 @@ vx npx create-react-app app   # Run npx
 vx cargo test                 # Run cargo
 vx just build                 # Run just (task runner)
 vx git status                 # Run git
+vx gh pr status               # Run GitHub CLI
 ```
+
+### Git and GitHub for Codex
+
+When Codex or another AI agent works in a vx-managed repository, use vx-managed
+Git and GitHub CLI commands. Do not run bare `git` or bare `gh`.
+
+```bash
+vx git status --short --branch
+vx git fetch origin main
+vx git checkout -B fix/example origin/main
+vx git diff --stat
+vx git add path/to/file
+vx git commit -m "fix: example"
+
+vx gh issue view 123
+vx gh pr view 456 --json title,state,headRefName
+vx gh pr checks 456
+vx gh run view 789 --log
+```
+
+### Token-Efficient Agent Workflows
+
+vx is not just an installation wrapper. For agents, it is the stable way to use
+fast search, structured GitHub queries, JSON filters, and scoped diffs without
+spending tokens on irrelevant output.
+
+Prefer narrow, structured commands before broad dumps:
+
+```bash
+# Search and file discovery
+vx rg -n --glob '!target/**' --glob '!node_modules/**' "OutputRenderer"
+vx rg --files -g '*.rs' -g '!target/**'
+vx fd provider.star crates/vx-providers
+
+# Git context with small output first
+vx git status --short --branch
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx git grep -n "CommandOutput" origin/main -- crates/vx-cli
+
+# GitHub context with selected fields
+vx gh issue view 123 --json title,state,labels,body
+vx gh pr view 456 --json title,state,headRefName,baseRefName,files
+vx gh pr checks 456 --json name,state,conclusion,link
+vx gh run view 789 --log | vx rg -n "error|failed|panic|warning"
+
+# Structured filtering
+vx jq -r '.files[].path' pr.json
+vx yq '.jobs | keys' .github/workflows/ci.yml
+```
+
+Token-saving defaults for agents:
+- Start with `vx rg`, `vx fd`, `vx git diff --stat`, and `vx git diff --name-only`; open full files or full diffs only after locating the relevant surface.
+- Use `vx gh --json ...` with selected fields, and add `--jq` when a small projection is enough.
+- Use vx structured output flags when the vx command supports them: `--json`, `--fields`, `--toon`, or `--output-format toon`.
+- For forwarded runtimes like `vx node`, `vx cargo`, or `vx npm`, use that tool's own quiet, JSON, or filtering flags when available.
+- Pipe large logs through vx-managed filters such as `vx rg`, `vx jq`, or `vx yq` before reading them.
+
+### Agent Operating Principles
+
+vx skills should help agents make small, correct, maintainable changes with
+bounded context. Treat vx as a token-aware execution layer, not just a command
+prefix.
+
+Use this loop for coding tasks:
+1. Inspect the narrowest relevant file, symbol, diff, log, or test output first.
+2. Prefer existing project patterns over new helpers or abstractions.
+3. Make the smallest maintainable change that solves the actual request.
+4. Validate with the cheapest useful scoped command for the risk involved.
+5. Summarize only what changed, what was checked, and any remaining risk.
+
+Context discipline:
+- Scope before printing. Search paths first, then open focused file sections.
+- Avoid dumping full files, broad diffs, generated output, or full CI logs unless the task truly requires them.
+- For unknown or potentially huge output, cap and filter with vx-managed tools.
+- Do not cap instruction files, skill files, or agent policy files; read the relevant one fully unless it is unexpectedly huge.
+- If capped output is insufficient, narrow the query before increasing the cap.
+
+Examples:
+
+```bash
+vx rg -n -m 20 "render_token_savings|OutputRenderer" crates/vx-cli crates/vx-metrics
+vx git diff --stat origin/main...HEAD
+vx git diff --name-only origin/main...HEAD
+vx gh run view 789 --log | vx rg -n -m 50 "error|failed|panic"
+vx metrics tokens --last 20 --json
+```
+
+Validation discipline:
+- Use focused checks first, such as `vx cargo test -p vx-cli --test cli_parsing_tests <case>`.
+- Run broader checks only when the touched surface or release risk justifies it.
+- Prefer evidence from the actual failing command, CI job, or runtime behavior over speculative fixes.
+- Do not add wrappers, maps, helper files, or validation layers unless they clearly reduce real complexity.
 
 ### Tool Management
 ```bash
@@ -82,14 +176,14 @@ rust = "1.80"       # Specific version
 just = "*"          # Any version
 
 [scripts]
-dev = "npm run dev"
-test = "cargo test"
-lint = "npm run lint && cargo clippy"
-build = "just build"
+dev = "vx npm run dev"
+test = "vx cargo test"
+lint = "vx npm run lint && vx cargo clippy"
+build = "vx just build"
 
 [hooks]
 pre_commit = ["vx run lint"]
-post_setup = ["npm install"]
+post_setup = ["vx npm install"]
 ```
 
 ## Using `--with` for Multi-Runtime
@@ -195,7 +289,7 @@ vx msvc@14.40 cl main.cpp
 | lib | `vx msvc lib` | Library manager |
 | nmake | `vx msvc nmake` | Make utility |
 
-## Supported Tools (105 Providers)
+## Supported Tools (137 Providers)
 
 | Category | Tools |
 |----------|-------|
@@ -203,12 +297,12 @@ vx msvc@14.40 cl main.cpp
 | **JS Tooling** | oxlint, biome |
 | **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
 | **Rust** | cargo, rustc, rustup |
-| **Go** | go, gofmt, gws |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
 | **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
 | **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
-| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, conan, vcpkg, spack |
-| **DevOps** | kubectl, helm, podman, terraform, hadolint, dagu, actionlint |
-| **Security** | gitleaks, trivy |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
 | **Cloud CLI** | awscli, azcli, gcloud |
 | **.NET** | dotnet, msbuild, nuget |
 | **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
@@ -219,11 +313,12 @@ vx msvc@14.40 cl main.cpp
 | **Container** | dive |
 | **Config Mgmt** | chezmoi, mise |
 | **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
 | **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
 
 ## Provider System (Starlark DSL)
 
-All 105 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+All 137 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
 
 vx uses a **two-phase execution model** (inspired by Buck2):
 1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
@@ -304,13 +399,17 @@ Key modules:
 2. **Use `vx just`** instead of `just` for task runner commands
 3. **Use `vx npm`** instead of `npm` directly
 4. **Use `vx cargo`** instead of `cargo` directly
-5. **Check `vx.toml`** first to understand project tool requirements
-6. **Use `vx run <script>`** for project-defined scripts
-7. **Never suggest manual tool installation** - vx handles it automatically
-8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
-9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
-10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
-11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+5. **Use `vx git`** instead of `git` for repository operations
+6. **Use `vx gh`** instead of `gh` for GitHub issue, PR, checks, and workflow operations
+7. **Use `vx rg`, `vx fd`, `vx jq`, and `vx yq`** for scoped search and structured filtering
+8. **Prefer token-efficient output**: `--json`, selected fields, `--jq`, `--toon`, `--output-format toon`, and narrow globs
+9. **Check `vx.toml`** first to understand project tool requirements
+10. **Use `vx run <script>`** for project-defined scripts
+11. **Never suggest manual tool installation** - vx handles it automatically
+12. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+13. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+14. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+15. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
 
 ## Version Resolution Priority
 

--- a/.cursor/skills/vx-best-practices/SKILL.md
+++ b/.cursor/skills/vx-best-practices/SKILL.md
@@ -46,6 +46,29 @@ git add vx.lock
 git commit -m "chore: update dependencies"
 ```
 
+### 4. Keep Agent Work Small and Observable
+
+When an AI agent uses vx, optimize for correctness, speed, judgment, and token
+efficiency:
+
+- Read enough surrounding code to understand the local pattern, then stop exploring.
+- Prefer targeted searches, focused file sections, scoped diffs, selected JSON fields, and capped logs.
+- Make the smallest maintainable change that solves the request.
+- Reuse existing project helpers before creating new abstractions.
+- Avoid single-use wrappers, speculative architecture, and unrelated cleanup.
+- Validate according to risk: focused tests for narrow changes, broader checks for shared behavior.
+- Preserve evidence from the actual command, CI job, or runtime surface when debugging.
+
+For large or unknown output, scope first and filter through vx-managed tools:
+
+```bash
+vx rg -n -m 20 "SearchTerm" src
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx gh pr view 123 --json title,state,files
+vx gh run view 456 --log | vx rg -n -m 50 "error|failed|panic"
+```
+
 ## Project Setup
 
 ### Initial Setup

--- a/.cursor/skills/vx-commands/SKILL.md
+++ b/.cursor/skills/vx-commands/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: vx-commands
-description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --output-format toon for token-optimized output."
 ---
 
 # VX Command Reference
 
-> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+> **Quick rule**: All vx commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
 
 ## Structured Output Commands (AI-Optimized)
 
-All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+All commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens).
 
 ### Project Analysis
 
@@ -108,7 +108,7 @@ vx list --json
 
 ### TOON Format (Token-Optimized)
 ```bash
-vx list --format toon
+vx list --output-format toon
 # Output:
 # runtimes[50]{name,installed,description}:
 #   node,true,Node.js runtime
@@ -190,7 +190,7 @@ vx cache clean              # Clean cache
 
 ```bash
 --json                      # JSON output
---format <text|json|toon>   # Output format
+--output-format <text|json|toon>   # Output format
 --verbose                   # Verbose output
 --debug                     # Debug output
 --use-system-path           # Use system PATH

--- a/.cursor/skills/vx-usage/SKILL.md
+++ b/.cursor/skills/vx-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vx-usage
-description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 105 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, Git/GitHub operations, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 137 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
 ---
 
 # VX - Universal Development Tool Manager
@@ -36,7 +36,101 @@ vx npx create-react-app app   # Run npx
 vx cargo test                 # Run cargo
 vx just build                 # Run just (task runner)
 vx git status                 # Run git
+vx gh pr status               # Run GitHub CLI
 ```
+
+### Git and GitHub for Codex
+
+When Codex or another AI agent works in a vx-managed repository, use vx-managed
+Git and GitHub CLI commands. Do not run bare `git` or bare `gh`.
+
+```bash
+vx git status --short --branch
+vx git fetch origin main
+vx git checkout -B fix/example origin/main
+vx git diff --stat
+vx git add path/to/file
+vx git commit -m "fix: example"
+
+vx gh issue view 123
+vx gh pr view 456 --json title,state,headRefName
+vx gh pr checks 456
+vx gh run view 789 --log
+```
+
+### Token-Efficient Agent Workflows
+
+vx is not just an installation wrapper. For agents, it is the stable way to use
+fast search, structured GitHub queries, JSON filters, and scoped diffs without
+spending tokens on irrelevant output.
+
+Prefer narrow, structured commands before broad dumps:
+
+```bash
+# Search and file discovery
+vx rg -n --glob '!target/**' --glob '!node_modules/**' "OutputRenderer"
+vx rg --files -g '*.rs' -g '!target/**'
+vx fd provider.star crates/vx-providers
+
+# Git context with small output first
+vx git status --short --branch
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx git grep -n "CommandOutput" origin/main -- crates/vx-cli
+
+# GitHub context with selected fields
+vx gh issue view 123 --json title,state,labels,body
+vx gh pr view 456 --json title,state,headRefName,baseRefName,files
+vx gh pr checks 456 --json name,state,conclusion,link
+vx gh run view 789 --log | vx rg -n "error|failed|panic|warning"
+
+# Structured filtering
+vx jq -r '.files[].path' pr.json
+vx yq '.jobs | keys' .github/workflows/ci.yml
+```
+
+Token-saving defaults for agents:
+- Start with `vx rg`, `vx fd`, `vx git diff --stat`, and `vx git diff --name-only`; open full files or full diffs only after locating the relevant surface.
+- Use `vx gh --json ...` with selected fields, and add `--jq` when a small projection is enough.
+- Use vx structured output flags when the vx command supports them: `--json`, `--fields`, `--toon`, or `--output-format toon`.
+- For forwarded runtimes like `vx node`, `vx cargo`, or `vx npm`, use that tool's own quiet, JSON, or filtering flags when available.
+- Pipe large logs through vx-managed filters such as `vx rg`, `vx jq`, or `vx yq` before reading them.
+
+### Agent Operating Principles
+
+vx skills should help agents make small, correct, maintainable changes with
+bounded context. Treat vx as a token-aware execution layer, not just a command
+prefix.
+
+Use this loop for coding tasks:
+1. Inspect the narrowest relevant file, symbol, diff, log, or test output first.
+2. Prefer existing project patterns over new helpers or abstractions.
+3. Make the smallest maintainable change that solves the actual request.
+4. Validate with the cheapest useful scoped command for the risk involved.
+5. Summarize only what changed, what was checked, and any remaining risk.
+
+Context discipline:
+- Scope before printing. Search paths first, then open focused file sections.
+- Avoid dumping full files, broad diffs, generated output, or full CI logs unless the task truly requires them.
+- For unknown or potentially huge output, cap and filter with vx-managed tools.
+- Do not cap instruction files, skill files, or agent policy files; read the relevant one fully unless it is unexpectedly huge.
+- If capped output is insufficient, narrow the query before increasing the cap.
+
+Examples:
+
+```bash
+vx rg -n -m 20 "render_token_savings|OutputRenderer" crates/vx-cli crates/vx-metrics
+vx git diff --stat origin/main...HEAD
+vx git diff --name-only origin/main...HEAD
+vx gh run view 789 --log | vx rg -n -m 50 "error|failed|panic"
+vx metrics tokens --last 20 --json
+```
+
+Validation discipline:
+- Use focused checks first, such as `vx cargo test -p vx-cli --test cli_parsing_tests <case>`.
+- Run broader checks only when the touched surface or release risk justifies it.
+- Prefer evidence from the actual failing command, CI job, or runtime behavior over speculative fixes.
+- Do not add wrappers, maps, helper files, or validation layers unless they clearly reduce real complexity.
 
 ### Tool Management
 ```bash
@@ -82,14 +176,14 @@ rust = "1.80"       # Specific version
 just = "*"          # Any version
 
 [scripts]
-dev = "npm run dev"
-test = "cargo test"
-lint = "npm run lint && cargo clippy"
-build = "just build"
+dev = "vx npm run dev"
+test = "vx cargo test"
+lint = "vx npm run lint && vx cargo clippy"
+build = "vx just build"
 
 [hooks]
 pre_commit = ["vx run lint"]
-post_setup = ["npm install"]
+post_setup = ["vx npm install"]
 ```
 
 ## Using `--with` for Multi-Runtime
@@ -195,7 +289,7 @@ vx msvc@14.40 cl main.cpp
 | lib | `vx msvc lib` | Library manager |
 | nmake | `vx msvc nmake` | Make utility |
 
-## Supported Tools (105 Providers)
+## Supported Tools (137 Providers)
 
 | Category | Tools |
 |----------|-------|
@@ -203,12 +297,12 @@ vx msvc@14.40 cl main.cpp
 | **JS Tooling** | oxlint, biome |
 | **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
 | **Rust** | cargo, rustc, rustup |
-| **Go** | go, gofmt, gws |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
 | **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
 | **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
-| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, conan, vcpkg, spack |
-| **DevOps** | kubectl, helm, podman, terraform, hadolint, dagu, actionlint |
-| **Security** | gitleaks, trivy |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
 | **Cloud CLI** | awscli, azcli, gcloud |
 | **.NET** | dotnet, msbuild, nuget |
 | **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
@@ -219,11 +313,12 @@ vx msvc@14.40 cl main.cpp
 | **Container** | dive |
 | **Config Mgmt** | chezmoi, mise |
 | **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
 | **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
 
 ## Provider System (Starlark DSL)
 
-All 105 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+All 137 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
 
 vx uses a **two-phase execution model** (inspired by Buck2):
 1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
@@ -304,13 +399,17 @@ Key modules:
 2. **Use `vx just`** instead of `just` for task runner commands
 3. **Use `vx npm`** instead of `npm` directly
 4. **Use `vx cargo`** instead of `cargo` directly
-5. **Check `vx.toml`** first to understand project tool requirements
-6. **Use `vx run <script>`** for project-defined scripts
-7. **Never suggest manual tool installation** - vx handles it automatically
-8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
-9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
-10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
-11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+5. **Use `vx git`** instead of `git` for repository operations
+6. **Use `vx gh`** instead of `gh` for GitHub issue, PR, checks, and workflow operations
+7. **Use `vx rg`, `vx fd`, `vx jq`, and `vx yq`** for scoped search and structured filtering
+8. **Prefer token-efficient output**: `--json`, selected fields, `--jq`, `--toon`, `--output-format toon`, and narrow globs
+9. **Check `vx.toml`** first to understand project tool requirements
+10. **Use `vx run <script>`** for project-defined scripts
+11. **Never suggest manual tool installation** - vx handles it automatically
+12. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+13. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+14. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+15. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
 
 ## Version Resolution Priority
 

--- a/.kiro/skills/vx-best-practices/SKILL.md
+++ b/.kiro/skills/vx-best-practices/SKILL.md
@@ -46,6 +46,29 @@ git add vx.lock
 git commit -m "chore: update dependencies"
 ```
 
+### 4. Keep Agent Work Small and Observable
+
+When an AI agent uses vx, optimize for correctness, speed, judgment, and token
+efficiency:
+
+- Read enough surrounding code to understand the local pattern, then stop exploring.
+- Prefer targeted searches, focused file sections, scoped diffs, selected JSON fields, and capped logs.
+- Make the smallest maintainable change that solves the request.
+- Reuse existing project helpers before creating new abstractions.
+- Avoid single-use wrappers, speculative architecture, and unrelated cleanup.
+- Validate according to risk: focused tests for narrow changes, broader checks for shared behavior.
+- Preserve evidence from the actual command, CI job, or runtime surface when debugging.
+
+For large or unknown output, scope first and filter through vx-managed tools:
+
+```bash
+vx rg -n -m 20 "SearchTerm" src
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx gh pr view 123 --json title,state,files
+vx gh run view 456 --log | vx rg -n -m 50 "error|failed|panic"
+```
+
 ## Project Setup
 
 ### Initial Setup

--- a/.kiro/skills/vx-commands/SKILL.md
+++ b/.kiro/skills/vx-commands/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: vx-commands
-description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --output-format toon for token-optimized output."
 ---
 
 # VX Command Reference
 
-> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+> **Quick rule**: All vx commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
 
 ## Structured Output Commands (AI-Optimized)
 
-All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+All commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens).
 
 ### Project Analysis
 
@@ -108,7 +108,7 @@ vx list --json
 
 ### TOON Format (Token-Optimized)
 ```bash
-vx list --format toon
+vx list --output-format toon
 # Output:
 # runtimes[50]{name,installed,description}:
 #   node,true,Node.js runtime
@@ -190,7 +190,7 @@ vx cache clean              # Clean cache
 
 ```bash
 --json                      # JSON output
---format <text|json|toon>   # Output format
+--output-format <text|json|toon>   # Output format
 --verbose                   # Verbose output
 --debug                     # Debug output
 --use-system-path           # Use system PATH

--- a/.kiro/skills/vx-usage/SKILL.md
+++ b/.kiro/skills/vx-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vx-usage
-description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 105 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, Git/GitHub operations, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 137 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
 ---
 
 # VX - Universal Development Tool Manager
@@ -36,7 +36,101 @@ vx npx create-react-app app   # Run npx
 vx cargo test                 # Run cargo
 vx just build                 # Run just (task runner)
 vx git status                 # Run git
+vx gh pr status               # Run GitHub CLI
 ```
+
+### Git and GitHub for Codex
+
+When Codex or another AI agent works in a vx-managed repository, use vx-managed
+Git and GitHub CLI commands. Do not run bare `git` or bare `gh`.
+
+```bash
+vx git status --short --branch
+vx git fetch origin main
+vx git checkout -B fix/example origin/main
+vx git diff --stat
+vx git add path/to/file
+vx git commit -m "fix: example"
+
+vx gh issue view 123
+vx gh pr view 456 --json title,state,headRefName
+vx gh pr checks 456
+vx gh run view 789 --log
+```
+
+### Token-Efficient Agent Workflows
+
+vx is not just an installation wrapper. For agents, it is the stable way to use
+fast search, structured GitHub queries, JSON filters, and scoped diffs without
+spending tokens on irrelevant output.
+
+Prefer narrow, structured commands before broad dumps:
+
+```bash
+# Search and file discovery
+vx rg -n --glob '!target/**' --glob '!node_modules/**' "OutputRenderer"
+vx rg --files -g '*.rs' -g '!target/**'
+vx fd provider.star crates/vx-providers
+
+# Git context with small output first
+vx git status --short --branch
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx git grep -n "CommandOutput" origin/main -- crates/vx-cli
+
+# GitHub context with selected fields
+vx gh issue view 123 --json title,state,labels,body
+vx gh pr view 456 --json title,state,headRefName,baseRefName,files
+vx gh pr checks 456 --json name,state,conclusion,link
+vx gh run view 789 --log | vx rg -n "error|failed|panic|warning"
+
+# Structured filtering
+vx jq -r '.files[].path' pr.json
+vx yq '.jobs | keys' .github/workflows/ci.yml
+```
+
+Token-saving defaults for agents:
+- Start with `vx rg`, `vx fd`, `vx git diff --stat`, and `vx git diff --name-only`; open full files or full diffs only after locating the relevant surface.
+- Use `vx gh --json ...` with selected fields, and add `--jq` when a small projection is enough.
+- Use vx structured output flags when the vx command supports them: `--json`, `--fields`, `--toon`, or `--output-format toon`.
+- For forwarded runtimes like `vx node`, `vx cargo`, or `vx npm`, use that tool's own quiet, JSON, or filtering flags when available.
+- Pipe large logs through vx-managed filters such as `vx rg`, `vx jq`, or `vx yq` before reading them.
+
+### Agent Operating Principles
+
+vx skills should help agents make small, correct, maintainable changes with
+bounded context. Treat vx as a token-aware execution layer, not just a command
+prefix.
+
+Use this loop for coding tasks:
+1. Inspect the narrowest relevant file, symbol, diff, log, or test output first.
+2. Prefer existing project patterns over new helpers or abstractions.
+3. Make the smallest maintainable change that solves the actual request.
+4. Validate with the cheapest useful scoped command for the risk involved.
+5. Summarize only what changed, what was checked, and any remaining risk.
+
+Context discipline:
+- Scope before printing. Search paths first, then open focused file sections.
+- Avoid dumping full files, broad diffs, generated output, or full CI logs unless the task truly requires them.
+- For unknown or potentially huge output, cap and filter with vx-managed tools.
+- Do not cap instruction files, skill files, or agent policy files; read the relevant one fully unless it is unexpectedly huge.
+- If capped output is insufficient, narrow the query before increasing the cap.
+
+Examples:
+
+```bash
+vx rg -n -m 20 "render_token_savings|OutputRenderer" crates/vx-cli crates/vx-metrics
+vx git diff --stat origin/main...HEAD
+vx git diff --name-only origin/main...HEAD
+vx gh run view 789 --log | vx rg -n -m 50 "error|failed|panic"
+vx metrics tokens --last 20 --json
+```
+
+Validation discipline:
+- Use focused checks first, such as `vx cargo test -p vx-cli --test cli_parsing_tests <case>`.
+- Run broader checks only when the touched surface or release risk justifies it.
+- Prefer evidence from the actual failing command, CI job, or runtime behavior over speculative fixes.
+- Do not add wrappers, maps, helper files, or validation layers unless they clearly reduce real complexity.
 
 ### Tool Management
 ```bash
@@ -82,14 +176,14 @@ rust = "1.80"       # Specific version
 just = "*"          # Any version
 
 [scripts]
-dev = "npm run dev"
-test = "cargo test"
-lint = "npm run lint && cargo clippy"
-build = "just build"
+dev = "vx npm run dev"
+test = "vx cargo test"
+lint = "vx npm run lint && vx cargo clippy"
+build = "vx just build"
 
 [hooks]
 pre_commit = ["vx run lint"]
-post_setup = ["npm install"]
+post_setup = ["vx npm install"]
 ```
 
 ## Using `--with` for Multi-Runtime
@@ -195,7 +289,7 @@ vx msvc@14.40 cl main.cpp
 | lib | `vx msvc lib` | Library manager |
 | nmake | `vx msvc nmake` | Make utility |
 
-## Supported Tools (105 Providers)
+## Supported Tools (137 Providers)
 
 | Category | Tools |
 |----------|-------|
@@ -203,12 +297,12 @@ vx msvc@14.40 cl main.cpp
 | **JS Tooling** | oxlint, biome |
 | **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
 | **Rust** | cargo, rustc, rustup |
-| **Go** | go, gofmt, gws |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
 | **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
 | **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
-| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, conan, vcpkg, spack |
-| **DevOps** | kubectl, helm, podman, terraform, hadolint, dagu, actionlint |
-| **Security** | gitleaks, trivy |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
 | **Cloud CLI** | awscli, azcli, gcloud |
 | **.NET** | dotnet, msbuild, nuget |
 | **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
@@ -219,11 +313,12 @@ vx msvc@14.40 cl main.cpp
 | **Container** | dive |
 | **Config Mgmt** | chezmoi, mise |
 | **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
 | **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
 
 ## Provider System (Starlark DSL)
 
-All 105 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+All 137 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
 
 vx uses a **two-phase execution model** (inspired by Buck2):
 1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
@@ -304,13 +399,17 @@ Key modules:
 2. **Use `vx just`** instead of `just` for task runner commands
 3. **Use `vx npm`** instead of `npm` directly
 4. **Use `vx cargo`** instead of `cargo` directly
-5. **Check `vx.toml`** first to understand project tool requirements
-6. **Use `vx run <script>`** for project-defined scripts
-7. **Never suggest manual tool installation** - vx handles it automatically
-8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
-9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
-10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
-11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+5. **Use `vx git`** instead of `git` for repository operations
+6. **Use `vx gh`** instead of `gh` for GitHub issue, PR, checks, and workflow operations
+7. **Use `vx rg`, `vx fd`, `vx jq`, and `vx yq`** for scoped search and structured filtering
+8. **Prefer token-efficient output**: `--json`, selected fields, `--jq`, `--toon`, `--output-format toon`, and narrow globs
+9. **Check `vx.toml`** first to understand project tool requirements
+10. **Use `vx run <script>`** for project-defined scripts
+11. **Never suggest manual tool installation** - vx handles it automatically
+12. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+13. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+14. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+15. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
 
 ## Version Resolution Priority
 

--- a/.opencode/skills/vx-best-practices/SKILL.md
+++ b/.opencode/skills/vx-best-practices/SKILL.md
@@ -46,6 +46,29 @@ git add vx.lock
 git commit -m "chore: update dependencies"
 ```
 
+### 4. Keep Agent Work Small and Observable
+
+When an AI agent uses vx, optimize for correctness, speed, judgment, and token
+efficiency:
+
+- Read enough surrounding code to understand the local pattern, then stop exploring.
+- Prefer targeted searches, focused file sections, scoped diffs, selected JSON fields, and capped logs.
+- Make the smallest maintainable change that solves the request.
+- Reuse existing project helpers before creating new abstractions.
+- Avoid single-use wrappers, speculative architecture, and unrelated cleanup.
+- Validate according to risk: focused tests for narrow changes, broader checks for shared behavior.
+- Preserve evidence from the actual command, CI job, or runtime surface when debugging.
+
+For large or unknown output, scope first and filter through vx-managed tools:
+
+```bash
+vx rg -n -m 20 "SearchTerm" src
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx gh pr view 123 --json title,state,files
+vx gh run view 456 --log | vx rg -n -m 50 "error|failed|panic"
+```
+
 ## Project Setup
 
 ### Initial Setup

--- a/.opencode/skills/vx-commands/SKILL.md
+++ b/.opencode/skills/vx-commands/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: vx-commands
-description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --output-format toon for token-optimized output."
 ---
 
 # VX Command Reference
 
-> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+> **Quick rule**: All vx commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
 
 ## Structured Output Commands (AI-Optimized)
 
-All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+All commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens).
 
 ### Project Analysis
 
@@ -108,7 +108,7 @@ vx list --json
 
 ### TOON Format (Token-Optimized)
 ```bash
-vx list --format toon
+vx list --output-format toon
 # Output:
 # runtimes[50]{name,installed,description}:
 #   node,true,Node.js runtime
@@ -190,7 +190,7 @@ vx cache clean              # Clean cache
 
 ```bash
 --json                      # JSON output
---format <text|json|toon>   # Output format
+--output-format <text|json|toon>   # Output format
 --verbose                   # Verbose output
 --debug                     # Debug output
 --use-system-path           # Use system PATH

--- a/.opencode/skills/vx-usage/SKILL.md
+++ b/.opencode/skills/vx-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vx-usage
-description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 105 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, Git/GitHub operations, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 137 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
 ---
 
 # VX - Universal Development Tool Manager
@@ -36,7 +36,101 @@ vx npx create-react-app app   # Run npx
 vx cargo test                 # Run cargo
 vx just build                 # Run just (task runner)
 vx git status                 # Run git
+vx gh pr status               # Run GitHub CLI
 ```
+
+### Git and GitHub for Codex
+
+When Codex or another AI agent works in a vx-managed repository, use vx-managed
+Git and GitHub CLI commands. Do not run bare `git` or bare `gh`.
+
+```bash
+vx git status --short --branch
+vx git fetch origin main
+vx git checkout -B fix/example origin/main
+vx git diff --stat
+vx git add path/to/file
+vx git commit -m "fix: example"
+
+vx gh issue view 123
+vx gh pr view 456 --json title,state,headRefName
+vx gh pr checks 456
+vx gh run view 789 --log
+```
+
+### Token-Efficient Agent Workflows
+
+vx is not just an installation wrapper. For agents, it is the stable way to use
+fast search, structured GitHub queries, JSON filters, and scoped diffs without
+spending tokens on irrelevant output.
+
+Prefer narrow, structured commands before broad dumps:
+
+```bash
+# Search and file discovery
+vx rg -n --glob '!target/**' --glob '!node_modules/**' "OutputRenderer"
+vx rg --files -g '*.rs' -g '!target/**'
+vx fd provider.star crates/vx-providers
+
+# Git context with small output first
+vx git status --short --branch
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx git grep -n "CommandOutput" origin/main -- crates/vx-cli
+
+# GitHub context with selected fields
+vx gh issue view 123 --json title,state,labels,body
+vx gh pr view 456 --json title,state,headRefName,baseRefName,files
+vx gh pr checks 456 --json name,state,conclusion,link
+vx gh run view 789 --log | vx rg -n "error|failed|panic|warning"
+
+# Structured filtering
+vx jq -r '.files[].path' pr.json
+vx yq '.jobs | keys' .github/workflows/ci.yml
+```
+
+Token-saving defaults for agents:
+- Start with `vx rg`, `vx fd`, `vx git diff --stat`, and `vx git diff --name-only`; open full files or full diffs only after locating the relevant surface.
+- Use `vx gh --json ...` with selected fields, and add `--jq` when a small projection is enough.
+- Use vx structured output flags when the vx command supports them: `--json`, `--fields`, `--toon`, or `--output-format toon`.
+- For forwarded runtimes like `vx node`, `vx cargo`, or `vx npm`, use that tool's own quiet, JSON, or filtering flags when available.
+- Pipe large logs through vx-managed filters such as `vx rg`, `vx jq`, or `vx yq` before reading them.
+
+### Agent Operating Principles
+
+vx skills should help agents make small, correct, maintainable changes with
+bounded context. Treat vx as a token-aware execution layer, not just a command
+prefix.
+
+Use this loop for coding tasks:
+1. Inspect the narrowest relevant file, symbol, diff, log, or test output first.
+2. Prefer existing project patterns over new helpers or abstractions.
+3. Make the smallest maintainable change that solves the actual request.
+4. Validate with the cheapest useful scoped command for the risk involved.
+5. Summarize only what changed, what was checked, and any remaining risk.
+
+Context discipline:
+- Scope before printing. Search paths first, then open focused file sections.
+- Avoid dumping full files, broad diffs, generated output, or full CI logs unless the task truly requires them.
+- For unknown or potentially huge output, cap and filter with vx-managed tools.
+- Do not cap instruction files, skill files, or agent policy files; read the relevant one fully unless it is unexpectedly huge.
+- If capped output is insufficient, narrow the query before increasing the cap.
+
+Examples:
+
+```bash
+vx rg -n -m 20 "render_token_savings|OutputRenderer" crates/vx-cli crates/vx-metrics
+vx git diff --stat origin/main...HEAD
+vx git diff --name-only origin/main...HEAD
+vx gh run view 789 --log | vx rg -n -m 50 "error|failed|panic"
+vx metrics tokens --last 20 --json
+```
+
+Validation discipline:
+- Use focused checks first, such as `vx cargo test -p vx-cli --test cli_parsing_tests <case>`.
+- Run broader checks only when the touched surface or release risk justifies it.
+- Prefer evidence from the actual failing command, CI job, or runtime behavior over speculative fixes.
+- Do not add wrappers, maps, helper files, or validation layers unless they clearly reduce real complexity.
 
 ### Tool Management
 ```bash
@@ -82,14 +176,14 @@ rust = "1.80"       # Specific version
 just = "*"          # Any version
 
 [scripts]
-dev = "npm run dev"
-test = "cargo test"
-lint = "npm run lint && cargo clippy"
-build = "just build"
+dev = "vx npm run dev"
+test = "vx cargo test"
+lint = "vx npm run lint && vx cargo clippy"
+build = "vx just build"
 
 [hooks]
 pre_commit = ["vx run lint"]
-post_setup = ["npm install"]
+post_setup = ["vx npm install"]
 ```
 
 ## Using `--with` for Multi-Runtime
@@ -195,7 +289,7 @@ vx msvc@14.40 cl main.cpp
 | lib | `vx msvc lib` | Library manager |
 | nmake | `vx msvc nmake` | Make utility |
 
-## Supported Tools (105 Providers)
+## Supported Tools (137 Providers)
 
 | Category | Tools |
 |----------|-------|
@@ -203,12 +297,12 @@ vx msvc@14.40 cl main.cpp
 | **JS Tooling** | oxlint, biome |
 | **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
 | **Rust** | cargo, rustc, rustup |
-| **Go** | go, gofmt, gws |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
 | **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
 | **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
-| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, conan, vcpkg, spack |
-| **DevOps** | kubectl, helm, podman, terraform, hadolint, dagu, actionlint |
-| **Security** | gitleaks, trivy |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
 | **Cloud CLI** | awscli, azcli, gcloud |
 | **.NET** | dotnet, msbuild, nuget |
 | **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
@@ -219,11 +313,12 @@ vx msvc@14.40 cl main.cpp
 | **Container** | dive |
 | **Config Mgmt** | chezmoi, mise |
 | **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
 | **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
 
 ## Provider System (Starlark DSL)
 
-All 105 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+All 137 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
 
 vx uses a **two-phase execution model** (inspired by Buck2):
 1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
@@ -304,13 +399,17 @@ Key modules:
 2. **Use `vx just`** instead of `just` for task runner commands
 3. **Use `vx npm`** instead of `npm` directly
 4. **Use `vx cargo`** instead of `cargo` directly
-5. **Check `vx.toml`** first to understand project tool requirements
-6. **Use `vx run <script>`** for project-defined scripts
-7. **Never suggest manual tool installation** - vx handles it automatically
-8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
-9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
-10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
-11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+5. **Use `vx git`** instead of `git` for repository operations
+6. **Use `vx gh`** instead of `gh` for GitHub issue, PR, checks, and workflow operations
+7. **Use `vx rg`, `vx fd`, `vx jq`, and `vx yq`** for scoped search and structured filtering
+8. **Prefer token-efficient output**: `--json`, selected fields, `--jq`, `--toon`, `--output-format toon`, and narrow globs
+9. **Check `vx.toml`** first to understand project tool requirements
+10. **Use `vx run <script>`** for project-defined scripts
+11. **Never suggest manual tool installation** - vx handles it automatically
+12. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+13. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+14. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+15. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
 
 ## Version Resolution Priority
 

--- a/.roo/skills/vx-best-practices/SKILL.md
+++ b/.roo/skills/vx-best-practices/SKILL.md
@@ -46,6 +46,29 @@ git add vx.lock
 git commit -m "chore: update dependencies"
 ```
 
+### 4. Keep Agent Work Small and Observable
+
+When an AI agent uses vx, optimize for correctness, speed, judgment, and token
+efficiency:
+
+- Read enough surrounding code to understand the local pattern, then stop exploring.
+- Prefer targeted searches, focused file sections, scoped diffs, selected JSON fields, and capped logs.
+- Make the smallest maintainable change that solves the request.
+- Reuse existing project helpers before creating new abstractions.
+- Avoid single-use wrappers, speculative architecture, and unrelated cleanup.
+- Validate according to risk: focused tests for narrow changes, broader checks for shared behavior.
+- Preserve evidence from the actual command, CI job, or runtime surface when debugging.
+
+For large or unknown output, scope first and filter through vx-managed tools:
+
+```bash
+vx rg -n -m 20 "SearchTerm" src
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx gh pr view 123 --json title,state,files
+vx gh run view 456 --log | vx rg -n -m 50 "error|failed|panic"
+```
+
 ## Project Setup
 
 ### Initial Setup

--- a/.roo/skills/vx-commands/SKILL.md
+++ b/.roo/skills/vx-commands/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: vx-commands
-description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --output-format toon for token-optimized output."
 ---
 
 # VX Command Reference
 
-> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+> **Quick rule**: All vx commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
 
 ## Structured Output Commands (AI-Optimized)
 
-All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+All commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens).
 
 ### Project Analysis
 
@@ -108,7 +108,7 @@ vx list --json
 
 ### TOON Format (Token-Optimized)
 ```bash
-vx list --format toon
+vx list --output-format toon
 # Output:
 # runtimes[50]{name,installed,description}:
 #   node,true,Node.js runtime
@@ -190,7 +190,7 @@ vx cache clean              # Clean cache
 
 ```bash
 --json                      # JSON output
---format <text|json|toon>   # Output format
+--output-format <text|json|toon>   # Output format
 --verbose                   # Verbose output
 --debug                     # Debug output
 --use-system-path           # Use system PATH

--- a/.roo/skills/vx-usage/SKILL.md
+++ b/.roo/skills/vx-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vx-usage
-description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 105 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, Git/GitHub operations, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 137 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
 ---
 
 # VX - Universal Development Tool Manager
@@ -36,7 +36,101 @@ vx npx create-react-app app   # Run npx
 vx cargo test                 # Run cargo
 vx just build                 # Run just (task runner)
 vx git status                 # Run git
+vx gh pr status               # Run GitHub CLI
 ```
+
+### Git and GitHub for Codex
+
+When Codex or another AI agent works in a vx-managed repository, use vx-managed
+Git and GitHub CLI commands. Do not run bare `git` or bare `gh`.
+
+```bash
+vx git status --short --branch
+vx git fetch origin main
+vx git checkout -B fix/example origin/main
+vx git diff --stat
+vx git add path/to/file
+vx git commit -m "fix: example"
+
+vx gh issue view 123
+vx gh pr view 456 --json title,state,headRefName
+vx gh pr checks 456
+vx gh run view 789 --log
+```
+
+### Token-Efficient Agent Workflows
+
+vx is not just an installation wrapper. For agents, it is the stable way to use
+fast search, structured GitHub queries, JSON filters, and scoped diffs without
+spending tokens on irrelevant output.
+
+Prefer narrow, structured commands before broad dumps:
+
+```bash
+# Search and file discovery
+vx rg -n --glob '!target/**' --glob '!node_modules/**' "OutputRenderer"
+vx rg --files -g '*.rs' -g '!target/**'
+vx fd provider.star crates/vx-providers
+
+# Git context with small output first
+vx git status --short --branch
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx git grep -n "CommandOutput" origin/main -- crates/vx-cli
+
+# GitHub context with selected fields
+vx gh issue view 123 --json title,state,labels,body
+vx gh pr view 456 --json title,state,headRefName,baseRefName,files
+vx gh pr checks 456 --json name,state,conclusion,link
+vx gh run view 789 --log | vx rg -n "error|failed|panic|warning"
+
+# Structured filtering
+vx jq -r '.files[].path' pr.json
+vx yq '.jobs | keys' .github/workflows/ci.yml
+```
+
+Token-saving defaults for agents:
+- Start with `vx rg`, `vx fd`, `vx git diff --stat`, and `vx git diff --name-only`; open full files or full diffs only after locating the relevant surface.
+- Use `vx gh --json ...` with selected fields, and add `--jq` when a small projection is enough.
+- Use vx structured output flags when the vx command supports them: `--json`, `--fields`, `--toon`, or `--output-format toon`.
+- For forwarded runtimes like `vx node`, `vx cargo`, or `vx npm`, use that tool's own quiet, JSON, or filtering flags when available.
+- Pipe large logs through vx-managed filters such as `vx rg`, `vx jq`, or `vx yq` before reading them.
+
+### Agent Operating Principles
+
+vx skills should help agents make small, correct, maintainable changes with
+bounded context. Treat vx as a token-aware execution layer, not just a command
+prefix.
+
+Use this loop for coding tasks:
+1. Inspect the narrowest relevant file, symbol, diff, log, or test output first.
+2. Prefer existing project patterns over new helpers or abstractions.
+3. Make the smallest maintainable change that solves the actual request.
+4. Validate with the cheapest useful scoped command for the risk involved.
+5. Summarize only what changed, what was checked, and any remaining risk.
+
+Context discipline:
+- Scope before printing. Search paths first, then open focused file sections.
+- Avoid dumping full files, broad diffs, generated output, or full CI logs unless the task truly requires them.
+- For unknown or potentially huge output, cap and filter with vx-managed tools.
+- Do not cap instruction files, skill files, or agent policy files; read the relevant one fully unless it is unexpectedly huge.
+- If capped output is insufficient, narrow the query before increasing the cap.
+
+Examples:
+
+```bash
+vx rg -n -m 20 "render_token_savings|OutputRenderer" crates/vx-cli crates/vx-metrics
+vx git diff --stat origin/main...HEAD
+vx git diff --name-only origin/main...HEAD
+vx gh run view 789 --log | vx rg -n -m 50 "error|failed|panic"
+vx metrics tokens --last 20 --json
+```
+
+Validation discipline:
+- Use focused checks first, such as `vx cargo test -p vx-cli --test cli_parsing_tests <case>`.
+- Run broader checks only when the touched surface or release risk justifies it.
+- Prefer evidence from the actual failing command, CI job, or runtime behavior over speculative fixes.
+- Do not add wrappers, maps, helper files, or validation layers unless they clearly reduce real complexity.
 
 ### Tool Management
 ```bash
@@ -82,14 +176,14 @@ rust = "1.80"       # Specific version
 just = "*"          # Any version
 
 [scripts]
-dev = "npm run dev"
-test = "cargo test"
-lint = "npm run lint && cargo clippy"
-build = "just build"
+dev = "vx npm run dev"
+test = "vx cargo test"
+lint = "vx npm run lint && vx cargo clippy"
+build = "vx just build"
 
 [hooks]
 pre_commit = ["vx run lint"]
-post_setup = ["npm install"]
+post_setup = ["vx npm install"]
 ```
 
 ## Using `--with` for Multi-Runtime
@@ -195,7 +289,7 @@ vx msvc@14.40 cl main.cpp
 | lib | `vx msvc lib` | Library manager |
 | nmake | `vx msvc nmake` | Make utility |
 
-## Supported Tools (105 Providers)
+## Supported Tools (137 Providers)
 
 | Category | Tools |
 |----------|-------|
@@ -203,12 +297,12 @@ vx msvc@14.40 cl main.cpp
 | **JS Tooling** | oxlint, biome |
 | **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
 | **Rust** | cargo, rustc, rustup |
-| **Go** | go, gofmt, gws |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
 | **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
 | **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
-| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, conan, vcpkg, spack |
-| **DevOps** | kubectl, helm, podman, terraform, hadolint, dagu, actionlint |
-| **Security** | gitleaks, trivy |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
 | **Cloud CLI** | awscli, azcli, gcloud |
 | **.NET** | dotnet, msbuild, nuget |
 | **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
@@ -219,11 +313,12 @@ vx msvc@14.40 cl main.cpp
 | **Container** | dive |
 | **Config Mgmt** | chezmoi, mise |
 | **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
 | **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
 
 ## Provider System (Starlark DSL)
 
-All 105 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+All 137 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
 
 vx uses a **two-phase execution model** (inspired by Buck2):
 1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
@@ -304,13 +399,17 @@ Key modules:
 2. **Use `vx just`** instead of `just` for task runner commands
 3. **Use `vx npm`** instead of `npm` directly
 4. **Use `vx cargo`** instead of `cargo` directly
-5. **Check `vx.toml`** first to understand project tool requirements
-6. **Use `vx run <script>`** for project-defined scripts
-7. **Never suggest manual tool installation** - vx handles it automatically
-8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
-9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
-10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
-11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+5. **Use `vx git`** instead of `git` for repository operations
+6. **Use `vx gh`** instead of `gh` for GitHub issue, PR, checks, and workflow operations
+7. **Use `vx rg`, `vx fd`, `vx jq`, and `vx yq`** for scoped search and structured filtering
+8. **Prefer token-efficient output**: `--json`, selected fields, `--jq`, `--toon`, `--output-format toon`, and narrow globs
+9. **Check `vx.toml`** first to understand project tool requirements
+10. **Use `vx run <script>`** for project-defined scripts
+11. **Never suggest manual tool installation** - vx handles it automatically
+12. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+13. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+14. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+15. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
 
 ## Version Resolution Priority
 

--- a/.trae/skills/vx-best-practices/SKILL.md
+++ b/.trae/skills/vx-best-practices/SKILL.md
@@ -46,6 +46,29 @@ git add vx.lock
 git commit -m "chore: update dependencies"
 ```
 
+### 4. Keep Agent Work Small and Observable
+
+When an AI agent uses vx, optimize for correctness, speed, judgment, and token
+efficiency:
+
+- Read enough surrounding code to understand the local pattern, then stop exploring.
+- Prefer targeted searches, focused file sections, scoped diffs, selected JSON fields, and capped logs.
+- Make the smallest maintainable change that solves the request.
+- Reuse existing project helpers before creating new abstractions.
+- Avoid single-use wrappers, speculative architecture, and unrelated cleanup.
+- Validate according to risk: focused tests for narrow changes, broader checks for shared behavior.
+- Preserve evidence from the actual command, CI job, or runtime surface when debugging.
+
+For large or unknown output, scope first and filter through vx-managed tools:
+
+```bash
+vx rg -n -m 20 "SearchTerm" src
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx gh pr view 123 --json title,state,files
+vx gh run view 456 --log | vx rg -n -m 50 "error|failed|panic"
+```
+
 ## Project Setup
 
 ### Initial Setup

--- a/.trae/skills/vx-commands/SKILL.md
+++ b/.trae/skills/vx-commands/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: vx-commands
-description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --output-format toon for token-optimized output."
 ---
 
 # VX Command Reference
 
-> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+> **Quick rule**: All vx commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
 
 ## Structured Output Commands (AI-Optimized)
 
-All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+All commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens).
 
 ### Project Analysis
 
@@ -108,7 +108,7 @@ vx list --json
 
 ### TOON Format (Token-Optimized)
 ```bash
-vx list --format toon
+vx list --output-format toon
 # Output:
 # runtimes[50]{name,installed,description}:
 #   node,true,Node.js runtime
@@ -190,7 +190,7 @@ vx cache clean              # Clean cache
 
 ```bash
 --json                      # JSON output
---format <text|json|toon>   # Output format
+--output-format <text|json|toon>   # Output format
 --verbose                   # Verbose output
 --debug                     # Debug output
 --use-system-path           # Use system PATH

--- a/.trae/skills/vx-usage/SKILL.md
+++ b/.trae/skills/vx-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vx-usage
-description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 105 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, Git/GitHub operations, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 137 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
 ---
 
 # VX - Universal Development Tool Manager
@@ -36,7 +36,101 @@ vx npx create-react-app app   # Run npx
 vx cargo test                 # Run cargo
 vx just build                 # Run just (task runner)
 vx git status                 # Run git
+vx gh pr status               # Run GitHub CLI
 ```
+
+### Git and GitHub for Codex
+
+When Codex or another AI agent works in a vx-managed repository, use vx-managed
+Git and GitHub CLI commands. Do not run bare `git` or bare `gh`.
+
+```bash
+vx git status --short --branch
+vx git fetch origin main
+vx git checkout -B fix/example origin/main
+vx git diff --stat
+vx git add path/to/file
+vx git commit -m "fix: example"
+
+vx gh issue view 123
+vx gh pr view 456 --json title,state,headRefName
+vx gh pr checks 456
+vx gh run view 789 --log
+```
+
+### Token-Efficient Agent Workflows
+
+vx is not just an installation wrapper. For agents, it is the stable way to use
+fast search, structured GitHub queries, JSON filters, and scoped diffs without
+spending tokens on irrelevant output.
+
+Prefer narrow, structured commands before broad dumps:
+
+```bash
+# Search and file discovery
+vx rg -n --glob '!target/**' --glob '!node_modules/**' "OutputRenderer"
+vx rg --files -g '*.rs' -g '!target/**'
+vx fd provider.star crates/vx-providers
+
+# Git context with small output first
+vx git status --short --branch
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx git grep -n "CommandOutput" origin/main -- crates/vx-cli
+
+# GitHub context with selected fields
+vx gh issue view 123 --json title,state,labels,body
+vx gh pr view 456 --json title,state,headRefName,baseRefName,files
+vx gh pr checks 456 --json name,state,conclusion,link
+vx gh run view 789 --log | vx rg -n "error|failed|panic|warning"
+
+# Structured filtering
+vx jq -r '.files[].path' pr.json
+vx yq '.jobs | keys' .github/workflows/ci.yml
+```
+
+Token-saving defaults for agents:
+- Start with `vx rg`, `vx fd`, `vx git diff --stat`, and `vx git diff --name-only`; open full files or full diffs only after locating the relevant surface.
+- Use `vx gh --json ...` with selected fields, and add `--jq` when a small projection is enough.
+- Use vx structured output flags when the vx command supports them: `--json`, `--fields`, `--toon`, or `--output-format toon`.
+- For forwarded runtimes like `vx node`, `vx cargo`, or `vx npm`, use that tool's own quiet, JSON, or filtering flags when available.
+- Pipe large logs through vx-managed filters such as `vx rg`, `vx jq`, or `vx yq` before reading them.
+
+### Agent Operating Principles
+
+vx skills should help agents make small, correct, maintainable changes with
+bounded context. Treat vx as a token-aware execution layer, not just a command
+prefix.
+
+Use this loop for coding tasks:
+1. Inspect the narrowest relevant file, symbol, diff, log, or test output first.
+2. Prefer existing project patterns over new helpers or abstractions.
+3. Make the smallest maintainable change that solves the actual request.
+4. Validate with the cheapest useful scoped command for the risk involved.
+5. Summarize only what changed, what was checked, and any remaining risk.
+
+Context discipline:
+- Scope before printing. Search paths first, then open focused file sections.
+- Avoid dumping full files, broad diffs, generated output, or full CI logs unless the task truly requires them.
+- For unknown or potentially huge output, cap and filter with vx-managed tools.
+- Do not cap instruction files, skill files, or agent policy files; read the relevant one fully unless it is unexpectedly huge.
+- If capped output is insufficient, narrow the query before increasing the cap.
+
+Examples:
+
+```bash
+vx rg -n -m 20 "render_token_savings|OutputRenderer" crates/vx-cli crates/vx-metrics
+vx git diff --stat origin/main...HEAD
+vx git diff --name-only origin/main...HEAD
+vx gh run view 789 --log | vx rg -n -m 50 "error|failed|panic"
+vx metrics tokens --last 20 --json
+```
+
+Validation discipline:
+- Use focused checks first, such as `vx cargo test -p vx-cli --test cli_parsing_tests <case>`.
+- Run broader checks only when the touched surface or release risk justifies it.
+- Prefer evidence from the actual failing command, CI job, or runtime behavior over speculative fixes.
+- Do not add wrappers, maps, helper files, or validation layers unless they clearly reduce real complexity.
 
 ### Tool Management
 ```bash
@@ -82,14 +176,14 @@ rust = "1.80"       # Specific version
 just = "*"          # Any version
 
 [scripts]
-dev = "npm run dev"
-test = "cargo test"
-lint = "npm run lint && cargo clippy"
-build = "just build"
+dev = "vx npm run dev"
+test = "vx cargo test"
+lint = "vx npm run lint && vx cargo clippy"
+build = "vx just build"
 
 [hooks]
 pre_commit = ["vx run lint"]
-post_setup = ["npm install"]
+post_setup = ["vx npm install"]
 ```
 
 ## Using `--with` for Multi-Runtime
@@ -195,7 +289,7 @@ vx msvc@14.40 cl main.cpp
 | lib | `vx msvc lib` | Library manager |
 | nmake | `vx msvc nmake` | Make utility |
 
-## Supported Tools (105 Providers)
+## Supported Tools (137 Providers)
 
 | Category | Tools |
 |----------|-------|
@@ -203,12 +297,12 @@ vx msvc@14.40 cl main.cpp
 | **JS Tooling** | oxlint, biome |
 | **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
 | **Rust** | cargo, rustc, rustup |
-| **Go** | go, gofmt, gws |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
 | **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
 | **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
-| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, conan, vcpkg, spack |
-| **DevOps** | kubectl, helm, podman, terraform, hadolint, dagu, actionlint |
-| **Security** | gitleaks, trivy |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
 | **Cloud CLI** | awscli, azcli, gcloud |
 | **.NET** | dotnet, msbuild, nuget |
 | **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
@@ -219,11 +313,12 @@ vx msvc@14.40 cl main.cpp
 | **Container** | dive |
 | **Config Mgmt** | chezmoi, mise |
 | **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
 | **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
 
 ## Provider System (Starlark DSL)
 
-All 105 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+All 137 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
 
 vx uses a **two-phase execution model** (inspired by Buck2):
 1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
@@ -304,13 +399,17 @@ Key modules:
 2. **Use `vx just`** instead of `just` for task runner commands
 3. **Use `vx npm`** instead of `npm` directly
 4. **Use `vx cargo`** instead of `cargo` directly
-5. **Check `vx.toml`** first to understand project tool requirements
-6. **Use `vx run <script>`** for project-defined scripts
-7. **Never suggest manual tool installation** - vx handles it automatically
-8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
-9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
-10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
-11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+5. **Use `vx git`** instead of `git` for repository operations
+6. **Use `vx gh`** instead of `gh` for GitHub issue, PR, checks, and workflow operations
+7. **Use `vx rg`, `vx fd`, `vx jq`, and `vx yq`** for scoped search and structured filtering
+8. **Prefer token-efficient output**: `--json`, selected fields, `--jq`, `--toon`, `--output-format toon`, and narrow globs
+9. **Check `vx.toml`** first to understand project tool requirements
+10. **Use `vx run <script>`** for project-defined scripts
+11. **Never suggest manual tool installation** - vx handles it automatically
+12. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+13. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+14. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+15. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
 
 ## Version Resolution Priority
 

--- a/.windsurf/skills/vx-best-practices/SKILL.md
+++ b/.windsurf/skills/vx-best-practices/SKILL.md
@@ -46,6 +46,29 @@ git add vx.lock
 git commit -m "chore: update dependencies"
 ```
 
+### 4. Keep Agent Work Small and Observable
+
+When an AI agent uses vx, optimize for correctness, speed, judgment, and token
+efficiency:
+
+- Read enough surrounding code to understand the local pattern, then stop exploring.
+- Prefer targeted searches, focused file sections, scoped diffs, selected JSON fields, and capped logs.
+- Make the smallest maintainable change that solves the request.
+- Reuse existing project helpers before creating new abstractions.
+- Avoid single-use wrappers, speculative architecture, and unrelated cleanup.
+- Validate according to risk: focused tests for narrow changes, broader checks for shared behavior.
+- Preserve evidence from the actual command, CI job, or runtime surface when debugging.
+
+For large or unknown output, scope first and filter through vx-managed tools:
+
+```bash
+vx rg -n -m 20 "SearchTerm" src
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx gh pr view 123 --json title,state,files
+vx gh run view 456 --log | vx rg -n -m 50 "error|failed|panic"
+```
+
 ## Project Setup
 
 ### Initial Setup

--- a/.windsurf/skills/vx-commands/SKILL.md
+++ b/.windsurf/skills/vx-commands/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: vx-commands
-description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --output-format toon for token-optimized output."
 ---
 
 # VX Command Reference
 
-> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+> **Quick rule**: All vx commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
 
 ## Structured Output Commands (AI-Optimized)
 
-All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+All commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens).
 
 ### Project Analysis
 
@@ -108,7 +108,7 @@ vx list --json
 
 ### TOON Format (Token-Optimized)
 ```bash
-vx list --format toon
+vx list --output-format toon
 # Output:
 # runtimes[50]{name,installed,description}:
 #   node,true,Node.js runtime
@@ -190,7 +190,7 @@ vx cache clean              # Clean cache
 
 ```bash
 --json                      # JSON output
---format <text|json|toon>   # Output format
+--output-format <text|json|toon>   # Output format
 --verbose                   # Verbose output
 --debug                     # Debug output
 --use-system-path           # Use system PATH

--- a/.windsurf/skills/vx-usage/SKILL.md
+++ b/.windsurf/skills/vx-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vx-usage
-description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 105 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, Git/GitHub operations, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 137 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
 ---
 
 # VX - Universal Development Tool Manager
@@ -36,7 +36,101 @@ vx npx create-react-app app   # Run npx
 vx cargo test                 # Run cargo
 vx just build                 # Run just (task runner)
 vx git status                 # Run git
+vx gh pr status               # Run GitHub CLI
 ```
+
+### Git and GitHub for Codex
+
+When Codex or another AI agent works in a vx-managed repository, use vx-managed
+Git and GitHub CLI commands. Do not run bare `git` or bare `gh`.
+
+```bash
+vx git status --short --branch
+vx git fetch origin main
+vx git checkout -B fix/example origin/main
+vx git diff --stat
+vx git add path/to/file
+vx git commit -m "fix: example"
+
+vx gh issue view 123
+vx gh pr view 456 --json title,state,headRefName
+vx gh pr checks 456
+vx gh run view 789 --log
+```
+
+### Token-Efficient Agent Workflows
+
+vx is not just an installation wrapper. For agents, it is the stable way to use
+fast search, structured GitHub queries, JSON filters, and scoped diffs without
+spending tokens on irrelevant output.
+
+Prefer narrow, structured commands before broad dumps:
+
+```bash
+# Search and file discovery
+vx rg -n --glob '!target/**' --glob '!node_modules/**' "OutputRenderer"
+vx rg --files -g '*.rs' -g '!target/**'
+vx fd provider.star crates/vx-providers
+
+# Git context with small output first
+vx git status --short --branch
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx git grep -n "CommandOutput" origin/main -- crates/vx-cli
+
+# GitHub context with selected fields
+vx gh issue view 123 --json title,state,labels,body
+vx gh pr view 456 --json title,state,headRefName,baseRefName,files
+vx gh pr checks 456 --json name,state,conclusion,link
+vx gh run view 789 --log | vx rg -n "error|failed|panic|warning"
+
+# Structured filtering
+vx jq -r '.files[].path' pr.json
+vx yq '.jobs | keys' .github/workflows/ci.yml
+```
+
+Token-saving defaults for agents:
+- Start with `vx rg`, `vx fd`, `vx git diff --stat`, and `vx git diff --name-only`; open full files or full diffs only after locating the relevant surface.
+- Use `vx gh --json ...` with selected fields, and add `--jq` when a small projection is enough.
+- Use vx structured output flags when the vx command supports them: `--json`, `--fields`, `--toon`, or `--output-format toon`.
+- For forwarded runtimes like `vx node`, `vx cargo`, or `vx npm`, use that tool's own quiet, JSON, or filtering flags when available.
+- Pipe large logs through vx-managed filters such as `vx rg`, `vx jq`, or `vx yq` before reading them.
+
+### Agent Operating Principles
+
+vx skills should help agents make small, correct, maintainable changes with
+bounded context. Treat vx as a token-aware execution layer, not just a command
+prefix.
+
+Use this loop for coding tasks:
+1. Inspect the narrowest relevant file, symbol, diff, log, or test output first.
+2. Prefer existing project patterns over new helpers or abstractions.
+3. Make the smallest maintainable change that solves the actual request.
+4. Validate with the cheapest useful scoped command for the risk involved.
+5. Summarize only what changed, what was checked, and any remaining risk.
+
+Context discipline:
+- Scope before printing. Search paths first, then open focused file sections.
+- Avoid dumping full files, broad diffs, generated output, or full CI logs unless the task truly requires them.
+- For unknown or potentially huge output, cap and filter with vx-managed tools.
+- Do not cap instruction files, skill files, or agent policy files; read the relevant one fully unless it is unexpectedly huge.
+- If capped output is insufficient, narrow the query before increasing the cap.
+
+Examples:
+
+```bash
+vx rg -n -m 20 "render_token_savings|OutputRenderer" crates/vx-cli crates/vx-metrics
+vx git diff --stat origin/main...HEAD
+vx git diff --name-only origin/main...HEAD
+vx gh run view 789 --log | vx rg -n -m 50 "error|failed|panic"
+vx metrics tokens --last 20 --json
+```
+
+Validation discipline:
+- Use focused checks first, such as `vx cargo test -p vx-cli --test cli_parsing_tests <case>`.
+- Run broader checks only when the touched surface or release risk justifies it.
+- Prefer evidence from the actual failing command, CI job, or runtime behavior over speculative fixes.
+- Do not add wrappers, maps, helper files, or validation layers unless they clearly reduce real complexity.
 
 ### Tool Management
 ```bash
@@ -82,14 +176,14 @@ rust = "1.80"       # Specific version
 just = "*"          # Any version
 
 [scripts]
-dev = "npm run dev"
-test = "cargo test"
-lint = "npm run lint && cargo clippy"
-build = "just build"
+dev = "vx npm run dev"
+test = "vx cargo test"
+lint = "vx npm run lint && vx cargo clippy"
+build = "vx just build"
 
 [hooks]
 pre_commit = ["vx run lint"]
-post_setup = ["npm install"]
+post_setup = ["vx npm install"]
 ```
 
 ## Using `--with` for Multi-Runtime
@@ -195,7 +289,7 @@ vx msvc@14.40 cl main.cpp
 | lib | `vx msvc lib` | Library manager |
 | nmake | `vx msvc nmake` | Make utility |
 
-## Supported Tools (105 Providers)
+## Supported Tools (137 Providers)
 
 | Category | Tools |
 |----------|-------|
@@ -203,12 +297,12 @@ vx msvc@14.40 cl main.cpp
 | **JS Tooling** | oxlint, biome |
 | **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
 | **Rust** | cargo, rustc, rustup |
-| **Go** | go, gofmt, gws |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
 | **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
 | **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
-| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, conan, vcpkg, spack |
-| **DevOps** | kubectl, helm, podman, terraform, hadolint, dagu, actionlint |
-| **Security** | gitleaks, trivy |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
 | **Cloud CLI** | awscli, azcli, gcloud |
 | **.NET** | dotnet, msbuild, nuget |
 | **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
@@ -219,11 +313,12 @@ vx msvc@14.40 cl main.cpp
 | **Container** | dive |
 | **Config Mgmt** | chezmoi, mise |
 | **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
 | **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
 
 ## Provider System (Starlark DSL)
 
-All 105 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+All 137 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
 
 vx uses a **two-phase execution model** (inspired by Buck2):
 1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
@@ -304,13 +399,17 @@ Key modules:
 2. **Use `vx just`** instead of `just` for task runner commands
 3. **Use `vx npm`** instead of `npm` directly
 4. **Use `vx cargo`** instead of `cargo` directly
-5. **Check `vx.toml`** first to understand project tool requirements
-6. **Use `vx run <script>`** for project-defined scripts
-7. **Never suggest manual tool installation** - vx handles it automatically
-8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
-9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
-10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
-11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+5. **Use `vx git`** instead of `git` for repository operations
+6. **Use `vx gh`** instead of `gh` for GitHub issue, PR, checks, and workflow operations
+7. **Use `vx rg`, `vx fd`, `vx jq`, and `vx yq`** for scoped search and structured filtering
+8. **Prefer token-efficient output**: `--json`, selected fields, `--jq`, `--toon`, `--output-format toon`, and narrow globs
+9. **Check `vx.toml`** first to understand project tool requirements
+10. **Use `vx run <script>`** for project-defined scripts
+11. **Never suggest manual tool installation** - vx handles it automatically
+12. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+13. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+14. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+15. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
 
 ## Version Resolution Priority
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,7 +487,7 @@ Use `@main` for latest, or pin to a release tag. Full guide: [`docs/guides/githu
 
 1. **Check for `vx.toml`** → if present, always use `vx` prefix
 2. **Never suggest manual installation** — `vx` handles it
-3. **Use structured output**: `vx list --json` or `vx list --format toon`
+3. **Use structured output**: `vx list --json` or `vx list --output-format toon`
 4. **For MCP servers**, replace `npx`/`uvx` with `vx` in config
 5. **For CI/CD**, use `loonghao/vx@main` GitHub Action
 
@@ -572,6 +572,6 @@ For a full error-by-error decision tree, see [`docs/appendix/troubleshooting.md`
 
 ```bash
 vx list --json             # JSON output
-vx list --format toon      # Token-optimized (saves 40-60% tokens)
+vx list --output-format toon      # Token-optimized (saves 40-60% tokens)
 vx analyze --json          # Project analysis
 ```

--- a/crates/vx-cli/src/cli.rs
+++ b/crates/vx-cli/src/cli.rs
@@ -41,7 +41,7 @@ pub enum FilterLevelArg {
 ///
 /// **TTY auto-selection:** when stdout is a TTY the renderer defaults to `text`.
 /// When stdout is NOT a TTY (pipe, script, AI agent) the renderer defaults to
-/// `toon` — token-optimised output that saves 40-60% tokens vs JSON.
+/// `toon` — token-oriented output for LLM prompts.
 /// Override with `VX_OUTPUT=json` to get JSON, or `VX_OUTPUT=compact` for RTK-style.
 #[derive(ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum OutputFormat {
@@ -50,7 +50,7 @@ pub enum OutputFormat {
     Text,
     /// JSON structured output (for scripts/CI/AI parsing)
     Json,
-    /// TOON format output — token-optimised for LLM prompts, saves 40-60% tokens.
+    /// TOON format output — token-oriented for LLM prompts.
     ///
     /// **Automatic default for non-TTY** (pipes, scripts, AI agents).
     /// Prefer over JSON for AI agent consumption; use `VX_OUTPUT=json` when
@@ -59,7 +59,7 @@ pub enum OutputFormat {
     /// Compact RTK-style one-liner output (ASCII icons, minimal tokens)
     ///
     /// Inspired by rtk (rtk-ai/rtk). Reduces token usage 60-80% vs text format.
-    /// Use with `VX_OUTPUT=compact` or `--format compact` / `-u`.
+    /// Use with `VX_OUTPUT=compact`, `--output-format compact`, or `-u`.
     /// Example: `ok node@22` instead of verbose install messages.
     Compact,
 }
@@ -207,9 +207,14 @@ pub struct Cli {
     /// Output format: text, json, toon, compact (RFC 0031).
     ///
     /// In an interactive TTY the default is `text`. When stdout is piped/redirected
-    /// the renderer automatically uses `toon` (token-optimised, saves 40-60% tokens).
+    /// the renderer automatically uses `toon` (token-oriented for LLM prompts).
     /// Set `VX_OUTPUT=json` to force JSON, or `VX_OUTPUT=compact` for RTK-style.
-    #[arg(long = "output-format", global = true, value_enum, default_value_t = OutputFormat::Text)]
+    #[arg(
+        long = "output-format",
+        global = true,
+        value_enum,
+        default_value_t = OutputFormat::Text
+    )]
     pub output_format: OutputFormat,
 
     /// JSON output shortcut (equivalent to --output-format json)
@@ -829,6 +834,8 @@ pub enum Commands {
 
     /// View execution performance metrics and reports
     Metrics {
+        #[command(subcommand)]
+        command: Option<MetricsCommand>,
         /// Number of recent runs to show (default: 10)
         #[arg(long, short = 'n', default_value = "10")]
         last: usize,
@@ -1118,6 +1125,19 @@ pub enum ConfigCommand {
     },
     /// Show configuration directory path
     Dir,
+}
+
+#[derive(Subcommand, Clone)]
+pub enum MetricsCommand {
+    /// Show estimated token savings from TOON and compact output
+    Tokens {
+        /// Number of recent runs to inspect (default: 100)
+        #[arg(long, short = 'n', default_value = "100")]
+        last: usize,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand, Clone)]
@@ -1566,7 +1586,7 @@ impl CommandHandler for Commands {
 
     async fn execute(&self, ctx: &CommandContext) -> Result<()> {
         match self {
-            Commands::Version => commands::version::handle().await,
+            Commands::Version => commands::version::handle(ctx.output_format()).await,
 
             Commands::Analyze { json, verbose } => commands::analyze::handle(*json, *verbose).await,
 
@@ -1696,7 +1716,9 @@ impl CommandHandler for Commands {
             }
 
             Commands::Config { command } => match command {
-                Some(ConfigCommand::Show) | None => commands::config::handle().await,
+                Some(ConfigCommand::Show) | None => {
+                    commands::config::handle(ctx.output_format()).await
+                }
                 Some(ConfigCommand::Set { key, value }) => {
                     commands::config::handle_set(key, value).await
                 }
@@ -2181,11 +2203,17 @@ impl CommandHandler for Commands {
             }
 
             Commands::Metrics {
+                command,
                 last,
                 json,
                 html,
                 clean,
-            } => commands::metrics::handle(*last, *json, html.clone(), *clean).await,
+            } => match command {
+                Some(MetricsCommand::Tokens { last, json }) => {
+                    commands::metrics::handle_tokens(*last, *json).await
+                }
+                None => commands::metrics::handle(*last, *json, html.clone(), *clean).await,
+            },
 
             Commands::Auth { command } => match command {
                 AuthCommand::Login { service, token } => {

--- a/crates/vx-cli/src/commands/check.rs
+++ b/crates/vx-cli/src/commands/check.rs
@@ -69,11 +69,11 @@ pub async fn handle(
 
             if !quiet {
                 let renderer = OutputRenderer::new(format);
-                if renderer.is_json() {
-                    renderer.render(&output)?;
-                } else {
+                if renderer.is_text() {
                     UI::warn("No vx.toml found in current directory or parents");
                     UI::hint("Run 'vx init' to create a project configuration");
+                } else {
+                    renderer.render(&output)?;
                 }
             }
             std::process::exit(1);
@@ -94,10 +94,10 @@ pub async fn handle(
 
         if !quiet {
             let renderer = OutputRenderer::new(format);
-            if renderer.is_json() {
-                renderer.render(&output)?;
-            } else {
+            if renderer.is_text() {
                 UI::info("No tools configured in vx.toml");
+            } else {
+                renderer.render(&output)?;
             }
         }
         return Ok(());
@@ -252,11 +252,11 @@ pub async fn handle(
     // Render output
     if !quiet {
         let renderer = OutputRenderer::new(format);
-        if renderer.is_json() {
-            renderer.render(&output)?;
-        } else {
+        if renderer.is_text() {
             // Text mode with optional details
             render_text_output(&output, detailed)?;
+        } else {
+            renderer.render(&output)?;
         }
     }
 

--- a/crates/vx-cli/src/commands/config.rs
+++ b/crates/vx-cli/src/commands/config.rs
@@ -1,36 +1,119 @@
 // Config command implementation
 
+use crate::cli::OutputFormat;
+use crate::output::{CommandOutput, OutputRenderer};
 use crate::ui::UI;
 use anyhow::Result;
+use serde::Serialize;
 use std::env;
 use std::path::PathBuf;
 use vx_paths::{CONFIG_FILE_NAME, find_config_file};
 
-pub async fn handle() -> Result<()> {
+#[derive(Serialize)]
+struct ConfigShowOutput {
+    found: bool,
+    file: Option<String>,
+    project: Option<String>,
+    tools_count: usize,
+    scripts_count: usize,
+    services_count: usize,
+    warnings: Vec<String>,
+}
+
+impl CommandOutput for ConfigShowOutput {
+    fn render_text(&self, writer: &mut dyn std::io::Write) -> Result<()> {
+        if !self.found {
+            writeln!(
+                writer,
+                "No vx.toml found in current directory or parent directories"
+            )?;
+            writeln!(writer, "Run 'vx init' to create one")?;
+            return Ok(());
+        }
+
+        writeln!(writer, "Project Configuration")?;
+        if let Some(file) = &self.file {
+            writeln!(writer, "File: {}", file)?;
+        }
+        if let Some(project) = &self.project {
+            writeln!(writer, "Project: {}", project)?;
+        }
+        writeln!(writer, "Tools: {}", self.tools_count)?;
+        writeln!(writer, "Scripts: {}", self.scripts_count)?;
+        writeln!(writer, "Services: {}", self.services_count)?;
+        Ok(())
+    }
+
+    fn render_compact(&self, writer: &mut dyn std::io::Write) -> Result<()> {
+        if !self.found {
+            writeln!(writer, "err no vx.toml")?;
+            return Ok(());
+        }
+
+        writeln!(
+            writer,
+            "config tools:{} scripts:{} services:{} file:{}",
+            self.tools_count,
+            self.scripts_count,
+            self.services_count,
+            self.file.as_deref().unwrap_or("")
+        )?;
+        Ok(())
+    }
+}
+
+pub async fn handle(format: OutputFormat) -> Result<()> {
     use vx_config::parse_config;
 
+    let renderer = OutputRenderer::new(format);
     let current_dir = env::current_dir()?;
     let Some(config_path) = find_config_file(&current_dir) else {
-        UI::warning("No vx.toml found in current directory or parent directories");
-        UI::hint("Run 'vx init' to create one");
+        let output = ConfigShowOutput {
+            found: false,
+            file: None,
+            project: None,
+            tools_count: 0,
+            scripts_count: 0,
+            services_count: 0,
+            warnings: vec!["No vx.toml found".to_string()],
+        };
+        if renderer.is_text() {
+            UI::warning("No vx.toml found in current directory or parent directories");
+            UI::hint("Run 'vx init' to create one");
+        } else {
+            renderer.render(&output)?;
+        }
         return Ok(());
     };
 
     let config = parse_config(&config_path)?;
+    let project = config
+        .project
+        .as_ref()
+        .and_then(|project| project.name.clone());
+    let output = ConfigShowOutput {
+        found: true,
+        file: Some(config_path.display().to_string()),
+        project: project.clone(),
+        tools_count: config.tools.len(),
+        scripts_count: config.scripts.len(),
+        services_count: config.services.len(),
+        warnings: vec![],
+    };
 
-    UI::header("📋 Project Configuration");
-    println!();
-    UI::info(&format!("File: {}", config_path.display()));
-
-    if let Some(project) = &config.project
-        && let Some(name) = &project.name
-    {
-        UI::info(&format!("Project: {}", name));
+    if renderer.is_text() {
+        UI::header("📋 Project Configuration");
+        println!();
+        UI::info(&format!("File: {}", config_path.display()));
+        if let Some(name) = &project {
+            UI::info(&format!("Project: {}", name));
+        }
+        UI::info(&format!("Tools: {}", config.tools.len()));
+        UI::info(&format!("Scripts: {}", config.scripts.len()));
+        UI::info(&format!("Services: {}", config.services.len()));
+    } else {
+        renderer.render(&output)?;
     }
-
-    UI::info(&format!("Tools: {}", config.tools.len()));
-    UI::info(&format!("Scripts: {}", config.scripts.len()));
-    UI::info(&format!("Services: {}", config.services.len()));
 
     Ok(())
 }

--- a/crates/vx-cli/src/commands/fetch.rs
+++ b/crates/vx-cli/src/commands/fetch.rs
@@ -19,6 +19,7 @@ pub async fn handle(
     interactive: bool,
     format: OutputFormat,
 ) -> Result<()> {
+    let renderer = OutputRenderer::new(format);
     let runtime = match registry.get_runtime(tool_name) {
         Some(r) => r,
         None => {
@@ -29,9 +30,13 @@ pub async fn handle(
         }
     };
 
-    let spinner = ProgressSpinner::new(&format!("Fetching versions for {}...", tool_name));
+    let spinner = renderer
+        .is_text()
+        .then(|| ProgressSpinner::new(&format!("Fetching versions for {}...", tool_name)));
     let mut versions = runtime.fetch_versions(context).await?;
-    spinner.finish_and_clear();
+    if let Some(spinner) = spinner {
+        spinner.finish_and_clear();
+    }
 
     // Filter out prereleases if not requested
     if !include_prerelease {
@@ -47,7 +52,6 @@ pub async fn handle(
             lts: None,
         };
 
-        let renderer = OutputRenderer::new(format);
         renderer.render(&output)?;
         return Ok(());
     }
@@ -86,19 +90,15 @@ pub async fn handle(
         lts: lts_version,
     };
 
-    let renderer = OutputRenderer::new(format);
-
-    if renderer.is_json() {
-        renderer.render(&output)?;
-    } else {
-        // Text mode: use UI for header, then render results
+    if renderer.is_text() {
         UI::success(&format!("Found {} versions:", versions.len()));
-        renderer.render(&output)?;
+    }
 
-        if interactive {
-            UI::hint("Interactive version selection not yet implemented");
-            UI::hint(&format!("Use: vx install {}@<version>", tool_name));
-        }
+    renderer.render(&output)?;
+
+    if interactive && renderer.is_text() {
+        UI::hint("Interactive version selection not yet implemented");
+        UI::hint(&format!("Use: vx install {}@<version>", tool_name));
     }
 
     Ok(())

--- a/crates/vx-cli/src/commands/global/args.rs
+++ b/crates/vx-cli/src/commands/global/args.rs
@@ -68,7 +68,7 @@ pub struct ListGlobalArgs {
 /// Output format for global list command
 ///
 /// Note: This is a local format enum for the global list command.
-/// The global --json/--format flags (RFC 0031) take precedence when specified.
+/// The global --json/--output-format flags (RFC 0031) take precedence when specified.
 #[derive(Clone, Debug, Default, clap::ValueEnum)]
 pub enum GlobalListFormat {
     #[default]

--- a/crates/vx-cli/src/commands/list/handler.rs
+++ b/crates/vx-cli/src/commands/list/handler.rs
@@ -79,36 +79,31 @@ async fn list_system_tools(
     let discovery = discover_system_tools(registry, version_check);
 
     let renderer = OutputRenderer::new(format);
+    let mut runtimes = Vec::new();
 
-    if renderer.is_json() {
-        // JSON output
-        let mut runtimes = Vec::new();
+    for tool in &discovery.available {
+        runtimes.push(RuntimeEntry {
+            name: tool.name.clone(),
+            versions: tool.version.clone().map(|v| vec![v]).unwrap_or_default(),
+            installed: true,
+            description: tool.description.clone(),
+            platform_supported: true,
+            ecosystem: Some(tool.category.clone()),
+            platform_label: None,
+        });
+    }
 
-        // Group available tools by category (unused but kept for future use)
-        let _grouped = group_by_category(&discovery.available);
+    // Sort alphabetically (a-z) for consistent output
+    runtimes.sort_by(|a, b| a.name.cmp(&b.name));
 
-        for tool in &discovery.available {
-            runtimes.push(RuntimeEntry {
-                name: tool.name.clone(),
-                versions: tool.version.clone().map(|v| vec![v]).unwrap_or_default(),
-                installed: true,
-                description: tool.description.clone(),
-                platform_supported: true,
-                ecosystem: Some(tool.category.clone()),
-                platform_label: None,
-            });
-        }
+    let output = ListOutput {
+        runtimes,
+        total: discovery.available.len(),
+        installed_count: discovery.available.len(),
+        platform: current_platform.as_str().to_string(),
+    };
 
-        // Sort alphabetically (a-z) for consistent output
-        runtimes.sort_by(|a, b| a.name.cmp(&b.name));
-
-        let output = ListOutput {
-            runtimes,
-            total: discovery.available.len(),
-            installed_count: discovery.available.len(),
-            platform: current_platform.as_str().to_string(),
-        };
-
+    if !renderer.is_text() {
         renderer.render(&output)?;
     } else {
         // Text output
@@ -275,14 +270,14 @@ async fn list_tool_versions(
     drop(reg);
 
     if version_paths.is_empty() {
-        if renderer.is_json() {
-            let output = VersionsOutput {
-                tool: tool_name.to_string(),
-                versions: vec![],
-                total: 0,
-                latest: None,
-                lts: None,
-            };
+        let output = VersionsOutput {
+            tool: tool_name.to_string(),
+            versions: vec![],
+            total: 0,
+            latest: None,
+            lts: None,
+        };
+        if !renderer.is_text() {
             renderer.render(&output)?;
         } else {
             if platform_supported {
@@ -317,25 +312,26 @@ async fn list_tool_versions(
         return Ok(());
     }
 
-    if renderer.is_json() {
-        let output = VersionsOutput {
-            tool: tool_name.to_string(),
-            versions: version_paths
-                .iter()
-                .map(|(v, path)| VersionEntry {
-                    version: v.clone(),
-                    installed: true,
-                    lts: false,
-                    lts_name: None,
-                    date: None,
-                    prerelease: false,
-                    download_url: path.as_ref().map(|p| p.display().to_string()),
-                })
-                .collect(),
-            total: version_paths.len(),
-            latest: version_paths.first().map(|(v, _)| v.clone()),
-            lts: None,
-        };
+    let output = VersionsOutput {
+        tool: tool_name.to_string(),
+        versions: version_paths
+            .iter()
+            .map(|(v, path)| VersionEntry {
+                version: v.clone(),
+                installed: true,
+                lts: false,
+                lts_name: None,
+                date: None,
+                prerelease: false,
+                download_url: path.as_ref().map(|p| p.display().to_string()),
+            })
+            .collect(),
+        total: version_paths.len(),
+        latest: version_paths.first().map(|(v, _)| v.clone()),
+        lts: None,
+    };
+
+    if !renderer.is_text() {
         renderer.render(&output)?;
     } else {
         if platform_supported {
@@ -451,15 +447,12 @@ async fn list_all_tools(
     let runtimes_count = runtimes.len();
     let output = ListOutput {
         runtimes,
-        total: renderer.is_json() as usize * supported_tools.len()
-            + !renderer.is_json() as usize * runtimes_count,
+        total: runtimes_count,
         installed_count,
         platform: current_platform.as_str().to_string(),
     };
 
-    if renderer.is_json() {
-        renderer.render(&output)?;
-    } else {
+    if renderer.is_text() {
         if show_all {
             UI::info("📦 Available Tools (showing all, including unsupported)");
         } else {
@@ -468,8 +461,8 @@ async fn list_all_tools(
                 current_platform.as_str()
             ));
         }
-        renderer.render(&output)?;
     }
+    renderer.render(&output)?;
 
     Ok(())
 }

--- a/crates/vx-cli/src/commands/metrics.rs
+++ b/crates/vx-cli/src/commands/metrics.rs
@@ -78,6 +78,30 @@ pub async fn handle(last: usize, json: bool, html: Option<String>, clean: bool) 
     Ok(())
 }
 
+/// Handle `vx metrics tokens`.
+pub async fn handle_tokens(last: usize, json: bool) -> Result<()> {
+    let metrics_dir = vx_paths::VxPaths::default().base_dir.join("metrics");
+
+    if !metrics_dir.exists() {
+        println!("No metrics data found at {}", metrics_dir.display());
+        println!(
+            "Run a command with `--toon`, `--output-format toon`, or `--compact` to generate token savings."
+        );
+        return Ok(());
+    }
+
+    let runs = vx_metrics::load_metrics(&metrics_dir, last)?;
+    let summary = vx_metrics::summarize_token_savings(&runs);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&summary)?);
+    } else {
+        print!("{}", vx_metrics::render_token_savings(&summary));
+    }
+
+    Ok(())
+}
+
 async fn handle_clean(metrics_dir: &std::path::Path) -> Result<()> {
     if !metrics_dir.exists() {
         println!("No metrics directory to clean.");

--- a/crates/vx-cli/src/commands/search.rs
+++ b/crates/vx-cli/src/commands/search.rs
@@ -73,13 +73,10 @@ pub async fn handle(
 
     // Use unified output renderer
     let renderer = OutputRenderer::new(format);
-    if renderer.is_json() {
-        renderer.render(&output)?;
-    } else {
-        // Text mode: use existing UI for header, then render results
+    if renderer.is_text() {
         UI::header(&format!("Searching for '{}'...", query));
-        renderer.render(&output)?;
     }
+    renderer.render(&output)?;
 
     Ok(())
 }

--- a/crates/vx-cli/src/commands/version.rs
+++ b/crates/vx-cli/src/commands/version.rs
@@ -1,10 +1,37 @@
 //! Version command implementation
 
-use crate::ui::UI;
+use crate::cli::OutputFormat;
+use crate::output::{CommandOutput, OutputRenderer};
 use anyhow::Result;
+use serde::Serialize;
 
-pub async fn handle() -> Result<()> {
-    UI::info(&format!("vx {}", env!("CARGO_PKG_VERSION")));
-    UI::info("Universal Development Tool Manager");
+#[derive(Serialize)]
+struct VersionOutput {
+    name: &'static str,
+    version: &'static str,
+    description: &'static str,
+}
+
+impl CommandOutput for VersionOutput {
+    fn render_text(&self, writer: &mut dyn std::io::Write) -> Result<()> {
+        writeln!(writer, "{} {}", self.name, self.version)?;
+        writeln!(writer, "{}", self.description)?;
+        Ok(())
+    }
+
+    fn render_compact(&self, writer: &mut dyn std::io::Write) -> Result<()> {
+        writeln!(writer, "{} {}", self.name, self.version)?;
+        Ok(())
+    }
+}
+
+pub async fn handle(format: OutputFormat) -> Result<()> {
+    let output = VersionOutput {
+        name: "vx",
+        version: env!("CARGO_PKG_VERSION"),
+        description: "Universal Development Tool Manager",
+    };
+
+    OutputRenderer::new(format).render(&output)?;
     Ok(())
 }

--- a/crates/vx-cli/src/commands/where_cmd.rs
+++ b/crates/vx-cli/src/commands/where_cmd.rs
@@ -282,9 +282,7 @@ pub async fn handle(
             all_paths: vec![],
         };
 
-        if renderer.is_json() {
-            renderer.render(&output)?;
-        } else {
+        if renderer.is_text() {
             let available_tools = registry.runtime_names();
             let suggestions = suggestions::get_tool_suggestions(&request.name, &available_tools);
 
@@ -329,6 +327,8 @@ pub async fn handle(
                 "💡".cyan(),
                 format!("Use 'vx install {}' to install this tool", request.name).dimmed()
             );
+        } else {
+            renderer.render(&output)?;
         }
         std::process::exit(1);
     }

--- a/crates/vx-cli/src/lib.rs
+++ b/crates/vx-cli/src/lib.rs
@@ -176,14 +176,16 @@ pub async fn main() -> anyhow::Result<()> {
 async fn try_execute_lightweight_command(cli: &Cli) -> Option<Result<()>> {
     use crate::cli::{Commands, ConfigCommand};
 
+    let output_format = GlobalOptions::from(cli).output_format;
+
     match &cli.command {
         // `vx version` only prints the compiled-in version string.
-        Some(Commands::Version) => Some(commands::version::handle().await),
+        Some(Commands::Version) => Some(commands::version::handle(output_format).await),
 
         // `vx config show` is used in benchmark parse tests and only needs local config I/O.
         Some(Commands::Config {
             command: Some(ConfigCommand::Show) | None,
-        }) => Some(commands::config::handle().await),
+        }) => Some(commands::config::handle(output_format).await),
 
         // `vx config validate` is also benchmarked and does not require runtime/provider init.
         Some(Commands::Config {
@@ -205,11 +207,17 @@ async fn try_execute_lightweight_command(cli: &Cli) -> Option<Result<()>> {
 
         // `vx metrics` reads JSON files from disk, no registry needed.
         Some(Commands::Metrics {
+            command: None,
             last,
             json,
             html,
             clean,
         }) => Some(commands::metrics::handle(*last, *json, html.clone(), *clean).await),
+
+        Some(Commands::Metrics {
+            command: Some(crate::cli::MetricsCommand::Tokens { last, json }),
+            ..
+        }) => Some(commands::metrics::handle_tokens(*last, *json).await),
 
         _ => None,
     }

--- a/crates/vx-cli/src/output/mod.rs
+++ b/crates/vx-cli/src/output/mod.rs
@@ -6,14 +6,14 @@
 //! ## Agent DX: TTY Detection
 //!
 //! When stdout is NOT a TTY (e.g. piped to a script or AI agent), the renderer
-//! automatically switches to **TOON** (token-optimised) format rather than text.
-//! TOON saves 40-60% tokens compared to JSON, making it the ideal default for
-//! AI agents and automated pipelines.
+//! automatically switches to **TOON** (token-oriented) format rather than text.
+//! Token deltas are recorded in metrics so agents can see when TOON or compact
+//! output actually helps for a command shape.
 //!
 //! Override with:
 //! - `VX_OUTPUT=text` to force text output even in pipelines
 //! - `VX_OUTPUT=json` to get JSON (structured, but more verbose)
-//! - `VX_OUTPUT=compact` for RTK-style ultra-compact one-liners (60-80% savings)
+//! - `VX_OUTPUT=compact` for RTK-style ultra-compact one-liners
 
 use crate::cli::OutputFormat;
 use anyhow::Result;
@@ -23,6 +23,21 @@ use std::collections::HashMap;
 /// Serialize a value to TOON format using the official toon-format library.
 fn to_toon<T: Serialize>(value: &T) -> Result<String> {
     toon_format::encode_default(value).map_err(|e| anyhow::anyhow!("TOON encoding error: {}", e))
+}
+
+fn record_token_savings<T>(
+    output_format: &str,
+    baseline_format: &str,
+    baseline: &str,
+    actual: &str,
+) {
+    vx_metrics::record_token_savings(vx_metrics::build_token_savings_record(
+        std::any::type_name::<T>(),
+        output_format,
+        baseline_format,
+        baseline,
+        actual,
+    ));
 }
 
 /// Detect whether stdout is a TTY.
@@ -77,7 +92,7 @@ pub fn stdout_is_tty() -> bool {
 pub trait CommandOutput: Serialize {
     /// Render human-readable text output to the given writer.
     ///
-    /// This is called when `--format text` (default) is used.
+    /// This is called when `--output-format text` (default) is used.
     /// Output should include colors, emoji, and formatting for human consumption.
     fn render_text(&self, writer: &mut dyn std::io::Write) -> Result<()>;
 
@@ -109,8 +124,8 @@ pub trait CommandOutput: Serialize {
 ///    (unless `VX_OUTPUT=text` env var is set)
 ///
 /// This implements the "Agent DX" principle: machines get token-efficient
-/// TOON output by default without needing extra flags, saving 40-60% tokens
-/// compared to JSON. Use `VX_OUTPUT=json` to opt-in to JSON when needed.
+/// TOON output by default without needing extra flags. Use `VX_OUTPUT=json`
+/// to opt-in to JSON when needed.
 pub struct OutputRenderer {
     format: OutputFormat,
 }
@@ -164,6 +179,11 @@ impl OutputRenderer {
         self.format == OutputFormat::Json
     }
 
+    /// Check if structured machine-readable output is active.
+    pub fn is_structured(&self) -> bool {
+        matches!(self.format, OutputFormat::Json | OutputFormat::Toon)
+    }
+
     /// Check if text output is active.
     pub fn is_text(&self) -> bool {
         self.format == OutputFormat::Text
@@ -199,13 +219,25 @@ impl OutputRenderer {
                 Ok(())
             }
             OutputFormat::Toon => {
+                let baseline = serde_json::to_string(output)?;
                 let toon = to_toon(output)?;
+                record_token_savings::<T>("toon", "json", &baseline, &toon);
                 println!("{toon}");
                 Ok(())
             }
             OutputFormat::Compact => {
-                let mut stdout = std::io::stdout().lock();
-                output.render_compact(&mut stdout)?;
+                use std::io::Write as _;
+
+                let mut baseline_buf = Vec::new();
+                output.render_text(&mut baseline_buf)?;
+                let baseline = String::from_utf8(baseline_buf)?;
+
+                let mut actual_buf = Vec::new();
+                output.render_compact(&mut actual_buf)?;
+                let actual = String::from_utf8(actual_buf)?;
+
+                record_token_savings::<T>("compact", "text", &baseline, &actual);
+                std::io::stdout().lock().write_all(actual.as_bytes())?;
                 Ok(())
             }
         }

--- a/crates/vx-cli/tests/cli_integration_tests.rs
+++ b/crates/vx-cli/tests/cli_integration_tests.rs
@@ -30,7 +30,7 @@ mod version_tests {
     #[tokio::test]
     async fn test_version_command_executes() {
         init_test_env();
-        let result = version::handle().await;
+        let result = version::handle(vx_cli::OutputFormat::Text).await;
         assert!(result.is_ok(), "Version command should succeed");
         cleanup_test_env();
     }
@@ -312,7 +312,7 @@ mod config_tests {
     #[tokio::test]
     async fn test_config_show() {
         init_test_env();
-        let result = config::handle().await;
+        let result = config::handle(vx_cli::OutputFormat::Text).await;
         assert!(result.is_ok(), "Config show should succeed");
         cleanup_test_env();
     }

--- a/crates/vx-cli/tests/cli_parsing_tests.rs
+++ b/crates/vx-cli/tests/cli_parsing_tests.rs
@@ -447,7 +447,7 @@ fn test_cli_search_command() {
 
 #[test]
 fn test_cli_search_json_format() {
-    // After RFC 0031, search uses global --json/--format instead of local --format
+    // After RFC 0031, search uses global --json/--output-format instead of local --format
     let args = vec!["vx", "--json", "search"];
     let cli = Cli::try_parse_from(args).unwrap();
 
@@ -993,6 +993,31 @@ fn test_output_format_enum() {
     assert!(matches!(OutputFormat::Text, OutputFormat::Text));
     assert!(matches!(OutputFormat::Json, OutputFormat::Json));
     assert!(matches!(OutputFormat::Toon, OutputFormat::Toon));
+}
+
+#[test]
+fn test_output_format_option() {
+    let cli = Cli::try_parse_from(vec!["vx", "--output-format", "toon", "list"]).unwrap();
+    let options = GlobalOptions::from(&cli);
+
+    assert_eq!(options.output_format, OutputFormat::Toon);
+}
+
+#[test]
+fn test_cli_metrics_tokens_subcommand() {
+    let cli =
+        Cli::try_parse_from(vec!["vx", "metrics", "tokens", "--last", "20", "--json"]).unwrap();
+
+    match cli.command {
+        Some(Commands::Metrics {
+            command: Some(MetricsCommand::Tokens { last, json }),
+            ..
+        }) => {
+            assert_eq!(last, 20);
+            assert!(json);
+        }
+        _ => panic!("Expected metrics tokens command"),
+    }
 }
 
 // ============================================

--- a/crates/vx-cli/tests/output_tests.rs
+++ b/crates/vx-cli/tests/output_tests.rs
@@ -65,6 +65,14 @@ fn test_renderer_is_json() {
 }
 
 #[test]
+fn test_renderer_is_structured() {
+    assert!(OutputRenderer::json().is_structured());
+    assert!(OutputRenderer::new_exact(OutputFormat::Toon).is_structured());
+    assert!(!OutputRenderer::text().is_structured());
+    assert!(!OutputRenderer::compact().is_structured());
+}
+
+#[test]
 fn test_renderer_format() {
     // Use new_exact() to bypass TTY detection — OutputRenderer::new(Text) may
     // auto-upgrade to Json in non-TTY environments (e.g. CI). This test only

--- a/crates/vx-metrics/src/init.rs
+++ b/crates/vx-metrics/src/init.rs
@@ -75,9 +75,10 @@ impl MetricsGuard {
         let _ = self.provider.force_flush();
 
         let spans = self.exporter.take_spans();
+        let token_savings = crate::drain_token_savings();
 
-        // Skip writing if no spans were collected (e.g., --help, list)
-        if spans.is_empty() {
+        // Skip writing if no spans or token savings were collected (e.g., --help)
+        if spans.is_empty() && token_savings.is_empty() {
             return Ok(());
         }
 
@@ -88,6 +89,7 @@ impl MetricsGuard {
         metrics.exit_code = Some(exit_code);
         metrics.total_duration_ms = elapsed.as_secs_f64() * 1000.0;
         metrics.spans = spans;
+        metrics.token_savings = token_savings;
         metrics.extract_stages_from_spans();
 
         // Ensure metrics directory exists

--- a/crates/vx-metrics/src/lib.rs
+++ b/crates/vx-metrics/src/lib.rs
@@ -56,10 +56,15 @@
 pub mod exporter;
 pub mod init;
 pub mod report;
+pub mod token_savings;
 pub mod visualize;
 
 pub use init::{MetricsConfig, MetricsGuard, fmt_filter_directive, init, otel_filter_directive};
-pub use report::{CommandMetrics, StageMetrics};
+pub use report::{CommandMetrics, StageMetrics, TokenSavingsRecord};
+pub use token_savings::{
+    build_token_savings_record, drain_token_savings, estimate_tokens, record_token_savings,
+    render_token_savings, summarize_token_savings,
+};
 pub use visualize::{
     generate_ai_summary, generate_html_report, load_metrics, render_comparison, render_insights,
     render_summary,

--- a/crates/vx-metrics/src/report.rs
+++ b/crates/vx-metrics/src/report.rs
@@ -22,10 +22,36 @@ pub struct CommandMetrics {
     /// Total wall-clock duration in milliseconds
     pub total_duration_ms: f64,
     /// Per-stage timing breakdown
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub stages: HashMap<String, StageMetrics>,
+    /// Token savings from machine-readable output rendering.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub token_savings: Vec<TokenSavingsRecord>,
     /// All collected OpenTelemetry spans
     pub spans: Vec<SpanRecord>,
+}
+
+/// Token savings for one rendered command output.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenSavingsRecord {
+    /// Rust output type rendered by the command.
+    pub output_type: String,
+    /// Actual output format written to stdout.
+    pub output_format: String,
+    /// Baseline format used for comparison.
+    pub baseline_format: String,
+    /// Baseline output size in bytes.
+    pub baseline_bytes: usize,
+    /// Actual output size in bytes.
+    pub actual_bytes: usize,
+    /// Estimated baseline token count.
+    pub baseline_tokens: u64,
+    /// Estimated actual token count.
+    pub actual_tokens: u64,
+    /// Positive means tokens saved; negative means extra tokens.
+    pub token_delta: i64,
+    /// Fraction saved vs baseline. Negative means the actual output used more tokens.
+    pub savings_ratio: f64,
 }
 
 /// Metrics for a single pipeline stage.
@@ -50,6 +76,7 @@ impl CommandMetrics {
             exit_code: None,
             total_duration_ms: 0.0,
             stages: HashMap::new(),
+            token_savings: Vec::new(),
             spans: Vec::new(),
         }
     }

--- a/crates/vx-metrics/src/token_savings.rs
+++ b/crates/vx-metrics/src/token_savings.rs
@@ -1,0 +1,240 @@
+//! Token savings accounting for machine-readable command output.
+
+use crate::report::{CommandMetrics, TokenSavingsRecord};
+use serde::Serialize;
+use std::cmp::Reverse;
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+
+static TOKEN_SAVINGS: OnceLock<Mutex<Vec<TokenSavingsRecord>>> = OnceLock::new();
+
+fn records() -> &'static Mutex<Vec<TokenSavingsRecord>> {
+    TOKEN_SAVINGS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Estimate token count from UTF-8 text.
+///
+/// This intentionally uses a small dependency-free heuristic for metrics. It is
+/// stable and cheap enough to run for every command, while still making savings
+/// trends visible during debugging.
+pub fn estimate_tokens(text: &str) -> u64 {
+    if text.is_empty() {
+        return 0;
+    }
+
+    text.chars().count().div_ceil(4) as u64
+}
+
+/// Build a token savings record from baseline and actual output strings.
+pub fn build_token_savings_record(
+    output_type: impl Into<String>,
+    output_format: impl Into<String>,
+    baseline_format: impl Into<String>,
+    baseline: &str,
+    actual: &str,
+) -> TokenSavingsRecord {
+    let baseline_tokens = estimate_tokens(baseline);
+    let actual_tokens = estimate_tokens(actual);
+    let token_delta = baseline_tokens as i64 - actual_tokens as i64;
+    let savings_ratio = if baseline_tokens == 0 {
+        0.0
+    } else {
+        token_delta as f64 / baseline_tokens as f64
+    };
+
+    TokenSavingsRecord {
+        output_type: output_type.into(),
+        output_format: output_format.into(),
+        baseline_format: baseline_format.into(),
+        baseline_bytes: baseline.len(),
+        actual_bytes: actual.len(),
+        baseline_tokens,
+        actual_tokens,
+        token_delta,
+        savings_ratio,
+    }
+}
+
+/// Record token savings for the current command.
+pub fn record_token_savings(record: TokenSavingsRecord) {
+    if let Ok(mut guard) = records().lock() {
+        guard.push(record);
+    }
+}
+
+/// Drain all token savings records collected for the current command.
+pub fn drain_token_savings() -> Vec<TokenSavingsRecord> {
+    records()
+        .lock()
+        .map(|mut guard| guard.drain(..).collect())
+        .unwrap_or_default()
+}
+
+/// Aggregated token savings across loaded metrics runs.
+#[derive(Debug, Clone, Serialize)]
+pub struct TokenSavingsSummary {
+    /// Number of metrics runs inspected.
+    pub runs: usize,
+    /// Number of render records that included token savings data.
+    pub records: usize,
+    /// Total baseline tokens across all records.
+    pub baseline_tokens: u64,
+    /// Total actual tokens across all records.
+    pub actual_tokens: u64,
+    /// Net token delta. Positive means saved tokens; negative means extra tokens.
+    pub net_saved_tokens: i64,
+    /// Fraction saved vs baseline. Negative means the actual output used more tokens.
+    pub savings_ratio: f64,
+    /// Per-command aggregate, sorted by largest savings first.
+    pub commands: Vec<CommandTokenSavings>,
+}
+
+/// Aggregated token savings for one command string.
+#[derive(Debug, Clone, Serialize)]
+pub struct CommandTokenSavings {
+    /// Command string as recorded in metrics.
+    pub command: String,
+    /// Number of metrics runs for this command.
+    pub runs: usize,
+    /// Number of render records for this command.
+    pub records: usize,
+    /// Total baseline tokens.
+    pub baseline_tokens: u64,
+    /// Total actual tokens.
+    pub actual_tokens: u64,
+    /// Net token delta. Positive means saved tokens; negative means extra tokens.
+    pub net_saved_tokens: i64,
+    /// Fraction saved vs baseline. Negative means the actual output used more tokens.
+    pub savings_ratio: f64,
+}
+
+#[derive(Default)]
+struct CommandAccumulator {
+    runs: usize,
+    records: usize,
+    baseline_tokens: u64,
+    actual_tokens: u64,
+    net_saved_tokens: i64,
+}
+
+/// Summarize token savings in newest-first metrics runs.
+pub fn summarize_token_savings(runs: &[CommandMetrics]) -> TokenSavingsSummary {
+    let mut by_command: BTreeMap<String, CommandAccumulator> = BTreeMap::new();
+    let mut baseline_tokens = 0_u64;
+    let mut actual_tokens = 0_u64;
+    let mut net_saved_tokens = 0_i64;
+    let mut records = 0_usize;
+
+    for run in runs {
+        if run.token_savings.is_empty() {
+            continue;
+        }
+
+        let entry = by_command.entry(run.command.clone()).or_default();
+        entry.runs += 1;
+
+        for record in &run.token_savings {
+            records += 1;
+            baseline_tokens += record.baseline_tokens;
+            actual_tokens += record.actual_tokens;
+            net_saved_tokens += record.token_delta;
+
+            entry.records += 1;
+            entry.baseline_tokens += record.baseline_tokens;
+            entry.actual_tokens += record.actual_tokens;
+            entry.net_saved_tokens += record.token_delta;
+        }
+    }
+
+    let mut commands: Vec<CommandTokenSavings> = by_command
+        .into_iter()
+        .map(|(command, acc)| CommandTokenSavings {
+            command,
+            runs: acc.runs,
+            records: acc.records,
+            baseline_tokens: acc.baseline_tokens,
+            actual_tokens: acc.actual_tokens,
+            net_saved_tokens: acc.net_saved_tokens,
+            savings_ratio: ratio(acc.net_saved_tokens, acc.baseline_tokens),
+        })
+        .collect();
+
+    commands.sort_by_key(|command| Reverse(command.net_saved_tokens));
+
+    TokenSavingsSummary {
+        runs: runs.len(),
+        records,
+        baseline_tokens,
+        actual_tokens,
+        net_saved_tokens,
+        savings_ratio: ratio(net_saved_tokens, baseline_tokens),
+        commands,
+    }
+}
+
+/// Render token savings summary as a compact terminal table.
+pub fn render_token_savings(summary: &TokenSavingsSummary) -> String {
+    if summary.records == 0 {
+        return "No token savings data found. Run vx commands with --format toon or --compact.\n"
+            .to_string();
+    }
+
+    let mut out = String::new();
+    out.push_str("Token savings summary\n");
+    out.push_str(&format!(
+        "runs:{} records:{} baseline:{} actual:{} net_saved:{} ({:.1}%)\n\n",
+        summary.runs,
+        summary.records,
+        summary.baseline_tokens,
+        summary.actual_tokens,
+        summary.net_saved_tokens,
+        summary.savings_ratio * 100.0
+    ));
+    out.push_str(&format!(
+        "{:<36} {:>6} {:>8} {:>8} {:>10} {:>8}\n",
+        "Command", "Runs", "Before", "After", "Net saved", "Saved%"
+    ));
+    out.push_str(&format!(
+        "{:<36} {:>6} {:>8} {:>8} {:>10} {:>8}\n",
+        "-".repeat(36),
+        "----",
+        "------",
+        "-----",
+        "---------",
+        "------"
+    ));
+
+    for command in &summary.commands {
+        out.push_str(&format!(
+            "{:<36} {:>6} {:>8} {:>8} {:>10} {:>7.1}%\n",
+            truncate(&command.command, 36),
+            command.runs,
+            command.baseline_tokens,
+            command.actual_tokens,
+            command.net_saved_tokens,
+            command.savings_ratio * 100.0
+        ));
+    }
+
+    out
+}
+
+fn ratio(net_saved_tokens: i64, baseline_tokens: u64) -> f64 {
+    if baseline_tokens == 0 {
+        0.0
+    } else {
+        net_saved_tokens as f64 / baseline_tokens as f64
+    }
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let truncated: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() && max_chars >= 3 {
+        let mut shortened: String = truncated.chars().take(max_chars - 3).collect();
+        shortened.push_str("...");
+        shortened
+    } else {
+        truncated
+    }
+}

--- a/crates/vx-metrics/tests/report_tests.rs
+++ b/crates/vx-metrics/tests/report_tests.rs
@@ -10,6 +10,7 @@ fn test_command_metrics_new() {
     assert!(metrics.exit_code.is_none());
     assert_eq!(metrics.total_duration_ms, 0.0);
     assert!(metrics.stages.is_empty());
+    assert!(metrics.token_savings.is_empty());
     assert!(metrics.spans.is_empty());
 }
 

--- a/crates/vx-metrics/tests/token_savings_tests.rs
+++ b/crates/vx-metrics/tests/token_savings_tests.rs
@@ -1,0 +1,97 @@
+use vx_metrics::report::{CommandMetrics, TokenSavingsRecord};
+use vx_metrics::{
+    build_token_savings_record, estimate_tokens, render_token_savings, summarize_token_savings,
+};
+
+#[test]
+fn test_estimate_tokens_uses_stable_char_heuristic() {
+    assert_eq!(estimate_tokens(""), 0);
+    assert_eq!(estimate_tokens("abcd"), 1);
+    assert_eq!(estimate_tokens("abcde"), 2);
+}
+
+#[test]
+fn test_build_token_savings_record() {
+    let record = build_token_savings_record(
+        "ListOutput",
+        "toon",
+        "json",
+        r#"{"runtimes":[{"name":"node"}]}"#,
+        "runtimes[1]{name}:\n  node",
+    );
+
+    assert_eq!(record.output_type, "ListOutput");
+    assert_eq!(record.output_format, "toon");
+    assert_eq!(record.baseline_format, "json");
+    assert!(record.baseline_tokens >= record.actual_tokens);
+    assert!(record.token_delta >= 0);
+}
+
+#[test]
+fn test_build_token_savings_record_preserves_negative_delta() {
+    let record = build_token_savings_record("ListOutput", "toon", "json", "abcd", "abcdabcd");
+
+    assert_eq!(record.token_delta, -1);
+    assert!(record.savings_ratio < 0.0);
+}
+
+#[test]
+fn test_summarize_token_savings_by_command() {
+    let mut first = CommandMetrics::new("vx --output-format toon list".to_string());
+    first.token_savings = vec![TokenSavingsRecord {
+        output_type: "ListOutput".to_string(),
+        output_format: "toon".to_string(),
+        baseline_format: "json".to_string(),
+        baseline_bytes: 400,
+        actual_bytes: 200,
+        baseline_tokens: 100,
+        actual_tokens: 50,
+        token_delta: 50,
+        savings_ratio: 0.5,
+    }];
+
+    let mut second = CommandMetrics::new("vx --compact list node".to_string());
+    second.token_savings = vec![TokenSavingsRecord {
+        output_type: "VersionsOutput".to_string(),
+        output_format: "compact".to_string(),
+        baseline_format: "text".to_string(),
+        baseline_bytes: 80,
+        actual_bytes: 20,
+        baseline_tokens: 20,
+        actual_tokens: 5,
+        token_delta: 15,
+        savings_ratio: 0.75,
+    }];
+
+    let summary = summarize_token_savings(&[first, second]);
+
+    assert_eq!(summary.runs, 2);
+    assert_eq!(summary.records, 2);
+    assert_eq!(summary.baseline_tokens, 120);
+    assert_eq!(summary.actual_tokens, 55);
+    assert_eq!(summary.net_saved_tokens, 65);
+    assert_eq!(summary.commands.len(), 2);
+    assert_eq!(summary.commands[0].command, "vx --output-format toon list");
+}
+
+#[test]
+fn test_render_token_savings_empty() {
+    let summary = summarize_token_savings(&[]);
+    let rendered = render_token_savings(&summary);
+    assert!(rendered.contains("No token savings data"));
+}
+
+#[test]
+fn test_command_metrics_deserializes_without_token_savings() {
+    let json = r#"{
+        "version": "1",
+        "timestamp": "2026-02-07T10:30:00Z",
+        "command": "vx list",
+        "total_duration_ms": 12.0,
+        "spans": []
+    }"#;
+
+    let metrics: CommandMetrics = serde_json::from_str(json).unwrap();
+    assert!(metrics.stages.is_empty());
+    assert!(metrics.token_savings.is_empty());
+}

--- a/crates/vx-metrics/tests/visualize_tests.rs
+++ b/crates/vx-metrics/tests/visualize_tests.rs
@@ -55,6 +55,7 @@ fn sample_metrics(
         exit_code: Some(0),
         total_duration_ms: total,
         stages,
+        token_savings: Vec::new(),
         spans: Vec::new(),
     }
 }

--- a/skills/README.md
+++ b/skills/README.md
@@ -9,12 +9,41 @@ These skills are the **single source of truth** shared across:
 - **ClawHub** — published automatically via CI when changes merge to main
 - **Agent config directories** — `.codebuddy/skills/`, `.claude/skills/`, `.cursor/skills/`, etc.
 
+## Management Model
+
+Edit `skills/` first. Treat project-level agent directories (`.agents/`, `.claude/`,
+`.cursor/`, and friends) as compatibility snapshots generated from the canonical
+skills, not as independently maintained sources.
+
+When a skill changes:
+
+1. Update the canonical file under `skills/<name>/SKILL.md`.
+2. Re-run or refresh the `vx ai setup` distribution path for agent-specific copies.
+3. Keep embedded skills and ClawHub publishing aligned through the existing
+   `crates/vx-cli/src/commands/ai.rs` embedding and `.github/workflows/sync-skills.yml`.
+
+This keeps the repository from becoming a maze of divergent skill copies while
+still supporting agents that require project-local skill folders.
+
+## Skill Authoring Principles
+
+vx skills should teach agents to be precise, scoped, and token-aware:
+
+- Prefer the smallest maintainable change that solves the actual request.
+- Read the narrowest relevant file, symbol, diff, log, or test output first.
+- Scope command output before printing it; use `vx rg`, `vx fd`, `vx gh --json`,
+  `vx jq`, and `vx metrics tokens` to keep context useful.
+- Avoid broad repo dumps, full logs, unrelated cleanup, and single-use wrappers.
+- Validate according to risk with the cheapest useful focused check first.
+- Treat `skills/` as the canonical source and project-level skill directories as
+  generated compatibility snapshots.
+
 ## Available Skills
 
 | Skill | Description | Size | Best for |
 |-------|-------------|------|----------|
 | **vx-usage** | Core usage guide — commands, vx.toml, providers, GitHub Actions, MCP integration | ~15 KB | First-time users, general questions |
-| **vx-commands** | CLI command reference — all flags, output formats (`--json`, `--format toon`) | ~6 KB | Looking up specific command syntax |
+| **vx-commands** | CLI command reference — all flags, output formats (`--json`, `--output-format toon`) | ~6 KB | Looking up specific command syntax |
 | **vx-project** | Project management — init, sync, setup, vx.toml configuration, monorepo | ~6 KB | Setting up or configuring projects |
 | **vx-best-practices** | Best practices — version strategy, cross-platform, security, provider development | ~10 KB | Team workflows, provider creation |
 | **vx-troubleshooting** | Troubleshooting — installation failures, PATH issues, diagnostics, recovery | ~8 KB | Fixing errors, diagnosing issues |

--- a/skills/vx-best-practices/SKILL.md
+++ b/skills/vx-best-practices/SKILL.md
@@ -46,6 +46,29 @@ git add vx.lock
 git commit -m "chore: update dependencies"
 ```
 
+### 4. Keep Agent Work Small and Observable
+
+When an AI agent uses vx, optimize for correctness, speed, judgment, and token
+efficiency:
+
+- Read enough surrounding code to understand the local pattern, then stop exploring.
+- Prefer targeted searches, focused file sections, scoped diffs, selected JSON fields, and capped logs.
+- Make the smallest maintainable change that solves the request.
+- Reuse existing project helpers before creating new abstractions.
+- Avoid single-use wrappers, speculative architecture, and unrelated cleanup.
+- Validate according to risk: focused tests for narrow changes, broader checks for shared behavior.
+- Preserve evidence from the actual command, CI job, or runtime surface when debugging.
+
+For large or unknown output, scope first and filter through vx-managed tools:
+
+```bash
+vx rg -n -m 20 "SearchTerm" src
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx gh pr view 123 --json title,state,files
+vx gh run view 456 --log | vx rg -n -m 50 "error|failed|panic"
+```
+
 ## Project Setup
 
 ### Initial Setup

--- a/skills/vx-commands/SKILL.md
+++ b/skills/vx-commands/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: vx-commands
-description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --output-format toon for token-optimized output."
 ---
 
 # VX Command Reference
 
-> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+> **Quick rule**: All vx commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
 
 ## Structured Output Commands (AI-Optimized)
 
-All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+All commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens).
 
 ### Project Analysis
 
@@ -108,7 +108,7 @@ vx list --json
 
 ### TOON Format (Token-Optimized)
 ```bash
-vx list --format toon
+vx list --output-format toon
 # Output:
 # runtimes[50]{name,installed,description}:
 #   node,true,Node.js runtime
@@ -190,7 +190,7 @@ vx cache clean              # Clean cache
 
 ```bash
 --json                      # JSON output
---format <text|json|toon>   # Output format
+--output-format <text|json|toon>   # Output format
 --verbose                   # Verbose output
 --debug                     # Debug output
 --use-system-path           # Use system PATH

--- a/skills/vx-usage/SKILL.md
+++ b/skills/vx-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vx-usage
-description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 129 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, Git/GitHub operations, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 137 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
 ---
 
 # VX - Universal Development Tool Manager
@@ -36,7 +36,101 @@ vx npx create-react-app app   # Run npx
 vx cargo test                 # Run cargo
 vx just build                 # Run just (task runner)
 vx git status                 # Run git
+vx gh pr status               # Run GitHub CLI
 ```
+
+### Git and GitHub for Codex
+
+When Codex or another AI agent works in a vx-managed repository, use vx-managed
+Git and GitHub CLI commands. Do not run bare `git` or bare `gh`.
+
+```bash
+vx git status --short --branch
+vx git fetch origin main
+vx git checkout -B fix/example origin/main
+vx git diff --stat
+vx git add path/to/file
+vx git commit -m "fix: example"
+
+vx gh issue view 123
+vx gh pr view 456 --json title,state,headRefName
+vx gh pr checks 456
+vx gh run view 789 --log
+```
+
+### Token-Efficient Agent Workflows
+
+vx is not just an installation wrapper. For agents, it is the stable way to use
+fast search, structured GitHub queries, JSON filters, and scoped diffs without
+spending tokens on irrelevant output.
+
+Prefer narrow, structured commands before broad dumps:
+
+```bash
+# Search and file discovery
+vx rg -n --glob '!target/**' --glob '!node_modules/**' "OutputRenderer"
+vx rg --files -g '*.rs' -g '!target/**'
+vx fd provider.star crates/vx-providers
+
+# Git context with small output first
+vx git status --short --branch
+vx git diff --stat
+vx git diff --name-only origin/main...HEAD
+vx git grep -n "CommandOutput" origin/main -- crates/vx-cli
+
+# GitHub context with selected fields
+vx gh issue view 123 --json title,state,labels,body
+vx gh pr view 456 --json title,state,headRefName,baseRefName,files
+vx gh pr checks 456 --json name,state,conclusion,link
+vx gh run view 789 --log | vx rg -n "error|failed|panic|warning"
+
+# Structured filtering
+vx jq -r '.files[].path' pr.json
+vx yq '.jobs | keys' .github/workflows/ci.yml
+```
+
+Token-saving defaults for agents:
+- Start with `vx rg`, `vx fd`, `vx git diff --stat`, and `vx git diff --name-only`; open full files or full diffs only after locating the relevant surface.
+- Use `vx gh --json ...` with selected fields, and add `--jq` when a small projection is enough.
+- Use vx structured output flags when the vx command supports them: `--json`, `--fields`, `--toon`, or `--output-format toon`.
+- For forwarded runtimes like `vx node`, `vx cargo`, or `vx npm`, use that tool's own quiet, JSON, or filtering flags when available.
+- Pipe large logs through vx-managed filters such as `vx rg`, `vx jq`, or `vx yq` before reading them.
+
+### Agent Operating Principles
+
+vx skills should help agents make small, correct, maintainable changes with
+bounded context. Treat vx as a token-aware execution layer, not just a command
+prefix.
+
+Use this loop for coding tasks:
+1. Inspect the narrowest relevant file, symbol, diff, log, or test output first.
+2. Prefer existing project patterns over new helpers or abstractions.
+3. Make the smallest maintainable change that solves the actual request.
+4. Validate with the cheapest useful scoped command for the risk involved.
+5. Summarize only what changed, what was checked, and any remaining risk.
+
+Context discipline:
+- Scope before printing. Search paths first, then open focused file sections.
+- Avoid dumping full files, broad diffs, generated output, or full CI logs unless the task truly requires them.
+- For unknown or potentially huge output, cap and filter with vx-managed tools.
+- Do not cap instruction files, skill files, or agent policy files; read the relevant one fully unless it is unexpectedly huge.
+- If capped output is insufficient, narrow the query before increasing the cap.
+
+Examples:
+
+```bash
+vx rg -n -m 20 "render_token_savings|OutputRenderer" crates/vx-cli crates/vx-metrics
+vx git diff --stat origin/main...HEAD
+vx git diff --name-only origin/main...HEAD
+vx gh run view 789 --log | vx rg -n -m 50 "error|failed|panic"
+vx metrics tokens --last 20 --json
+```
+
+Validation discipline:
+- Use focused checks first, such as `vx cargo test -p vx-cli --test cli_parsing_tests <case>`.
+- Run broader checks only when the touched surface or release risk justifies it.
+- Prefer evidence from the actual failing command, CI job, or runtime behavior over speculative fixes.
+- Do not add wrappers, maps, helper files, or validation layers unless they clearly reduce real complexity.
 
 ### Tool Management
 ```bash
@@ -82,14 +176,14 @@ rust = "1.80"       # Specific version
 just = "*"          # Any version
 
 [scripts]
-dev = "npm run dev"
-test = "cargo test"
-lint = "npm run lint && cargo clippy"
-build = "just build"
+dev = "vx npm run dev"
+test = "vx cargo test"
+lint = "vx npm run lint && vx cargo clippy"
+build = "vx just build"
 
 [hooks]
 pre_commit = ["vx run lint"]
-post_setup = ["npm install"]
+post_setup = ["vx npm install"]
 ```
 
 ## Using `--with` for Multi-Runtime
@@ -195,7 +289,7 @@ vx msvc@14.40 cl main.cpp
 | lib | `vx msvc lib` | Library manager |
 | nmake | `vx msvc nmake` | Make utility |
 
-## Supported Tools (129 Providers)
+## Supported Tools (137 Providers)
 
 | Category | Tools |
 |----------|-------|
@@ -224,7 +318,7 @@ vx msvc@14.40 cl main.cpp
 
 ## Provider System (Starlark DSL)
 
-All 129 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+All 137 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
 
 vx uses a **two-phase execution model** (inspired by Buck2):
 1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
@@ -305,13 +399,17 @@ Key modules:
 2. **Use `vx just`** instead of `just` for task runner commands
 3. **Use `vx npm`** instead of `npm` directly
 4. **Use `vx cargo`** instead of `cargo` directly
-5. **Check `vx.toml`** first to understand project tool requirements
-6. **Use `vx run <script>`** for project-defined scripts
-7. **Never suggest manual tool installation** - vx handles it automatically
-8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
-9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
-10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
-11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+5. **Use `vx git`** instead of `git` for repository operations
+6. **Use `vx gh`** instead of `gh` for GitHub issue, PR, checks, and workflow operations
+7. **Use `vx rg`, `vx fd`, `vx jq`, and `vx yq`** for scoped search and structured filtering
+8. **Prefer token-efficient output**: `--json`, selected fields, `--jq`, `--toon`, `--output-format toon`, and narrow globs
+9. **Check `vx.toml`** first to understand project tool requirements
+10. **Use `vx run <script>`** for project-defined scripts
+11. **Never suggest manual tool installation** - vx handles it automatically
+12. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+13. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+14. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+15. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
 
 ## Version Resolution Priority
 

--- a/tests/structured_output_e2e_tests.rs
+++ b/tests/structured_output_e2e_tests.rs
@@ -1,0 +1,184 @@
+//! E2E coverage for machine-readable output purity.
+
+use assert_cmd::Command;
+use serde_json::Value;
+use std::path::Path;
+use std::process::Output;
+
+fn run_vx(args: &[&str]) -> Output {
+    #[allow(deprecated)]
+    let mut cmd = Command::cargo_bin("vx").unwrap();
+    cmd.args(args).output().expect("failed to run vx binary")
+}
+
+fn run_vx_with_home(args: &[&str], vx_home: &Path) -> Output {
+    #[allow(deprecated)]
+    let mut cmd = Command::cargo_bin("vx").unwrap();
+    cmd.env("VX_HOME", vx_home)
+        .args(args)
+        .output()
+        .expect("failed to run vx binary")
+}
+
+fn stdout_str(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn assert_machine_stdout_has_no_text_ui(output: &Output, context: &str) {
+    assert!(
+        output.status.success(),
+        "{} should succeed: stdout:\n{}\nstderr:\n{}",
+        context,
+        stdout_str(output),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = stdout_str(output);
+    assert!(
+        !stdout.trim().is_empty(),
+        "{} should produce machine-readable stdout",
+        context
+    );
+    assert!(
+        !stdout.contains("Searching for")
+            && !stdout.contains("Available Tools")
+            && !stdout.contains("No versions installed")
+            && !stdout.contains("Did you mean")
+            && !stdout.contains("Use 'vx list'")
+            && !stdout.contains('\u{2139}')
+            && !stdout.contains('\u{1f4e6}'),
+        "{} should not mix text UI with machine-readable stdout:\n{}",
+        context,
+        stdout
+    );
+}
+
+#[test]
+fn test_search_toon_stdout_has_no_text_ui_header() {
+    let output = run_vx(&["--output-format", "toon", "search", "node"]);
+
+    assert_machine_stdout_has_no_text_ui(&output, "vx --output-format toon search node");
+}
+
+#[test]
+fn test_list_toon_stdout_has_no_text_ui_header() {
+    let output = run_vx(&["--output-format", "toon", "list"]);
+
+    assert_machine_stdout_has_no_text_ui(&output, "vx --output-format toon list");
+}
+
+#[test]
+fn test_version_toon_stdout_has_no_text_ui_header() {
+    let output = run_vx(&["--output-format", "toon", "version"]);
+
+    assert_machine_stdout_has_no_text_ui(&output, "vx --output-format toon version");
+    assert!(
+        stdout_str(&output).contains("version:"),
+        "version command should render structured version data"
+    );
+}
+
+#[test]
+fn test_config_show_toon_stdout_has_no_text_ui_header() {
+    let output = run_vx(&["--output-format", "toon", "config", "show"]);
+
+    assert_machine_stdout_has_no_text_ui(&output, "vx --output-format toon config show");
+    assert!(
+        stdout_str(&output).contains("tools_count:"),
+        "config show should render structured config data"
+    );
+}
+
+#[test]
+fn test_list_tool_compact_stdout_has_no_text_ui_header() {
+    let output = run_vx(&["--compact", "list", "node"]);
+
+    assert_machine_stdout_has_no_text_ui(&output, "vx --compact list node");
+}
+
+#[test]
+fn test_missing_which_toon_stdout_has_no_text_ui_suggestions() {
+    let output = run_vx(&[
+        "--output-format",
+        "toon",
+        "which",
+        "definitely-not-a-vx-runtime-xyz",
+    ]);
+
+    assert!(
+        !output.status.success(),
+        "missing runtime lookup should fail"
+    );
+
+    let stdout = stdout_str(&output);
+    assert!(
+        stdout.contains("source: not_found"),
+        "missing runtime should render structured not_found stdout:\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("Did you mean")
+            && !stdout.contains("Use 'vx list'")
+            && !stdout.contains('\u{2139}'),
+        "missing runtime should not mix suggestion UI into stdout:\n{}",
+        stdout
+    );
+}
+
+#[test]
+fn test_metrics_tokens_reports_structured_output_savings() {
+    let vx_home = tempfile::tempdir().unwrap();
+
+    let list_toon = run_vx_with_home(&["--output-format", "toon", "list"], vx_home.path());
+    assert_machine_stdout_has_no_text_ui(&list_toon, "vx --output-format toon list");
+
+    let list_compact = run_vx_with_home(&["--compact", "list", "node"], vx_home.path());
+    assert_machine_stdout_has_no_text_ui(&list_compact, "vx --compact list node");
+
+    let summary = run_vx_with_home(
+        &["metrics", "tokens", "--last", "20", "--json"],
+        vx_home.path(),
+    );
+    assert!(
+        summary.status.success(),
+        "metrics tokens should succeed: stdout:\n{}\nstderr:\n{}",
+        stdout_str(&summary),
+        String::from_utf8_lossy(&summary.stderr)
+    );
+
+    let json: Value = serde_json::from_str(&stdout_str(&summary)).unwrap();
+    assert!(
+        json["records"].as_u64().unwrap_or_default() >= 2,
+        "expected at least two token savings records:\n{}",
+        stdout_str(&summary)
+    );
+    let commands = json["commands"].as_array().unwrap();
+    assert!(
+        commands.iter().any(|entry| entry["command"]
+            .as_str()
+            .is_some_and(|command| command.contains("--output-format toon"))),
+        "summary should include the TOON command:\n{}",
+        stdout_str(&summary)
+    );
+    assert!(
+        commands.iter().any(|entry| entry["command"]
+            .as_str()
+            .is_some_and(|command| command.contains("--compact"))),
+        "summary should include the compact command:\n{}",
+        stdout_str(&summary)
+    );
+
+    let compact = commands
+        .iter()
+        .find(|entry| {
+            entry["command"]
+                .as_str()
+                .is_some_and(|command| command.contains("--compact"))
+        })
+        .unwrap();
+    assert!(
+        compact["net_saved_tokens"].as_i64().unwrap_or_default() > 0,
+        "compact output should report positive token savings:\n{}",
+        stdout_str(&summary)
+    );
+}


### PR DESCRIPTION
## Summary

- record estimated token deltas for TOON and compact command output in the existing vx metrics reports
- add `vx metrics tokens` with text and JSON summaries grouped by command
- update vx usage skills and structured-output coverage so agents use `vx gh`, `vx git`, `vx rg`, and token-aware output paths consistently
- add agent skill principles for scoped context, small maintainable changes, capped output, and risk-based validation

## Validation

- `vx cargo fmt`
- `vx cargo test -p vx-metrics --test token_savings_tests -- --nocapture`
- `vx cargo test -p vx-metrics --test visualize_tests -- --nocapture`
- `vx cargo test -p vx-cli --test cli_parsing_tests test_cli_metrics_tokens_subcommand -- --nocapture`
- `vx cargo test --test structured_output_e2e_tests -- --nocapture`
- `vx cargo test -p vx-cli --test cli_parsing_tests -- --nocapture`
- `vx cargo nextest run -p vx-cli`
- `vx cargo clippy -p vx-metrics --all-targets -- -D warnings`
- `vx cargo clippy -p vx-cli --all-targets -- -D warnings`
- `vx cargo clippy -p vx --test structured_output_e2e_tests -- -D warnings`
- `vx git diff --check`
- smoke: `target/debug/vx.exe metrics tokens --last 20` and `--json` with isolated `VX_HOME`
- follow-up docs check: `vx git diff --check`