### PR TITLE
fix: keep metrics trace collection under RUST_LOG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4586,7 +4586,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "indexmap",
  "regex",
@@ -4616,7 +4616,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4626,7 +4626,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4705,7 +4705,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4727,7 +4727,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4766,7 +4766,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "colored",
@@ -4788,7 +4788,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4810,7 +4810,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4843,7 +4843,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4906,14 +4906,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-output-filter"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "regex",
@@ -4927,7 +4927,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4946,7 +4946,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4971,7 +4971,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5005,7 +5005,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5035,7 +5035,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "flate2",
@@ -5054,7 +5054,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5121,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "serde",
@@ -5139,11 +5139,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.9.7"
+version = "0.9.8"
 
 [[package]]
 name = "vx-starlark"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5173,7 +5173,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5214,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/vx-metrics/src/init.rs
+++ b/crates/vx-metrics/src/init.rs
@@ -229,14 +229,9 @@ pub fn fmt_filter_directive(config: &MetricsConfig) -> String {
 /// Build the OTel layer filter string.
 ///
 /// The OTel filter always captures all vx spans (trace level) for metrics
-/// collection, regardless of the user's verbosity preference.
-/// Only overridden if RUST_LOG is explicitly set.
+/// collection, regardless of the user's verbosity preference or `RUST_LOG`.
 pub fn otel_filter_directive() -> String {
-    if std::env::var("RUST_LOG").is_ok() {
-        std::env::var("RUST_LOG").unwrap_or_default()
-    } else {
-        "vx=trace,warn,error".to_string()
-    }
+    "vx=trace,warn,error".to_string()
 }
 
 /// Clean up old metrics files, keeping only the most recent `keep` files.

--- a/crates/vx-metrics/tests/init_tests.rs
+++ b/crates/vx-metrics/tests/init_tests.rs
@@ -124,6 +124,20 @@ fn test_otel_filter_always_captures_vx_trace() {
     assert!(filter.contains("error"));
 }
 
+#[test]
+fn test_otel_filter_ignores_rust_log_for_metrics_collection() {
+    unsafe {
+        std::env::set_var("RUST_LOG", "warn");
+    }
+    let filter = vx_metrics::otel_filter_directive();
+
+    unsafe {
+        std::env::remove_var("RUST_LOG");
+    }
+
+    assert_eq!(filter, "vx=trace,warn,error");
+}
+
 #[rstest]
 #[case(false, false, "warn,error")]
 #[case(true, false, "vx=debug,info")]


### PR DESCRIPTION
## Summary
- keep the OpenTelemetry metrics layer collecting vx trace spans even when RUST_LOG is set
- add a regression test for RUST_LOG=warn so metrics history continues updating
- include the lockfile version alignment required by the repo pre-push hook

## Validation
- vx cargo test -p vx-metrics
- vx cargo build -p vx
- target/debug/vx.exe git --version with VX_HOME temp dir and RUST_LOG=warn generated a metrics JSON
- vx just quick: clippy passed; nextest had one transient local failure in test_python_version_command, which passed on standalone rerun