### PR TITLE
docs: update version references to v0.9.13 (2026-06-03)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@
 
 ## What is vx?
 
-vx is a **zero-config universal development tool manager** (v0.9.11, MIT-licensed, written in Rust). Users prefix any command with `vx` (e.g., `vx node --version`, `vx cargo build`) and vx automatically installs, manages, and forwards to the correct tool version. vx currently ships **142 providers** covering language runtimes, build tools, DevOps CLIs, cloud platforms, and more — all defined via Starlark DSL (`provider.star`).
+vx is a **zero-config universal development tool manager** (v0.9.13, MIT-licensed, written in Rust). Users prefix any command with `vx` (e.g., `vx node --version`, `vx cargo build`) and vx automatically installs, manages, and forwards to the correct tool version. vx currently ships **142 providers** covering language runtimes, build tools, DevOps CLIs, cloud platforms, and more — all defined via Starlark DSL (`provider.star`).
 
 **Key insight for agents**: vx is a transparent proxy. The user writes the exact same commands they already know — just prepended with `vx`. There is **no new syntax to learn** for tool execution.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 - Use Conventional Commits: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`
 - Run `vx just quick` before submitting PR.
 - PRs target `main` branch.
-- Project version: **v0.9.11** with **142 providers**.
+- Project version: **v0.9.13** with **142 providers**.
 
 ## Quick Reference
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4570,7 +4570,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "indexmap",
  "regex",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4625,7 +4625,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4689,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4732,7 +4732,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "colored",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4828,7 +4828,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4846,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4869,7 +4869,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4891,14 +4891,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-output-filter"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "regex",
@@ -4912,7 +4912,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4931,7 +4931,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "flate2",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5089,7 +5089,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5106,7 +5106,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "serde",
@@ -5124,11 +5124,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.9.12"
+version = "0.9.13"
 
 [[package]]
 name = "vx-starlark"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5158,7 +5158,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -10,7 +10,7 @@
 - Use Conventional Commits: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`
 - Run `vx just quick` before submitting PR.
 - PRs target `main` branch.
-- Project version: **v0.9.11** with **142 providers**.
+- Project version: **v0.9.13** with **142 providers**.
 
 ## Quick Reference
 

--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ Use vx in your CI/CD workflows:
 - run: vx npm test
 ```
 
-> **Note**: Use `@main` for latest, or pin to a specific release tag (e.g., `@vx-v0.9.11`). Check [releases](https://github.com/loonghao/vx/releases) for the latest version.
+> **Note**: Use `@main` for latest, or pin to a specific release tag (e.g., `@vx-v0.9.13`). Check [releases](https://github.com/loonghao/vx/releases) for the latest version.
 
 See [GitHub Action Guide](docs/guides/github-action.md) for full documentation.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -602,7 +602,7 @@ cargo install --git https://github.com/loonghao/vx
 - run: vx npm test
 ```
 
-> **注意**: 请使用 `@main` 获取最新版本，或使用具体的版本标签（如 `@vx-v0.9.11`）。查看 [releases](https://github.com/loonghao/vx/releases) 获取最新版本。
+> **注意**: 请使用 `@main` 获取最新版本，或使用具体的版本标签（如 `@vx-v0.9.13`）。查看 [releases](https://github.com/loonghao/vx/releases) 获取最新版本。
 
 详细文档请参阅 [GitHub Action 指南](docs/guides/github-action.md)。
 

--- a/docs/cli/self-update.md
+++ b/docs/cli/self-update.md
@@ -47,7 +47,7 @@ vx self-update
 vx self-update --check
 
 # Update to a specific version
-vx self-update v0.9.11
+vx self-update v0.9.13
 
 # Use beta channel
 vx self-update --channel beta


### PR DESCRIPTION
## Summary

Update version references across documentation after v0.9.13 release.

## Changes

- **AGENTS.md**: v0.9.11 → v0.9.13
- **CLAUDE.md**: v0.9.11 → v0.9.13
- **GEMINI.md**: v0.9.11 → v0.9.13
- **README.md**: @vx-v0.9.11 → @vx-v0.9.13
- **README_zh.md**: @vx-v0.9.11 → @vx-v0.9.13
- **docs/cli/self-update.md**: v0.9.11 → v0.9.13

Provider count unchanged: 142

## Notes

- The \docs/cli/commands.md\, \docs/config/vx-toml.md\, \docs/tools/python.md\ and \docs/zh/tools/python.md\ were already updated on main with the \eat: support legacy python and ai skills checks\ commit — no further changes needed.