### PR TITLE
fix(metrics): improve statistics display and align CLI help with contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,12 @@ vx npx create-react-app x  # Auto-installs Node.js + runs npx
 6. **Provider count is 142** — Update any docs that reference old counts (78, 73, 70+, 50+, 105, 122, 124, 126, 129, 131, 132, 135, 136, 137, 138, 139, 140, 141, etc.)
 7. **Version syntax** — Always use `vx install <runtime>@<version>` (never `vx install <runtime> <version>`)
 8. **MCP integration** — Replace `npx`/`uvx` with `vx` in MCP server configurations
+9. **MUST use `vx git`** — Never use bare `git` commands; always use `vx git` (e.g., `vx git commit`, `vx git push`)
+10. **MUST use `vx gh` (HIGH PRIORITY)** — Never use bare `gh` commands; always use `vx gh` for all GitHub CLI operations (e.g., `vx gh pr create`, `vx gh issue list`)
+11. **Efficient output** — Use output filtering to minimize token consumption in agent contexts:
+    - PowerShell: `vx git status 2>&1 | Select-Object -Last 3`
+    - Unix: `vx git status 2>&1 | tail -3`
+    - Cross-platform: prefer `vx --compact` or `--json` with `--fields` for structured data
 
 ### How vx Works (Execution Flow)
 
@@ -139,6 +145,8 @@ User Command: vx npm install
 8. **New providers use Starlark DSL only** — No Rust code required for new tool definitions
 9. **Layer dependencies go downward only** — Never import from a higher architectural layer
 10. **Provider count is 142** — Update any docs that reference old counts (78, 73, 70+, 50+, 105, 122, 124, 126, 129, 131, 132, 135, 136, 137, 138, 139, 140, 141, etc.)
+11. **MUST use `vx git` for all git operations** — Never use bare `git`; always `vx git status`, `vx git commit`, `vx git push`, etc.
+12. **MUST use `vx gh` for all GitHub operations** — Never use bare `gh`; always `vx gh pr create`, `vx gh run list`, etc.
 
 ### Setup Commands
 
@@ -185,6 +193,10 @@ vx dev                         # Enter dev environment
 | `npm install` | `vx npm install` |
 | `pip install flask` | `vx uv pip install flask` |
 | `go build` | `vx go build` |
+| `git commit -m "..."` | `vx git commit -m "..."` |
+| `git push` | `vx git push` |
+| `gh pr create` | `vx gh pr create` |
+| `gh issue list` | `vx gh issue list` |
 | Tell user to "install Node.js first" | Just run `vx node --version` (auto-installs) |
 | Suggest `nvm use 22` | Suggest `vx switch node@22` or set in `vx.toml` |
 | Write `#[cfg(test)] mod tests {}` | Create tests in `crates/<name>/tests/` directory |
@@ -582,3 +594,26 @@ For CI and other huge logs, use this order: `vx gh ... --json --jq` for status,
 matches, then `vx --compact ...` when broad context is still needed. Default
 `vx git` and `vx gh` remain transparent forwarded commands; compacting is an
 explicit opt-in.
+
+### Efficient Git/GitHub Patterns for Agents
+
+When running multi-step git/gh operations, minimize token output:
+
+```powershell
+# PowerShell (Windows) — keep only last N lines
+vx git checkout main 2>&1 | Select-Object -Last 3
+vx git pull --ff-only 2>&1 | Select-Object -Last 2
+vx git checkout -b feat/my-feature 2>&1 | Select-Object -Last 2
+
+# Unix (bash/zsh) — keep only last N lines
+vx git checkout main 2>&1 | tail -3
+vx git pull --ff-only 2>&1 | tail -2
+vx git checkout -b feat/my-feature 2>&1 | tail -2
+
+# Cross-platform (using vx-managed tools)
+vx git log --oneline -5    # concise history
+vx gh pr list --json number,title,state --jq '.[:5]'  # structured, minimal
+vx gh run list --json status,conclusion,name --jq '.[:3]'  # CI status
+```
+
+**Key principle**: Always pipe verbose git/gh output through tail/Select-Object or use `--json --jq` to reduce token consumption. Agents should never dump full git log or gh output into context.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,3 +40,24 @@ vx-providers/*  → Tool definitions (provider.star)
 - **Token optimization**: Use `vx list --format toon` for token-optimized output (saves 40-60% tokens).
 - **Worktree workflow**: Use `vx wt` commands for parallel agent worktrees.
 - **Diagnostics**: Run `vx doctor` first when encountering errors.
+
+## Mandatory: Always Use `vx` Prefix for Git and GitHub
+
+**CRITICAL**: All git and GitHub CLI operations MUST use the `vx` prefix:
+
+| ❌ Never | ✅ Always |
+|----------|-----------|
+| `git status` | `vx git status` |
+| `git commit -m "..."` | `vx git commit -m "..."` |
+| `git push` | `vx git push` |
+| `gh pr create` | `vx gh pr create` |
+| `gh run list` | `vx gh run list` |
+| `gh issue create` | `vx gh issue create` |
+
+**Efficient output patterns** (minimize tokens in agent context):
+```powershell
+# PowerShell
+vx git checkout main 2>&1 | Select-Object -Last 3
+vx git pull --ff-only 2>&1 | Select-Object -Last 2
+vx gh pr list --json number,title,state --jq '.[:5]'
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4586,7 +4586,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "indexmap",
  "regex",
@@ -4616,7 +4616,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4626,7 +4626,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4705,7 +4705,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4727,7 +4727,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4766,7 +4766,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "colored",
@@ -4788,7 +4788,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4810,7 +4810,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4843,7 +4843,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4906,14 +4906,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-output-filter"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "regex",
@@ -4927,7 +4927,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4946,7 +4946,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4971,7 +4971,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5005,7 +5005,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5035,7 +5035,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "flate2",
@@ -5054,7 +5054,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5121,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "serde",
@@ -5139,11 +5139,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.9.8"
+version = "0.9.9"
 
 [[package]]
 name = "vx-starlark"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5173,7 +5173,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5214,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/vx-cli/src/cli.rs
+++ b/crates/vx-cli/src/cli.rs
@@ -137,21 +137,29 @@ USAGE MODES:
        vx --with bun@1.1.0 --with deno node app.js
 
   6. Shell launch (canonical):
-       vx shell <runtime>[@version] [shell_name]
-       vx shell node@22 powershell
-       vx shell git git-bash
+       vx shell launch <runtime>[@version] [shell_name]
+       vx shell launch node@22 powershell
+       vx shell launch git git-bash
      Compatibility alias: vx <runtime>::<shell_name>
 
-  7. Globally installed package shims:
-       vx tsc --version        (from: vx pkg install npm:typescript)
-       vx ruff check .         (from: vx pkg install uvx:ruff)
+  7. Environment assembly:
+       vx env <create|use|list|show|add|remove|sync|shell|delete> ...
+       vx dev
 
-  8. Global package management:
-       vx pkg <install|uninstall|list|info|update> ...
+  8. Project script execution:
+       vx run <script> [-- <args...>]
+       vx run test -- --nocapture
+
+  9. Project state sync:
+       vx sync [--check]
+       vx lock [--check]
+
+ 10. Global package management:
+       vx pkg <install|uninstall|list|info|shim-update> ...
        vx pkg install npm:typescript
      Compatibility alias: vx global ...
 
-  9. Project toolchain management:
+ 11. Project toolchain management:
        vx project <init|add|rm|sync|lock|check> ...
      Compatibility aliases: vx init, vx add, vx sync, etc.
 
@@ -166,6 +174,13 @@ SUPPORTED ECOSYSTEMS:
   Ruby:     gem (aliases: ruby, rubygems)
   Windows:  choco (chocolatey)
 
+GLOBAL OPTIONS:
+  --json              JSON structured output (shortcut for --output-format json)
+  --toon              Token-oriented output for LLM prompts (shortcut for --output-format toon)
+  --compact / -u      Ultra-compact output (shortcut for --output-format compact)
+  --output-format     Explicit output mode: text|json|toon|compact
+  --cache-mode        Cache strategy: normal|refresh|offline|no-cache
+
 EXAMPLES:
   vx node --version
   vx npx@20 create-react-app my-app
@@ -173,12 +188,14 @@ EXAMPLES:
   vx npm:create-react-app my-app
   vx uvx:ruff check .
   vx cargo:ripgrep::rg --version
-  vx shell git git-bash
+  vx shell launch git git-bash
   vx --with bun npm:opencode-ai::opencode
-  vx pkg install npm:typescript")]
+  vx pkg install npm:typescript
+  vx run test
+  vx sync --check")]
 #[command(version)]
 #[command(
-    after_help = "Run 'vx <command> --help' for more information on a command.\nRun 'vx pkg --help' for global package management.\nRun 'vx shell launch --help' for runtime shell launching.\nRun 'vx versions <tool>' to see available versions."
+    after_help = "Run 'vx <command> --help' for more information on a command.\nRun 'vx pkg --help' for global package management.\nRun 'vx shell launch --help' for runtime shell launching.\nRun 'vx run --list' to see available project scripts.\nRun 'vx versions <tool>' to see available versions."
 )]
 pub struct Cli {
     #[command(subcommand)]

--- a/crates/vx-metrics/src/visualize.rs
+++ b/crates/vx-metrics/src/visualize.rs
@@ -134,14 +134,14 @@ pub fn render_comparison(runs: &[CommandMetrics]) -> String {
 
     out.push_str("  Performance History (newest first):\n");
     out.push_str(
-        "  ═══════════════════════════════════════════════════════════════════════════════\n",
+        "  ════════════════════════════════════════════════════════════════════════════════════════════\n",
     );
     out.push_str(&format!(
-        "  {:<22} {:<30} {:>8} {:>8} {:>8} {:>8} {:>8}\n",
-        "Timestamp", "Command", "Total", "Resolve", "Ensure", "Prepare", "Execute"
+        "  {:<22} {:<30} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8}\n",
+        "Timestamp", "Command", "Total", "Resolve", "Ensure", "Prepare", "Execute", "Overhead"
     ));
     out.push_str(
-        "  ───────────────────────────────────────────────────────────────────────────────\n",
+        "  ────────────────────────────────────────────────────────────────────────────────────────────\n",
     );
 
     for (i, m) in runs.iter().enumerate() {
@@ -156,6 +156,15 @@ pub fn render_comparison(runs: &[CommandMetrics]) -> String {
         let ensure = stage_ms(&m.stages, "ensure");
         let prepare = stage_ms(&m.stages, "prepare");
         let execute = stage_ms(&m.stages, "execute");
+
+        // Compute overhead (total - sum of stages)
+        let stage_sum: f64 = m.stages.values().map(|s| s.duration_ms).sum();
+        let overhead_ms = m.total_duration_ms - stage_sum;
+        let overhead_str = if overhead_ms > 0.5 {
+            format!("{:.0}", overhead_ms)
+        } else {
+            "-".to_string()
+        };
 
         // Show trend arrows comparing to previous run
         let trend = if i + 1 < runs.len() {
@@ -172,16 +181,14 @@ pub fn render_comparison(runs: &[CommandMetrics]) -> String {
         };
 
         out.push_str(&format!(
-            "  {:<22} {:<30} {:>6.0}ms{} {:>6}ms {:>6}ms {:>6}ms {:>6}ms\n",
-            ts, cmd, m.total_duration_ms, trend, resolve, ensure, prepare, execute
+            "  {:<22} {:<30} {:>6.0}ms{} {:>6}ms {:>6}ms {:>6}ms {:>6}ms {:>6}ms\n",
+            ts, cmd, m.total_duration_ms, trend, resolve, ensure, prepare, execute, overhead_str
         ));
     }
 
     out.push_str(
-        "  ═══════════════════════════════════════════════════════════════════════════════\n",
+        "  ════════════════════════════════════════════════════════════════════════════════════════════\n",
     );
-
-    // Summary statistics
     if runs.len() > 1 {
         let totals: Vec<f64> = runs.iter().map(|r| r.total_duration_ms).collect();
         let avg = totals.iter().sum::<f64>() / totals.len() as f64;
@@ -231,6 +238,28 @@ pub fn render_comparison(runs: &[CommandMetrics]) -> String {
                     stage, stage_avg, stage_pct
                 ));
             }
+        }
+
+        // Overhead average (total - sum of stages)
+        let overhead_vals: Vec<f64> = runs
+            .iter()
+            .map(|r| {
+                let stage_sum: f64 = r.stages.values().map(|s| s.duration_ms).sum();
+                r.total_duration_ms - stage_sum
+            })
+            .collect();
+        let overhead_avg = overhead_vals.iter().sum::<f64>() / overhead_vals.len() as f64;
+        let total_avg = runs.iter().map(|r| r.total_duration_ms).sum::<f64>() / runs.len() as f64;
+        let overhead_pct = if total_avg > 0.0 {
+            overhead_avg / total_avg * 100.0
+        } else {
+            0.0
+        };
+        if overhead_avg > 0.5 {
+            out.push_str(&format!(
+                "    {:<10} avg={:>8.1}ms  ({:>5.1}% of total)\n",
+                "overhead", overhead_avg, overhead_pct
+            ));
         }
     }
 
@@ -300,14 +329,25 @@ pub fn render_insights(runs: &[CommandMetrics]) -> String {
         ));
     }
 
-    // Overhead analysis
-    let stage_total: f64 = latest.stages.values().map(|s| s.duration_ms).sum();
-    let overhead = latest.total_duration_ms - stage_total;
-    if overhead > 50.0 {
-        let pct = overhead / latest.total_duration_ms * 100.0;
+    // Overhead analysis (average across all runs)
+    let overhead_vals: Vec<f64> = runs
+        .iter()
+        .map(|r| {
+            let stage_sum: f64 = r.stages.values().map(|s| s.duration_ms).sum();
+            r.total_duration_ms - stage_sum
+        })
+        .collect();
+    let avg_overhead = overhead_vals.iter().sum::<f64>() / overhead_vals.len() as f64;
+    let avg_total = runs.iter().map(|r| r.total_duration_ms).sum::<f64>() / runs.len() as f64;
+    if avg_overhead > 50.0 {
+        let pct = if avg_total > 0.0 {
+            avg_overhead / avg_total * 100.0
+        } else {
+            0.0
+        };
         out.push_str(&format!(
-            "  📊 Overhead (CLI init, provider loading): {:.0}ms ({:.1}%)\n",
-            overhead, pct
+            "  📊 Avg overhead (CLI init, provider loading): {:.0}ms ({:.1}% of avg total {:.0}ms)\n",
+            avg_overhead, pct, avg_total
         ));
     }
 


### PR DESCRIPTION
## Summary

- Add overhead column to metrics comparison table so Total = stages + overhead (no unexplained gaps)
- Add overhead row to Stage Averages section — percentages now sum to ~100%
- Fix Performance Insights to use average overhead across all runs instead of only latest run
- Update CLI help text to include all 11 usage modes from the command-syntax-rules contract
- Fix `vx pkg` subcommand listing (`update` → `shim-update`)
- Enforce `vx git` / `vx gh` prefix usage rules in AGENTS.md and CLAUDE.md
- Add efficient git/gh output patterns for AI agents

## Test plan

- [x] `vx cargo build` passes
- [x] `vx cargo test -p vx-metrics` — all 18 tests pass
- [x] `vx cargo clippy -p vx-metrics -p vx -- -D warnings` — clean
- [x] `vx cargo fmt -- --check` — clean
- [ ] CI workflow passes on all platforms