### PR TITLE
fix: harden release workflow reruns

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,10 +35,11 @@
 # is skipped — so cargo-dist never runs for that version.
 #
 # Fix: Both jobs trigger the Release workflow when their release-please step
-# reports releases_created=true. Additionally, the `release` job has a fallback
-# that dispatches Release based on the tag derived from
-# .release-please-manifest.json when the release already exists (i.e. it was
-# created by a prior run), ensuring cargo-dist always runs once per release.
+# reports releases_created=true. Additionally, the `release` job checks whether
+# the manifest tag already has a GitHub Release before invoking release-please.
+# If it does, skip release-please to avoid duplicate tag/release failures, then
+# dispatch cargo-dist only when the release has no assets and no Release workflow
+# is already active.
 
 name: Release Please
 
@@ -61,10 +62,43 @@ jobs:
     if: >-
       startsWith(github.event.head_commit.message, 'chore: release')
     outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
+      releases_created: ${{ steps.release.outputs.releases_created || 'false' }}
+      tag_name: ${{ steps.release.outputs.tag_name || steps.release-state.outputs.tag }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Check existing release state
+        id: release-state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version=$(jq -r '."."' .release-please-manifest.json)
+          if [ -z "$version" ] || [ "$version" = "null" ]; then
+            echo "::warning::Could not read version from .release-please-manifest.json."
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "release_exists=false" >> "$GITHUB_OUTPUT"
+            echo "asset_count=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          tag="v${version}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "Release commit targets ${tag}."
+
+          if asset_count=$(gh release view "$tag" --repo "${{ github.repository }}" --json assets --jq '.assets | length' 2>/dev/null); then
+            echo "release_exists=true" >> "$GITHUB_OUTPUT"
+            echo "asset_count=${asset_count}" >> "$GITHUB_OUTPUT"
+            echo "Release ${tag} already exists with ${asset_count} asset(s); skipping release-please create path."
+          else
+            echo "release_exists=false" >> "$GITHUB_OUTPUT"
+            echo "asset_count=0" >> "$GITHUB_OUTPUT"
+            echo "Release ${tag} does not exist yet; release-please will create it."
+          fi
+
       - uses: googleapis/release-please-action@v5
+        if: ${{ steps.release-state.outputs.release_exists != 'true' }}
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -83,33 +117,39 @@ jobs:
             --repo "${{ github.repository }}" \
             --field "tag=${{ steps.release.outputs.tag_name }}"
 
-      # Fallback: the release may have been created by a prior `update-pr`
-      # run (race condition — see workflow header). In that case
-      # releases_created is 'false' but the release still needs cargo-dist
-      # to publish artifacts. Derive the tag from the manifest, verify the
-      # release exists, and dispatch Release if it does.
-      - name: Checkout repository
-        if: ${{ steps.release.outputs.releases_created != 'true' }}
-        uses: actions/checkout@v6
-
-      - name: Trigger Release workflow (fallback)
-        if: ${{ steps.release.outputs.releases_created != 'true' }}
+      # Fallback: the release may already exist because an earlier run created
+      # it before this release commit's workflow started. If assets are still
+      # missing and no Release workflow is active, dispatch cargo-dist once.
+      - name: Trigger Release workflow (existing release fallback)
+        if: >-
+          ${{
+            steps.release.outputs.releases_created != 'true' &&
+            steps.release-state.outputs.release_exists == 'true' &&
+            steps.release-state.outputs.asset_count == '0'
+          }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          version=$(jq -r '."."' .release-please-manifest.json)
-          if [ -z "$version" ] || [ "$version" = "null" ]; then
-            echo "::warning::Could not read version from .release-please-manifest.json; skipping fallback dispatch."
+          tag="${{ steps.release-state.outputs.tag }}"
+          if [ -z "$tag" ]; then
+            echo "::warning::No release tag available; skipping fallback dispatch."
             exit 0
           fi
-          tag="v${version}"
-          echo "releases_created=false but commit is 'chore: release'; checking tag ${tag}..."
-          if ! gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "::warning::Release ${tag} does not exist yet; nothing to dispatch."
+
+          active_release_runs="$(gh run list \
+            --repo "${{ github.repository }}" \
+            --workflow release.yml \
+            --limit 20 \
+            --json status \
+            --jq '[.[] | select(.status != "completed")] | length')"
+
+          if [ "$active_release_runs" != "0" ]; then
+            echo "Release workflow is already active (${active_release_runs} run(s)); skipping fallback dispatch for ${tag}."
             exit 0
           fi
-          echo "Release ${tag} already exists (likely created by a prior run). Dispatching Release workflow..."
+
+          echo "Release ${tag} exists without assets and no Release workflow is active. Dispatching Release workflow..."
           gh workflow run release.yml \
             --repo "${{ github.repository }}" \
             --field "tag=${tag}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,8 +173,22 @@ jobs:
           path: target/distrib/
           merge-multiple: true
       - name: Install dependencies
+        shell: bash
         run: |
+          set -euo pipefail
+          install_script="$(mktemp)"
+          cat > "$install_script" <<'PACKAGES_INSTALL'
           ${{ matrix.packages_install }}
+          PACKAGES_INSTALL
+
+          if [ ! -s "$install_script" ]; then
+            echo "No extra system packages required for this target."
+            exit 0
+          fi
+
+          # cargo-dist emits apt-get install without -y; keep release jobs non-interactive.
+          sed -i -E 's/^([[:space:]]*sudo[[:space:]]+)?apt-get[[:space:]]+install[[:space:]]+/\1apt-get install -y /' "$install_script"
+          DEBIAN_FRONTEND=noninteractive bash -euxo pipefail "$install_script"
       - name: Build artifacts
         run: |
           # Actually do builds and make zips and whatnot

--- a/docs/advanced/release-process.md
+++ b/docs/advanced/release-process.md
@@ -302,7 +302,7 @@ This condition:
 - `.github/workflows/benchmark.yml` - `benchmark` job
 
 **Not affected** (intentionally):
-- `.github/workflows/release-please.yml` - Must still run on release commits to detect `releases_created` and trigger the Release workflow
+- `.github/workflows/release-please.yml` - Must still run on release commits to create or detect the GitHub Release, then trigger the Release workflow only when artifacts still need publishing
 
 ## Best Practices
 

--- a/docs/zh/advanced/release-process.md
+++ b/docs/zh/advanced/release-process.md
@@ -300,7 +300,7 @@ if: >-
 - `.github/workflows/benchmark.yml` - `benchmark` 作业
 
 **不受影响**（有意为之）：
-- `.github/workflows/release-please.yml` - 必须在发布提交时继续运行，以检测 `releases_created` 并触发 Release 工作流
+- `.github/workflows/release-please.yml` - 必须在发布提交时继续运行，以创建或检测 GitHub Release，并且只在发布资源仍需上传时触发 Release 工作流
 
 ## 最佳实践
 


### PR DESCRIPTION
## Summary
- skip the release-please create path when the release commit target already has a GitHub Release
- only fallback-dispatch the Release workflow when assets are missing and no Release workflow is active
- make cargo-dist system dependency installation non-interactive for musl release jobs
- update release process docs to match the guarded rerun behavior

## Root Cause
The v0.9.4 release commit triggered Release Please again after the GitHub Release already existed, so release-please attempted to create the same tag/release and failed with `already_exists` on `tag_name`. The cargo-dist Release workflow also exposed a non-interactive install gap because its generated musl dependency command used `apt-get install musl-tools` without `-y`.

## Validation
- `vx actionlint .github/workflows/release-please.yml .github/workflows/release.yml`
- `vx git diff --check`
- `vx just docs-install`
- `vx just docs-build`