### PR TITLE
docs: teach token-efficient vx agent workflows

### DIFF
--- a/.agents/skills/vx-best-practices/SKILL.md
+++ b/.agents/skills/vx-best-practices/SKILL.md
@@ -5,7 +5,7 @@ description: "Best practices for using vx effectively. Use when following recomm
 
 # VX Best Practices
 
-> **Golden rule**: Always prefix tool commands with `vx` in vx-managed projects. Use `vx.toml` for project-level tool versions, commit `vx.lock` for reproducibility, and prefer templates over custom code when creating providers.
+> **Golden rule**: Always prefix tool commands with `vx` in vx-managed projects. Use `vx.toml` for project-level tool versions, commit `vx.lock` for reproducibility, prefer templates over custom code when creating providers, and prefer structured or compact output before reading large logs.
 
 ## General Principles
 
@@ -42,8 +42,8 @@ vx install node@22
 Always commit `vx.lock` to ensure reproducible builds:
 
 ```bash
-git add vx.lock
-git commit -m "chore: update dependencies"
+vx git add vx.lock
+vx git commit -m "chore: update dependencies"
 ```
 
 ### 4. Keep Agent Work Small and Observable
@@ -66,8 +66,23 @@ vx rg -n -m 20 "SearchTerm" src
 vx git diff --stat
 vx git diff --name-only origin/main...HEAD
 vx gh pr view 123 --json title,state,files
-vx gh run view 456 --log | vx rg -n -m 50 "error|failed|panic"
+vx gh run view 456 --json status,conclusion,jobs --jq '.jobs[] | {name,conclusion}'
+vx gh run view 456 --log | vx rg -n -m 50 "error|failed|panic|Traceback|FAILED"
+vx --compact gh run view 456 --log
 ```
+
+Use this priority order for token-heavy surfaces:
+1. Ask for semantic data: `--json`, selected fields, `--jq`, `--fields`, `--toon`.
+2. Search the raw source with caps: `vx rg -n -m 80 ...`, `vx jq`, `vx yq`.
+3. Use `vx --compact <tool> ...` for broad subprocess output that still needs context.
+4. Read full raw output only after the smaller views fail to explain the issue.
+
+The compact filter follows RTK-style principles: preserve high-signal lines,
+strip presentation noise, collapse repetition, cap volume, and measure savings
+with `vx metrics tokens --json` when comparing approaches. Do not make
+transparent forwarding commands (`vx git`, `vx gh`, `vx cargo`, `vx npm`) compact
+by default; agents should opt in explicitly with `--compact` so scripts and
+humans keep the native tool contract.
 
 ## Project Setup
 
@@ -86,7 +101,7 @@ vx add just
 vx lock
 
 # 4. Commit configuration
-git add vx.toml vx.lock
+vx git add vx.toml vx.lock
 ```
 
 ### Team Onboarding

--- a/.agents/skills/vx-commands/SKILL.md
+++ b/.agents/skills/vx-commands/SKILL.md
@@ -1,15 +1,19 @@
 ---
 name: vx-commands
-description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --output-format toon for token-optimized output."
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, output formats, or token-efficient forwarding. vx-native commands support --json, --toon, --compact, and --output-format; forwarded tools keep native output unless compact mode is explicitly requested."
 ---
 
 # VX Command Reference
 
-> **Quick rule**: All vx commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+> **Quick rule**: Prefer semantic reduction first: `--json` with selected fields, then `--jq`/`vx rg` filtering, then `--compact` for broad logs. Set `VX_OUTPUT=json`, `VX_OUTPUT=toon`, or `VX_OUTPUT=compact` only when you want that default for the whole invocation.
 
 ## Structured Output Commands (AI-Optimized)
 
-All commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens).
+vx-native commands support `--json`, `--toon`, `--compact`, and
+`--output-format <text|json|toon|compact>`. Forwarded tools such as `vx git`,
+`vx gh`, `vx cargo`, or `vx npm` keep their native stdout by default; use the
+tool's own structured flags first, or add `vx --compact ...` when broad
+subprocess output must be filtered.
 
 ### Project Analysis
 
@@ -68,7 +72,7 @@ vx sync --json              # Sync from vx.toml
 ```
 
 **Output fields (install)**:
-- `runtime` - Tool name
+- `runtime` - Runtime name
 - `version` - Installed version
 - `path` - Installation path
 - `duration_ms` - Installation duration
@@ -109,6 +113,7 @@ vx list --json
 ### TOON Format (Token-Optimized)
 ```bash
 vx list --output-format toon
+vx list --toon
 # Output:
 # runtimes[50]{name,installed,description}:
 #   node,true,Node.js runtime
@@ -118,10 +123,43 @@ vx list --output-format toon
 
 TOON format is recommended for AI agents - it saves 40-60% tokens compared to JSON.
 
+### Compact Format and Forwarded Logs
+```bash
+# vx-native compact summary
+vx --compact list node
+vx list --output-format compact
+
+# Forwarded subprocess filtering
+vx --compact gh run view 789 --log
+vx --compact --filter-level aggressive cargo test
+```
+
+Compact mode is RTK-inspired: it strips ANSI noise, collapses repeated lines,
+keeps error-looking lines, and enforces a line budget for subprocess output.
+Use it after semantic options like `gh --json --jq` or `vx rg` filters.
+
+### GitHub and CI Triage
+```bash
+# Smallest useful status view
+vx gh run view 789 --json status,conclusion,jobs --jq '.jobs[] | {name,conclusion}'
+
+# Failure search with capped matches
+vx gh run view 789 --log | vx rg -n -m 80 "error|failed|panic|Traceback|FAILED|warning"
+
+# Broad fallback without raw-log token cost
+vx --compact gh run view 789 --log
+```
+
+Do not rely on default `vx gh` or `vx git` output to save tokens. Their default
+behavior is transparent forwarding; savings come from selected fields, `--jq`,
+search filters, or explicit `--compact`.
+
 ### Environment Variable
 ```bash
 export VX_OUTPUT=json       # Default to JSON output
 export VX_OUTPUT=toon       # Default to TOON output
+export VX_OUTPUT=compact    # Default to compact output/filtering
+export VX_FILTER_LEVEL=normal  # light, normal, aggressive
 ```
 
 ## Command Groups
@@ -190,7 +228,11 @@ vx cache clean              # Clean cache
 
 ```bash
 --json                      # JSON output
---output-format <text|json|toon>   # Output format
+--toon                      # TOON output
+--compact, -u               # Compact RTK-style output / subprocess filter
+--output-format <text|json|toon|compact>   # Output format
+--fields <a,b,c>            # Field mask for JSON-capable vx commands
+--filter-level <light|normal|aggressive>   # Compact subprocess filter level
 --verbose                   # Verbose output
 --debug                     # Debug output
 --use-system-path           # Use system PATH

--- a/.agents/skills/vx-troubleshooting/SKILL.md
+++ b/.agents/skills/vx-troubleshooting/SKILL.md
@@ -256,6 +256,28 @@ vx --trace node --version
 vx --verbose install node
 ```
 
+### Noisy CI and Log Triage
+
+When debugging GitHub Actions, do not start by reading the full log. Use
+structured status first, then capped searches, then compact mode if the failure
+still needs broad context:
+
+```bash
+# Job status without logs
+vx gh run view <run-id> --json status,conclusion,jobs --jq '.jobs[] | {name,conclusion}'
+
+# Focused failure search
+vx gh run view <run-id> --log | vx rg -n -m 80 "error|failed|panic|Traceback|FAILED|warning"
+
+# Broad fallback with compact filtering
+vx --compact gh run view <run-id> --log
+```
+
+Interpret keyword searches carefully. Passing tests may contain names like
+`returns_failure_envelope PASSED`, and build commands may include flags such as
+`--warnings-as-errors`; confirm the job conclusion and surrounding lines before
+treating a match as the root cause.
+
 ### Cache Inspection
 
 ```bash
@@ -393,6 +415,7 @@ When a user reports a vx issue, follow this decision tree:
    → Ensure the GitHub Action is used: loonghao/vx@main
    → Add github-token for rate limit avoidance
    → Use cache: 'true' for faster CI runs
+   → Inspect logs in order: `--json --jq`, capped `vx rg`, then `vx --compact`
 
 8. General error (exit code 1)
    → Run: vx doctor for full diagnostics

--- a/.agents/skills/vx-usage/SKILL.md
+++ b/.agents/skills/vx-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vx-usage
-description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, Git/GitHub operations, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 138 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, Git/GitHub operations, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 142 providers via Starlark DSL provider.star files. Also covers MCP integration patterns and GitHub Actions."
 ---
 
 # VX - Universal Development Tool Manager
@@ -55,7 +55,7 @@ vx git commit -m "fix: example"
 vx gh issue view 123
 vx gh pr view 456 --json title,state,headRefName
 vx gh pr checks 456
-vx gh run view 789 --log
+vx gh run view 789 --json status,conclusion,jobs
 ```
 
 ### Token-Efficient Agent Workflows
@@ -82,7 +82,9 @@ vx git grep -n "CommandOutput" origin/main -- crates/vx-cli
 vx gh issue view 123 --json title,state,labels,body
 vx gh pr view 456 --json title,state,headRefName,baseRefName,files
 vx gh pr checks 456 --json name,state,conclusion,link
-vx gh run view 789 --log | vx rg -n "error|failed|panic|warning"
+vx gh run view 789 --json status,conclusion,jobs
+vx gh run view 789 --json jobs --jq '.jobs[] | {name,conclusion,startedAt,completedAt}'
+vx gh run view 789 --log | vx rg -n -m 80 "error|failed|panic|Traceback|warning"
 
 # Structured filtering
 vx jq -r '.files[].path' pr.json
@@ -92,9 +94,23 @@ vx yq '.jobs | keys' .github/workflows/ci.yml
 Token-saving defaults for agents:
 - Start with `vx rg`, `vx fd`, `vx git diff --stat`, and `vx git diff --name-only`; open full files or full diffs only after locating the relevant surface.
 - Use `vx gh --json ...` with selected fields, and add `--jq` when a small projection is enough.
-- Use vx structured output flags when the vx command supports them: `--json`, `--fields`, `--toon`, or `--output-format toon`.
+- Use vx structured output flags when the vx command supports them: `--json`, `--fields`, `--toon`, `--compact`, or `--output-format toon|compact`.
 - For forwarded runtimes like `vx node`, `vx cargo`, or `vx npm`, use that tool's own quiet, JSON, or filtering flags when available.
 - Pipe large logs through vx-managed filters such as `vx rg`, `vx jq`, or `vx yq` before reading them.
+- Use `vx --compact <tool> ...` only when you still need broad subprocess output after structured fields and grep-style filters are not enough. It preserves vx transparency unless explicitly requested.
+- Do not expect default `vx git` or `vx gh` forwarding to shrink output; explicit `--json`, `--jq`, filtering, or `--compact` is what saves tokens.
+
+Compression decision tree for CI/log triage:
+1. Status only: `vx gh run view <run> --json status,conclusion,jobs --jq '.jobs[] | {name,conclusion}'`.
+2. Suspected failure: `vx gh run view <run> --log | vx rg -n -m 80 "error|failed|panic|Traceback|FAILED|warning"`.
+3. Broad but bounded context: `vx --compact gh run view <run> --log`.
+4. Last resort: full raw logs, preferably saved to a file and searched locally before being pasted into an agent prompt.
+
+Observed on a successful 5,589-line GitHub Actions run: selected `gh --json --jq`
+projection was about 500 tokens, raw `gh --log` output was about 226k tokens,
+and `vx --compact gh --log` was about 15.9k tokens. That makes semantic
+selection the default, compact mode the fallback for broad context, and raw logs
+the exception.
 
 ### Agent Operating Principles
 
@@ -122,7 +138,9 @@ Examples:
 vx rg -n -m 20 "render_token_savings|OutputRenderer" crates/vx-cli crates/vx-metrics
 vx git diff --stat origin/main...HEAD
 vx git diff --name-only origin/main...HEAD
-vx gh run view 789 --log | vx rg -n -m 50 "error|failed|panic"
+vx gh run view 789 --json status,conclusion,jobs --jq '.jobs[] | {name,conclusion}'
+vx gh run view 789 --log | vx rg -n -m 50 "error|failed|panic|Traceback|FAILED"
+vx --compact gh run view 789 --log
 vx metrics tokens --last 20 --json
 ```
 
@@ -289,7 +307,7 @@ vx msvc@14.40 cl main.cpp
 | lib | `vx msvc lib` | Library manager |
 | nmake | `vx msvc nmake` | Make utility |
 
-## Supported Tools (138 Providers)
+## Supported Tools (142 Providers)
 
 | Category | Tools |
 |----------|-------|
@@ -318,7 +336,7 @@ vx msvc@14.40 cl main.cpp
 
 ## Provider System (Starlark DSL)
 
-All 138 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+All 142 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
 
 vx uses a **two-phase execution model** (inspired by Buck2):
 1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
@@ -402,7 +420,7 @@ Key modules:
 5. **Use `vx git`** instead of `git` for repository operations
 6. **Use `vx gh`** instead of `gh` for GitHub issue, PR, checks, and workflow operations
 7. **Use `vx rg`, `vx fd`, `vx jq`, and `vx yq`** for scoped search and structured filtering
-8. **Prefer token-efficient output**: `--json`, selected fields, `--jq`, `--toon`, `--output-format toon`, and narrow globs
+8. **Prefer token-efficient output**: `--json`, selected fields, `--jq`, `--toon`, `--compact`, `--output-format toon|compact`, and narrow globs
 9. **Check `vx.toml`** first to understand project tool requirements
 10. **Use `vx run <script>`** for project-defined scripts
 11. **Never suggest manual tool installation** - vx handles it automatically

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,7 +487,7 @@ Use `@main` for latest, or pin to a release tag. Full guide: [`docs/guides/githu
 
 1. **Check for `vx.toml`** → if present, always use `vx` prefix
 2. **Never suggest manual installation** — `vx` handles it
-3. **Use structured output**: `vx list --json` or `vx list --output-format toon`
+3. **Use token-efficient output**: prefer `--json` with selected fields, `--jq`, `--toon`, and explicit `--compact` for broad logs
 4. **For MCP servers**, replace `npx`/`uvx` with `vx` in config
 5. **For CI/CD**, use `loonghao/vx@main` GitHub Action
 
@@ -572,6 +572,13 @@ For a full error-by-error decision tree, see [`docs/appendix/troubleshooting.md`
 
 ```bash
 vx list --json             # JSON output
-vx list --output-format toon      # Token-optimized (saves 40-60% tokens)
+vx list --output-format toon      # Token-oriented structured output
+vx --compact gh run view 123 --log # Compact forwarded subprocess output
 vx analyze --json          # Project analysis
 ```
+
+For CI and other huge logs, use this order: `vx gh ... --json --jq` for status,
+`vx gh ... --log | vx rg -n -m 80 "error|failed|panic|Traceback"` for focused
+matches, then `vx --compact ...` when broad context is still needed. Default
+`vx git` and `vx gh` remain transparent forwarded commands; compacting is an
+explicit opt-in.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4586,7 +4586,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "indexmap",
  "regex",
@@ -4616,7 +4616,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4626,7 +4626,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4705,7 +4705,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4727,7 +4727,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4766,7 +4766,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "colored",
@@ -4788,7 +4788,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4810,7 +4810,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4843,7 +4843,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4906,14 +4906,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-output-filter"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "regex",
@@ -4927,7 +4927,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4946,7 +4946,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4971,7 +4971,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5005,7 +5005,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5035,7 +5035,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "flate2",
@@ -5054,7 +5054,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5121,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "serde",
@@ -5139,11 +5139,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.9.3"
+version = "0.9.4"
 
 [[package]]
 name = "vx-starlark"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5173,7 +5173,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5214,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/vx-cli/src/cli.rs
+++ b/crates/vx-cli/src/cli.rs
@@ -1471,7 +1471,7 @@ pub enum AuthCommand {
 pub enum AiCommand {
     /// Install vx skills to AI agent configuration directories
     ///
-    /// Copies the built-in vx-usage skill to each agent's skills directory,
+    /// Copies the built-in vx skills to each agent's skills directory,
     /// so AI coding agents can better understand and use vx.
     Setup {
         /// Target specific agents (default: all supported agents)

--- a/crates/vx-cli/tests/ai_setup_tests.rs
+++ b/crates/vx-cli/tests/ai_setup_tests.rs
@@ -1,0 +1,59 @@
+//! Tests for `vx ai setup` skill installation.
+
+use std::fs;
+use std::path::PathBuf;
+
+use serial_test::serial;
+use tempfile::TempDir;
+
+struct CwdGuard {
+    original: PathBuf,
+}
+
+impl CwdGuard {
+    fn enter(path: &std::path::Path) -> Self {
+        let original = std::env::current_dir().expect("Failed to read current dir");
+        std::env::set_current_dir(path).expect("Failed to enter temp dir");
+        Self { original }
+    }
+}
+
+impl Drop for CwdGuard {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.original);
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_ai_setup_installs_token_efficient_builtin_skills() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let _cwd = CwdGuard::enter(temp_dir.path());
+    let agents = vec!["codex".to_string()];
+
+    vx_cli::commands::ai::handle_setup(&agents, false, true)
+        .await
+        .expect("vx ai setup should succeed");
+
+    let usage = fs::read_to_string(temp_dir.path().join(".agents/skills/vx-usage/SKILL.md"))
+        .expect("Failed to read installed vx-usage skill");
+    let commands = fs::read_to_string(temp_dir.path().join(".agents/skills/vx-commands/SKILL.md"))
+        .expect("Failed to read installed vx-commands skill");
+
+    assert!(
+        usage.contains("Compression decision tree for CI/log triage"),
+        "embedded vx-usage skill should include the CI compression decision tree"
+    );
+    assert!(
+        usage.contains("vx --compact gh run view <run> --log"),
+        "embedded vx-usage skill should teach explicit compact forwarding"
+    );
+    assert!(
+        commands.contains("Forwarded tools such as `vx git`,"),
+        "embedded vx-commands skill should explain transparent forwarding"
+    );
+    assert!(
+        commands.contains("--output-format <text|json|toon|compact>"),
+        "embedded vx-commands skill should document compact output format"
+    );
+}

--- a/crates/vx-output-filter/tests/filter_tests.rs
+++ b/crates/vx-output-filter/tests/filter_tests.rs
@@ -7,6 +7,16 @@ fn compact_config() -> OutputFilterConfig {
     OutputFilterConfig::compact_defaults()
 }
 
+fn filter_lines(level: FilterLevel, lines: &[String]) -> Vec<String> {
+    let mut filter = OutputFilter::new(OutputFilterConfig::for_level(level));
+    let mut output = Vec::new();
+    for line in lines {
+        output.extend(filter.filter_line(line));
+    }
+    output.extend(filter.finalize());
+    output
+}
+
 // ── ANSI stripping ────────────────────────────────────────────────────────────
 
 #[test]
@@ -221,5 +231,47 @@ fn test_light_level_no_dedup() {
     assert!(
         !summary.iter().any(|l| l.contains("omitted")),
         "Light level should not suppress any lines"
+    );
+}
+
+#[test]
+fn test_filter_level_comparison_reduces_tokens_and_keeps_errors() {
+    let mut raw = Vec::new();
+    raw.extend((0..60).map(|_| "building dependency graph".to_string()));
+    raw.extend((0..5).map(|_| "error: failed to compile crate".to_string()));
+    raw.extend((0..160).map(|i| format!("progress step {i}")));
+    raw.extend((0..140).map(|_| "warning: retrying download".to_string()));
+    raw.extend((0..160).map(|i| format!("trace detail {i}")));
+
+    let normal = filter_lines(FilterLevel::Normal, &raw);
+    let aggressive = filter_lines(FilterLevel::Aggressive, &raw);
+
+    let raw_chars = raw.join("\n").len();
+    let normal_chars = normal.join("\n").len();
+    let aggressive_chars = aggressive.join("\n").len();
+
+    assert!(
+        normal_chars < raw_chars,
+        "normal compact output should be smaller than raw output"
+    );
+    assert!(
+        aggressive_chars < normal_chars,
+        "aggressive compact output should be smaller than normal compact output"
+    );
+    assert!(
+        normal.iter().any(|line| line.contains("error: failed")),
+        "normal filtering must preserve error-looking lines"
+    );
+    assert!(
+        aggressive.iter().any(|line| line.contains("error: failed")),
+        "aggressive filtering must preserve early error-looking lines"
+    );
+    assert!(
+        normal.iter().any(|line| line.contains("omitted")),
+        "normal filtering should explain omitted repeated lines"
+    );
+    assert!(
+        aggressive.iter().any(|line| line.contains("omitted")),
+        "aggressive filtering should explain omitted or truncated lines"
     );
 }

--- a/docs/guide/agent-dx.md
+++ b/docs/guide/agent-dx.md
@@ -20,18 +20,19 @@ vx addresses all of these.
 
 ---
 
-## 1. Auto Machine-Readable Output (TTY Detection)
+## 1. Auto Token-Oriented Output (TTY Detection)
 
 When stdout is **not a TTY** (piped to an agent, script, or CI pipeline), vx
-automatically switches from human-readable text to compact NDJSON — no flags needed.
+automatically switches from human-readable text to TOON — a token-oriented
+structured format for LLM prompts.
 
 ```bash
 # Human (TTY): rich text with emoji
 vx list
 
-# Agent (pipe): compact JSON, one object per line
+# Agent (pipe): token-oriented TOON
 vx list | cat
-# {"runtimes":[{"name":"node","installed":true,"version":"20.0.0",...}],...}
+# runtimes[...]{name,installed,description}:
 ```
 
 ### Override
@@ -43,6 +44,11 @@ VX_OUTPUT=text vx list | cat
 # Force JSON even in terminal
 vx list --json
 vx list --output-format json
+
+# Force TOON or compact output
+vx list --toon
+vx list --output-format toon
+vx --compact list node
 ```
 
 ---
@@ -66,7 +72,30 @@ The `--fields` flag is global and applies to all JSON-outputting commands.
 
 ---
 
-## 3. Schema Introspection (`vx schema`)
+## 3. Compact Subprocess Output
+
+Forwarded tools keep their native stdout by default. When a command can produce
+huge logs and no better structured output is available, opt in to compact mode:
+
+```bash
+# GitHub Actions status first, without logs
+vx gh run view 123 --json status,conclusion,jobs --jq '.jobs[] | {name,conclusion}'
+
+# Capped log search next
+vx gh run view 123 --log | vx rg -n -m 80 "error|failed|panic|Traceback|FAILED|warning"
+
+# Broad fallback with RTK-style filtering
+vx --compact gh run view 123 --log
+vx --compact --filter-level aggressive cargo test
+```
+
+Compact mode strips ANSI noise, collapses repeated lines, preserves
+error-looking lines, and applies a line budget. Use `--filter-level light`,
+`normal`, or `aggressive` to tune how much output is suppressed.
+
+---
+
+## 4. Schema Introspection (`vx schema`)
 
 Agents can discover what vx accepts at runtime — no static docs, no hallucinations:
 
@@ -102,7 +131,7 @@ Example output for `vx schema node`:
 
 ---
 
-## 4. Input Validation (Defense Against Hallucinations)
+## 5. Input Validation (Defense Against Hallucinations)
 
 vx treats all CLI inputs as untrusted — agents can hallucinate adversarial values.
 The `input_validation` module rejects:
@@ -123,7 +152,7 @@ Error: Invalid runtime name 'node?version=20': embedded query parameters not all
 
 ---
 
-## 5. Disable Auto-Install (`--no-auto-install`)
+## 6. Disable Auto-Install (`--no-auto-install`)
 
 Agents in CI/CD pipelines should have explicit install steps. Use this to prevent
 silent auto-installation:
@@ -138,7 +167,7 @@ VX_NO_AUTO_INSTALL=1 vx node --version
 
 ---
 
-## 6. Dry-Run Mode (`--dry-run`)
+## 7. Dry-Run Mode (`--dry-run`)
 
 Agents can validate operations before executing them, preventing data loss from
 hallucinated parameters:
@@ -156,7 +185,7 @@ vx init --dry-run
 
 ---
 
-## 7. Environment Variable Authentication
+## 8. Environment Variable Authentication
 
 Agents cannot perform browser-based OAuth flows. Use environment variables to
 inject credentials:
@@ -171,7 +200,7 @@ vx auth login github --token ghp_xxx
 
 ---
 
-## 8. AI Context (`vx ai context`)
+## 9. AI Context (`vx ai context`)
 
 Get a structured project context dump optimized for AI agents:
 
@@ -185,7 +214,7 @@ vx ai context --minimal --json
 
 ---
 
-## 9. Cross-Language Global Install Contract
+## 10. Cross-Language Global Install Contract
 
 vx preserves ecosystem-native global install syntax while keeping installs inside
 vx-managed isolation and shim workflows:
@@ -236,7 +265,8 @@ vx ai context --minimal --json
 
 | Variable | Values | Description |
 |----------|--------|-------------|
-| `VX_OUTPUT` | `json`, `text`, `toon` | Override output format |
+| `VX_OUTPUT` | `json`, `text`, `toon`, `compact` | Override output format |
+| `VX_FILTER_LEVEL` | `light`, `normal`, `aggressive` | Tune compact subprocess filtering |
 | `VX_NO_AUTO_INSTALL` | `1`, `true`, `yes` | Disable auto-installation |
 | `VX_OUTPUT_JSON` | `1` | Legacy: force JSON (prefer `VX_OUTPUT=json`) |
 | `GITHUB_TOKEN` | `ghp_...` | GitHub API token for version fetching |

--- a/docs/guide/command-syntax-rules.md
+++ b/docs/guide/command-syntax-rules.md
@@ -65,12 +65,15 @@ These flags are cross-cutting syntax contracts and apply consistently to runtime
 |---|---|---|
 | Structured output (JSON) | `--json` | Shortcut for `--output-format json`; overrides `--output-format` when both are provided. |
 | LLM-friendly output (TOON) | `--toon` | Shortcut for `--output-format toon`; overrides `--output-format` when both are provided. |
-| Explicit output mode | `--output-format <text|json|toon>` | Canonical explicit form when shortcut flags are not used. |
+| Compact output / filtering | `--compact` / `-u` | Shortcut for `--output-format compact`; for forwarded subprocesses, opt in to compact filtering. |
+| Explicit output mode | `--output-format <text|json|toon|compact>` | Canonical explicit form when shortcut flags are not used. |
+| Compact filter level | `--filter-level <light|normal|aggressive>` | Tunes subprocess output filtering when compact mode is active. |
 | Cache strategy | `--cache-mode <normal|refresh|offline|no-cache>` | Unified cache control for all execution paths. |
 
 Resolution notes:
 
-- Output option precedence: shortcut flags (`--json` / `--toon`) > `--output-format` > environment defaults.
+- Output option precedence: shortcut flags (`--json` / `--toon` / `--compact`) > `--output-format` > environment defaults.
+- Forwarded commands such as `vx git` and `vx gh` keep native stdout by default; compact filtering is an explicit opt-in.
 - Cache mode must be interpreted uniformly by parser/executor and documented examples.
 
 ## Capability Coverage Matrix (Core Scenarios)

--- a/docs/tools/ai.md
+++ b/docs/tools/ai.md
@@ -83,6 +83,25 @@ mcp-tools = "vx --compact mcpcall list --url http://127.0.0.1:8765/mcp --json"
 mcp-doctor = "vx --compact mcpcall doctor --url http://127.0.0.1:8765/mcp --json"
 ```
 
+### Token-Efficient CI Inspection
+
+For GitHub Actions or other large logs, reduce semantically before reading raw
+output:
+
+```bash
+# Status and job conclusions first
+vx gh run view <run-id> --json status,conclusion,jobs --jq '.jobs[] | {name,conclusion}'
+
+# Focused log search with a match cap
+vx gh run view <run-id> --log | vx rg -n -m 80 "error|failed|panic|Traceback|FAILED|warning"
+
+# Broad fallback with compact subprocess filtering
+vx --compact gh run view <run-id> --log
+```
+
+Default `vx gh` and `vx git` stay transparent. Use `--compact` explicitly when
+the native tool does not offer a smaller structured view.
+
 ### Local LLM + Python AI Stack
 
 Set up a complete local AI development environment:

--- a/docs/zh/guide/command-syntax-rules.md
+++ b/docs/zh/guide/command-syntax-rules.md
@@ -65,12 +65,15 @@
 |---|---|---|
 | JSON 结构化输出 | `--json` | `--output-format json` 的快捷方式；与 `--output-format` 同时出现时优先。 |
 | TOON（LLM 友好）输出 | `--toon` | `--output-format toon` 的快捷方式；与 `--output-format` 同时出现时优先。 |
-| 显式输出模式 | `--output-format <text|json|toon>` | 未使用快捷参数时的显式主写法。 |
+| Compact 输出 / 过滤 | `--compact` / `-u` | `--output-format compact` 的快捷方式；对转发子进程输出显式启用压缩过滤。 |
+| 显式输出模式 | `--output-format <text|json|toon|compact>` | 未使用快捷参数时的显式主写法。 |
+| Compact 过滤级别 | `--filter-level <light|normal|aggressive>` | compact 模式生效时调节子进程输出过滤强度。 |
 | 缓存策略 | `--cache-mode <normal|refresh|offline|no-cache>` | 所有执行路径统一缓存控制语义。 |
 
 决策说明：
 
-- 输出参数优先级：快捷参数（`--json` / `--toon`）> `--output-format` > 环境默认值。
+- 输出参数优先级：快捷参数（`--json` / `--toon` / `--compact`）> `--output-format` > 环境默认值。
+- `vx git`、`vx gh` 这类转发命令默认保持原生命令输出；compact 过滤必须显式开启。
 - `cache-mode` 的解析和执行语义必须在解析器、执行器、文档示例中保持一致。
 
 ## 能力覆盖矩阵（核心场景）

--- a/docs/zh/tools/ai.md
+++ b/docs/zh/tools/ai.md
@@ -83,6 +83,24 @@ mcp-tools = "vx --compact mcpcall list --url http://127.0.0.1:8765/mcp --json"
 mcp-doctor = "vx --compact mcpcall doctor --url http://127.0.0.1:8765/mcp --json"
 ```
 
+### 省 token 的 CI 检查
+
+查看 GitHub Actions 或其他大日志时，先做语义压缩，再读原始输出：
+
+```bash
+# 先看状态和 job 结论
+vx gh run view <run-id> --json status,conclusion,jobs --jq '.jobs[] | {name,conclusion}'
+
+# 再做带上限的日志搜索
+vx gh run view <run-id> --log | vx rg -n -m 80 "error|failed|panic|Traceback|FAILED|warning"
+
+# 仍需要大范围上下文时，用 compact 子进程过滤兜底
+vx --compact gh run view <run-id> --log
+```
+
+默认 `vx gh` 和 `vx git` 保持透明转发。只有在原生命令没有更小的结构化视图时，
+才显式加 `--compact`。
+
 ### 本地 LLM + Python AI 技术栈
 
 搭建完整的本地 AI 开发环境：

--- a/llms.txt
+++ b/llms.txt
@@ -39,7 +39,8 @@ vx run test                # Run project scripts
 
 # AI-optimized output:
 vx list --json             # JSON for parsing
-vx list --format toon      # Token-optimized (saves 40-60% tokens)
+vx list --output-format toon # Token-oriented structured output
+vx --compact gh run view 123 --log # Compact forwarded logs
 vx analyze --json          # Project analysis as JSON
 ```
 
@@ -150,7 +151,7 @@ This eliminates the need for users to pre-install Node.js, Python, or any runtim
 - [Skills Overview](https://github.com/loonghao/vx/blob/main/skills/README.md): AI agent skills distribution and activation
 - [AGENTS.md](https://github.com/loonghao/vx/blob/main/AGENTS.md): Primary AI agent entry point with rules, architecture, and quick reference
 - [vx-usage Skill](https://github.com/loonghao/vx/blob/main/skills/vx-usage/SKILL.md): Core usage guide — commands, vx.toml, providers, MCP, GitHub Actions
-- [vx-commands Skill](https://github.com/loonghao/vx/blob/main/skills/vx-commands/SKILL.md): CLI command reference with --json and --format toon output
+- [vx-commands Skill](https://github.com/loonghao/vx/blob/main/skills/vx-commands/SKILL.md): CLI command reference with --json, --toon, --compact, and --output-format output
 - [vx-project Skill](https://github.com/loonghao/vx/blob/main/skills/vx-project/SKILL.md): Project management — init, sync, setup, monorepo
 - [vx-best-practices Skill](https://github.com/loonghao/vx/blob/main/skills/vx-best-practices/SKILL.md): Best practices and provider development
 - [vx-troubleshooting Skill](https://github.com/loonghao/vx/blob/main/skills/vx-troubleshooting/SKILL.md): Troubleshooting and recovery procedures

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,6 @@
 # vx — AI Agent Skills
 
-This directory contains AI agent skills for **[vx](https://github.com/loonghao/vx)** — the universal development tool manager (v0.8.25).
+This directory contains AI agent skills for **[vx](https://github.com/loonghao/vx)** — the universal development tool manager (v0.9.4).
 
 > **Core concept**: vx = prefix any dev tool command with `vx` → it auto-installs the tool and runs it.
 
@@ -32,7 +32,10 @@ vx skills should teach agents to be precise, scoped, and token-aware:
 - Prefer the smallest maintainable change that solves the actual request.
 - Read the narrowest relevant file, symbol, diff, log, or test output first.
 - Scope command output before printing it; use `vx rg`, `vx fd`, `vx gh --json`,
-  `vx jq`, and `vx metrics tokens` to keep context useful.
+  `vx gh --jq`, `vx jq`, `vx --compact`, and `vx metrics tokens` to keep context useful.
+- Prefer semantic reduction first (`--json`, selected fields, `--jq`, `--toon`);
+  use explicit `--compact` for broad subprocess logs after structured and grep-style
+  views are insufficient.
 - Avoid broad repo dumps, full logs, unrelated cleanup, and single-use wrappers.
 - Validate according to risk with the cheapest useful focused check first.
 - Treat `skills/` as the canonical source and project-level skill directories as
@@ -43,7 +46,7 @@ vx skills should teach agents to be precise, scoped, and token-aware:
 | Skill | Description | Size | Best for |
 |-------|-------------|------|----------|
 | **vx-usage** | Core usage guide — commands, vx.toml, providers, GitHub Actions, MCP integration | ~15 KB | First-time users, general questions |
-| **vx-commands** | CLI command reference — all flags, output formats (`--json`, `--output-format toon`) | ~6 KB | Looking up specific command syntax |
+| **vx-commands** | CLI command reference — flags, forwarding, and output formats (`--json`, `--toon`, `--compact`) | ~6 KB | Looking up specific command syntax |
 | **vx-project** | Project management — init, sync, setup, vx.toml configuration, monorepo | ~6 KB | Setting up or configuring projects |
 | **vx-best-practices** | Best practices — version strategy, cross-platform, security, provider development | ~10 KB | Team workflows, provider creation |
 | **vx-troubleshooting** | Troubleshooting — installation failures, PATH issues, diagnostics, recovery | ~8 KB | Fixing errors, diagnosing issues |

--- a/skills/vx-best-practices/SKILL.md
+++ b/skills/vx-best-practices/SKILL.md
@@ -5,7 +5,7 @@ description: "Best practices for using vx effectively. Use when following recomm
 
 # VX Best Practices
 
-> **Golden rule**: Always prefix tool commands with `vx` in vx-managed projects. Use `vx.toml` for project-level tool versions, commit `vx.lock` for reproducibility, and prefer templates over custom code when creating providers.
+> **Golden rule**: Always prefix tool commands with `vx` in vx-managed projects. Use `vx.toml` for project-level tool versions, commit `vx.lock` for reproducibility, prefer templates over custom code when creating providers, and prefer structured or compact output before reading large logs.
 
 ## General Principles
 
@@ -42,8 +42,8 @@ vx install node@22
 Always commit `vx.lock` to ensure reproducible builds:
 
 ```bash
-git add vx.lock
-git commit -m "chore: update dependencies"
+vx git add vx.lock
+vx git commit -m "chore: update dependencies"
 ```
 
 ### 4. Keep Agent Work Small and Observable
@@ -66,8 +66,23 @@ vx rg -n -m 20 "SearchTerm" src
 vx git diff --stat
 vx git diff --name-only origin/main...HEAD
 vx gh pr view 123 --json title,state,files
-vx gh run view 456 --log | vx rg -n -m 50 "error|failed|panic"
+vx gh run view 456 --json status,conclusion,jobs --jq '.jobs[] | {name,conclusion}'
+vx gh run view 456 --log | vx rg -n -m 50 "error|failed|panic|Traceback|FAILED"
+vx --compact gh run view 456 --log
 ```
+
+Use this priority order for token-heavy surfaces:
+1. Ask for semantic data: `--json`, selected fields, `--jq`, `--fields`, `--toon`.
+2. Search the raw source with caps: `vx rg -n -m 80 ...`, `vx jq`, `vx yq`.
+3. Use `vx --compact <tool> ...` for broad subprocess output that still needs context.
+4. Read full raw output only after the smaller views fail to explain the issue.
+
+The compact filter follows RTK-style principles: preserve high-signal lines,
+strip presentation noise, collapse repetition, cap volume, and measure savings
+with `vx metrics tokens --json` when comparing approaches. Do not make
+transparent forwarding commands (`vx git`, `vx gh`, `vx cargo`, `vx npm`) compact
+by default; agents should opt in explicitly with `--compact` so scripts and
+humans keep the native tool contract.
 
 ## Project Setup
 
@@ -86,7 +101,7 @@ vx add just
 vx lock
 
 # 4. Commit configuration
-git add vx.toml vx.lock
+vx git add vx.toml vx.lock
 ```
 
 ### Team Onboarding

--- a/skills/vx-commands/SKILL.md
+++ b/skills/vx-commands/SKILL.md
@@ -1,15 +1,19 @@
 ---
 name: vx-commands
-description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --output-format toon for token-optimized output."
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, output formats, or token-efficient forwarding. vx-native commands support --json, --toon, --compact, and --output-format; forwarded tools keep native output unless compact mode is explicitly requested."
 ---
 
 # VX Command Reference
 
-> **Quick rule**: All vx commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+> **Quick rule**: Prefer semantic reduction first: `--json` with selected fields, then `--jq`/`vx rg` filtering, then `--compact` for broad logs. Set `VX_OUTPUT=json`, `VX_OUTPUT=toon`, or `VX_OUTPUT=compact` only when you want that default for the whole invocation.
 
 ## Structured Output Commands (AI-Optimized)
 
-All commands support `--json` for structured output and `--output-format toon` for token-optimized output (saves 40-60% tokens).
+vx-native commands support `--json`, `--toon`, `--compact`, and
+`--output-format <text|json|toon|compact>`. Forwarded tools such as `vx git`,
+`vx gh`, `vx cargo`, or `vx npm` keep their native stdout by default; use the
+tool's own structured flags first, or add `vx --compact ...` when broad
+subprocess output must be filtered.
 
 ### Project Analysis
 
@@ -68,7 +72,7 @@ vx sync --json              # Sync from vx.toml
 ```
 
 **Output fields (install)**:
-- `runtime` - Tool name
+- `runtime` - Runtime name
 - `version` - Installed version
 - `path` - Installation path
 - `duration_ms` - Installation duration
@@ -109,6 +113,7 @@ vx list --json
 ### TOON Format (Token-Optimized)
 ```bash
 vx list --output-format toon
+vx list --toon
 # Output:
 # runtimes[50]{name,installed,description}:
 #   node,true,Node.js runtime
@@ -118,10 +123,43 @@ vx list --output-format toon
 
 TOON format is recommended for AI agents - it saves 40-60% tokens compared to JSON.
 
+### Compact Format and Forwarded Logs
+```bash
+# vx-native compact summary
+vx --compact list node
+vx list --output-format compact
+
+# Forwarded subprocess filtering
+vx --compact gh run view 789 --log
+vx --compact --filter-level aggressive cargo test
+```
+
+Compact mode is RTK-inspired: it strips ANSI noise, collapses repeated lines,
+keeps error-looking lines, and enforces a line budget for subprocess output.
+Use it after semantic options like `gh --json --jq` or `vx rg` filters.
+
+### GitHub and CI Triage
+```bash
+# Smallest useful status view
+vx gh run view 789 --json status,conclusion,jobs --jq '.jobs[] | {name,conclusion}'
+
+# Failure search with capped matches
+vx gh run view 789 --log | vx rg -n -m 80 "error|failed|panic|Traceback|FAILED|warning"
+
+# Broad fallback without raw-log token cost
+vx --compact gh run view 789 --log
+```
+
+Do not rely on default `vx gh` or `vx git` output to save tokens. Their default
+behavior is transparent forwarding; savings come from selected fields, `--jq`,
+search filters, or explicit `--compact`.
+
 ### Environment Variable
 ```bash
 export VX_OUTPUT=json       # Default to JSON output
 export VX_OUTPUT=toon       # Default to TOON output
+export VX_OUTPUT=compact    # Default to compact output/filtering
+export VX_FILTER_LEVEL=normal  # light, normal, aggressive
 ```
 
 ## Command Groups
@@ -190,7 +228,11 @@ vx cache clean              # Clean cache
 
 ```bash
 --json                      # JSON output
---output-format <text|json|toon>   # Output format
+--toon                      # TOON output
+--compact, -u               # Compact RTK-style output / subprocess filter
+--output-format <text|json|toon|compact>   # Output format
+--fields <a,b,c>            # Field mask for JSON-capable vx commands
+--filter-level <light|normal|aggressive>   # Compact subprocess filter level
 --verbose                   # Verbose output
 --debug                     # Debug output
 --use-system-path           # Use system PATH

--- a/skills/vx-troubleshooting/SKILL.md
+++ b/skills/vx-troubleshooting/SKILL.md
@@ -256,6 +256,28 @@ vx --trace node --version
 vx --verbose install node
 ```
 
+### Noisy CI and Log Triage
+
+When debugging GitHub Actions, do not start by reading the full log. Use
+structured status first, then capped searches, then compact mode if the failure
+still needs broad context:
+
+```bash
+# Job status without logs
+vx gh run view <run-id> --json status,conclusion,jobs --jq '.jobs[] | {name,conclusion}'
+
+# Focused failure search
+vx gh run view <run-id> --log | vx rg -n -m 80 "error|failed|panic|Traceback|FAILED|warning"
+
+# Broad fallback with compact filtering
+vx --compact gh run view <run-id> --log
+```
+
+Interpret keyword searches carefully. Passing tests may contain names like
+`returns_failure_envelope PASSED`, and build commands may include flags such as
+`--warnings-as-errors`; confirm the job conclusion and surrounding lines before
+treating a match as the root cause.
+
 ### Cache Inspection
 
 ```bash
@@ -393,6 +415,7 @@ When a user reports a vx issue, follow this decision tree:
    → Ensure the GitHub Action is used: loonghao/vx@main
    → Add github-token for rate limit avoidance
    → Use cache: 'true' for faster CI runs
+   → Inspect logs in order: `--json --jq`, capped `vx rg`, then `vx --compact`
 
 8. General error (exit code 1)
    → Run: vx doctor for full diagnostics

--- a/skills/vx-usage/SKILL.md
+++ b/skills/vx-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vx-usage
-description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, Git/GitHub operations, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 138 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, Git/GitHub operations, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 142 providers via Starlark DSL provider.star files. Also covers MCP integration patterns and GitHub Actions."
 ---
 
 # VX - Universal Development Tool Manager
@@ -55,7 +55,7 @@ vx git commit -m "fix: example"
 vx gh issue view 123
 vx gh pr view 456 --json title,state,headRefName
 vx gh pr checks 456
-vx gh run view 789 --log
+vx gh run view 789 --json status,conclusion,jobs
 ```
 
 ### Token-Efficient Agent Workflows
@@ -82,7 +82,9 @@ vx git grep -n "CommandOutput" origin/main -- crates/vx-cli
 vx gh issue view 123 --json title,state,labels,body
 vx gh pr view 456 --json title,state,headRefName,baseRefName,files
 vx gh pr checks 456 --json name,state,conclusion,link
-vx gh run view 789 --log | vx rg -n "error|failed|panic|warning"
+vx gh run view 789 --json status,conclusion,jobs
+vx gh run view 789 --json jobs --jq '.jobs[] | {name,conclusion,startedAt,completedAt}'
+vx gh run view 789 --log | vx rg -n -m 80 "error|failed|panic|Traceback|warning"
 
 # Structured filtering
 vx jq -r '.files[].path' pr.json
@@ -92,9 +94,23 @@ vx yq '.jobs | keys' .github/workflows/ci.yml
 Token-saving defaults for agents:
 - Start with `vx rg`, `vx fd`, `vx git diff --stat`, and `vx git diff --name-only`; open full files or full diffs only after locating the relevant surface.
 - Use `vx gh --json ...` with selected fields, and add `--jq` when a small projection is enough.
-- Use vx structured output flags when the vx command supports them: `--json`, `--fields`, `--toon`, or `--output-format toon`.
+- Use vx structured output flags when the vx command supports them: `--json`, `--fields`, `--toon`, `--compact`, or `--output-format toon|compact`.
 - For forwarded runtimes like `vx node`, `vx cargo`, or `vx npm`, use that tool's own quiet, JSON, or filtering flags when available.
 - Pipe large logs through vx-managed filters such as `vx rg`, `vx jq`, or `vx yq` before reading them.
+- Use `vx --compact <tool> ...` only when you still need broad subprocess output after structured fields and grep-style filters are not enough. It preserves vx transparency unless explicitly requested.
+- Do not expect default `vx git` or `vx gh` forwarding to shrink output; explicit `--json`, `--jq`, filtering, or `--compact` is what saves tokens.
+
+Compression decision tree for CI/log triage:
+1. Status only: `vx gh run view <run> --json status,conclusion,jobs --jq '.jobs[] | {name,conclusion}'`.
+2. Suspected failure: `vx gh run view <run> --log | vx rg -n -m 80 "error|failed|panic|Traceback|FAILED|warning"`.
+3. Broad but bounded context: `vx --compact gh run view <run> --log`.
+4. Last resort: full raw logs, preferably saved to a file and searched locally before being pasted into an agent prompt.
+
+Observed on a successful 5,589-line GitHub Actions run: selected `gh --json --jq`
+projection was about 500 tokens, raw `gh --log` output was about 226k tokens,
+and `vx --compact gh --log` was about 15.9k tokens. That makes semantic
+selection the default, compact mode the fallback for broad context, and raw logs
+the exception.
 
 ### Agent Operating Principles
 
@@ -122,7 +138,9 @@ Examples:
 vx rg -n -m 20 "render_token_savings|OutputRenderer" crates/vx-cli crates/vx-metrics
 vx git diff --stat origin/main...HEAD
 vx git diff --name-only origin/main...HEAD
-vx gh run view 789 --log | vx rg -n -m 50 "error|failed|panic"
+vx gh run view 789 --json status,conclusion,jobs --jq '.jobs[] | {name,conclusion}'
+vx gh run view 789 --log | vx rg -n -m 50 "error|failed|panic|Traceback|FAILED"
+vx --compact gh run view 789 --log
 vx metrics tokens --last 20 --json
 ```
 
@@ -289,7 +307,7 @@ vx msvc@14.40 cl main.cpp
 | lib | `vx msvc lib` | Library manager |
 | nmake | `vx msvc nmake` | Make utility |
 
-## Supported Tools (138 Providers)
+## Supported Tools (142 Providers)
 
 | Category | Tools |
 |----------|-------|
@@ -318,7 +336,7 @@ vx msvc@14.40 cl main.cpp
 
 ## Provider System (Starlark DSL)
 
-All 138 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+All 142 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
 
 vx uses a **two-phase execution model** (inspired by Buck2):
 1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
@@ -402,7 +420,7 @@ Key modules:
 5. **Use `vx git`** instead of `git` for repository operations
 6. **Use `vx gh`** instead of `gh` for GitHub issue, PR, checks, and workflow operations
 7. **Use `vx rg`, `vx fd`, `vx jq`, and `vx yq`** for scoped search and structured filtering
-8. **Prefer token-efficient output**: `--json`, selected fields, `--jq`, `--toon`, `--output-format toon`, and narrow globs
+8. **Prefer token-efficient output**: `--json`, selected fields, `--jq`, `--toon`, `--compact`, `--output-format toon|compact`, and narrow globs
 9. **Check `vx.toml`** first to understand project tool requirements
 10. **Use `vx run <script>`** for project-defined scripts
 11. **Never suggest manual tool installation** - vx handles it automatically


### PR DESCRIPTION
## Summary

- Teach vx skills and agent-facing docs to prefer structured, filtered, and explicit compact output for token-heavy workflows.
- Sync the canonical `skills/` content with `.agents/skills/` compatibility copies.
- Add coverage for compact output comparison and `vx ai setup` installing the embedded token-efficient skills.

## Validation

- `vx cargo fmt --all`
- `vx cargo test -p vx-output-filter`
- `vx cargo test -p vx-cli --test ai_setup_tests`
- `vx git diff --check`
