### PR TITLE
fix: prepend node_modules/.bin to PATH for npm/npx execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4445,7 +4445,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4462,7 +4462,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "indexmap",
  "regex",
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4500,7 +4500,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4564,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4607,7 +4607,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4625,7 +4625,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "colored",
@@ -4647,7 +4647,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4669,7 +4669,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4702,7 +4702,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4720,7 +4720,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4743,7 +4743,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4765,14 +4765,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-output-filter"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "regex",
@@ -4786,7 +4786,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4830,7 +4830,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4864,7 +4864,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4894,7 +4894,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "flate2",
@@ -4913,7 +4913,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4963,7 +4963,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -4998,11 +4998,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.9.2"
+version = "0.9.3"
 
 [[package]]
 name = "vx-starlark"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5032,7 +5032,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/vx-resolver/src/executor/environment.rs
+++ b/crates/vx-resolver/src/executor/environment.rs
@@ -83,6 +83,27 @@ impl<'a> EnvironmentManager<'a> {
                         path_parts.push(expanded);
                     }
 
+                    // For Node.js ecosystem tools (npm, npx), prepend the local
+                    // node_modules/.bin directory to PATH. This mirrors what npm
+                    // does internally when running scripts (`npm run`) but acts
+                    // as a safety net: on Windows, npm's own PATH prepend can
+                    // fail when the environment is set explicitly via
+                    // Command::env(), causing locally-installed binaries (tsc,
+                    // vite, etc.) to not be found.
+                    if matches!(runtime_name, "npm" | "npx")
+                        && let Ok(cwd) = std::env::current_dir()
+                    {
+                        let local_bin = cwd.join("node_modules").join(".bin");
+                        if local_bin.is_dir() {
+                            let bin_str = local_bin.to_string_lossy().to_string();
+                            debug!(
+                                "Prepending local node_modules/.bin to PATH for {}: {}",
+                                runtime_name, bin_str
+                            );
+                            path_parts.push(bin_str);
+                        }
+                    }
+
                     // Get current PATH
                     let isolate_env = if inherit_env { false } else { advanced.isolate };
                     let current_path = if !isolate_env {


### PR DESCRIPTION
## Summary
- When `vx npm run <script>` executes on Windows, npm's internal PATH prepend for `node_modules/.bin` can fail when the env is set explicitly via `Command::env()`, causing locally-installed binaries (`tsc`, `vite`, etc.) to not be found.
- This adds a defensive safety net: vx now prepends the local `node_modules/.bin` directory to PATH when executing `npm` or `npx` commands (only when the directory exists).
- Fixes the `'tsc' is not recognized` error in `dcc-mcp-core`'s `build.rs` when running `vx npm run build`.

## Test plan
- [x] All 3679 existing tests pass (`cargo nextest run --workspace`)
- [x] `cargo clippy --workspace -- -D warnings` passes with zero warnings
- [x] `cargo fmt --all -- --check` passes
- [ ] CI passes on this PR
- [ ] Verify fix in dcc-mcp-core: `vx just dev` completes without `tsc` not found error

🤖 Generated with [Claude Code](https://claude.com/claude-code)