### PR TITLE
feat: add codegraph provider for colbymchenry/codegraph releases

### DIFF
--- a/crates/vx-providers/codegraph/provider.star
+++ b/crates/vx-providers/codegraph/provider.star
@@ -1,0 +1,151 @@
+# provider.star - codegraph provider
+#
+# CodeGraph: Pre-indexed code knowledge graph for AI coding agents.
+# Integrates with Claude Code, Cursor, Codex, Gemini CLI, etc.
+# Releases: https://github.com/colbymchenry/codegraph/releases
+#
+# Asset format: codegraph-{os}-{arch}.{ext}
+#   os:   win32, darwin, linux
+#   arch: x64, arm64
+#   ext:  zip (windows), tar.gz (darwin/linux)
+# Tag format:  v{version}
+#
+# Bundled Node.js archive: top-level codegraph-{os}-{arch}/ directory
+# contains node (runtime) and bin/codegraph (entry script).
+
+load("@vx//stdlib:provider.star",
+     "runtime_def", "github_permissions",
+     "post_extract_permissions",
+     "path_fns",
+     "fetch_versions_with_tag_prefix")
+load("@vx//stdlib:env.star", "env_prepend")
+
+# ---------------------------------------------------------------------------
+# Provider metadata
+# ---------------------------------------------------------------------------
+name        = "codegraph"
+description = "CodeGraph - Pre-indexed code knowledge graph for AI coding agents"
+homepage    = "https://github.com/colbymchenry/codegraph"
+repository  = "https://github.com/colbymchenry/codegraph"
+license     = "MIT"
+ecosystem   = "ai"
+
+# ---------------------------------------------------------------------------
+# Runtime definitions
+# ---------------------------------------------------------------------------
+
+runtimes = [
+    runtime_def("codegraph",
+        version_pattern = "\\d+\\.\\d+\\.\\d+",
+        test_commands = [
+            {"command": "{executable} --version", "name": "version_check",
+             "expected_output": "\\d+\\.\\d+\\.\\d+"},
+        ],
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Permissions
+# ---------------------------------------------------------------------------
+
+permissions = github_permissions()
+
+# ---------------------------------------------------------------------------
+# Platform mapping
+#
+# codegraph uses simple platform names (not Rust triples):
+#   windows → win32
+#   macos   → darwin
+#   linux   → linux
+# ---------------------------------------------------------------------------
+
+_PLATFORMS = {
+    "windows/x64":   ("win32", "x64"),
+    "windows/arm64": ("win32", "arm64"),
+    "macos/x64":     ("darwin", "x64"),
+    "macos/arm64":   ("darwin", "arm64"),
+    "linux/x64":     ("linux", "x64"),
+    "linux/arm64":   ("linux", "arm64"),
+}
+
+def _codegraph_platform(ctx):
+    key = "{}/{}".format(ctx.platform.os, ctx.platform.arch)
+    return _PLATFORMS.get(key)
+
+# ---------------------------------------------------------------------------
+# fetch_versions — from colbymchenry/codegraph releases
+# ---------------------------------------------------------------------------
+
+fetch_versions = fetch_versions_with_tag_prefix(
+    "colbymchenry", "codegraph",
+    tag_prefix = "v",
+)
+
+# ---------------------------------------------------------------------------
+# download_url
+# ---------------------------------------------------------------------------
+
+def download_url(ctx, version):
+    platform = _codegraph_platform(ctx)
+    if not platform:
+        return None
+    os_str, arch_str = platform
+    ext = "zip" if ctx.platform.os == "windows" else "tar.gz"
+    return "https://github.com/colbymchenry/codegraph/releases/download/v{}/codegraph-{}-{}.{}".format(
+        version, os_str, arch_str, ext)
+
+# ---------------------------------------------------------------------------
+# install_layout
+#
+# Archive layout: codegraph-{os}-{arch}/
+#   bin/codegraph      (Linux/macOS — shell script invoking bundled node)
+#   bin/codegraph.cmd  (Windows — cmd wrapper)
+#   node / node.exe    (bundled Node.js runtime)
+#   lib/               (application code)
+# ---------------------------------------------------------------------------
+
+def install_layout(ctx, _version):
+    platform = _codegraph_platform(ctx)
+    if not platform:
+        return {
+            "type":         "archive",
+            "strip_prefix": "",
+            "executable_paths": ["bin/codegraph"],
+        }
+    os_str, arch_str = platform
+    strip = "codegraph-{}-{}".format(os_str, arch_str)
+    if ctx.platform.os == "windows":
+        exe_paths = ["bin/codegraph.cmd"]
+    else:
+        exe_paths = ["bin/codegraph"]
+    return {
+        "type":             "archive",
+        "strip_prefix":     strip,
+        "executable_paths": exe_paths,
+    }
+
+# ---------------------------------------------------------------------------
+# post_extract — ensure +x on Unix entry scripts
+# ---------------------------------------------------------------------------
+
+post_extract = post_extract_permissions([
+    "bin/codegraph",
+    "node",
+])
+
+# ---------------------------------------------------------------------------
+# Path queries + environment
+# ---------------------------------------------------------------------------
+
+paths = path_fns("codegraph")
+store_root       = paths["store_root"]
+get_execute_path = paths["get_execute_path"]
+
+def environment(ctx, _version):
+    return [env_prepend("PATH", ctx.install_dir + "/bin")]
+
+def post_install(_ctx, _version):
+    return None
+
+def deps(_ctx, _version):
+    return []

--- a/crates/vx-starlark/tests/codegraph_tests.rs
+++ b/crates/vx-starlark/tests/codegraph_tests.rs
@@ -1,0 +1,236 @@
+//! Tests for the `codegraph` provider.
+//!
+//! Verifies that the Starlark DSL loads correctly and that
+//! `download_url` / `install_layout` produce expected results
+//! for the codegraph-{os}-{arch} GitHub release format.
+
+use vx_starlark::StarlarkEngine;
+use vx_starlark::StarlarkProvider;
+
+// Helper: load provider.star content for a given provider name
+fn load_provider_content(provider_name: &str) -> (std::path::PathBuf, String) {
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let provider_dir = manifest_dir
+        .parent() // crates/
+        .unwrap()
+        .join("vx-providers")
+        .join(provider_name);
+    let star_path = provider_dir.join("provider.star");
+    let content = std::fs::read_to_string(&star_path).unwrap();
+    (star_path, content)
+}
+
+fn make_ctx() -> vx_starlark::ProviderContext {
+    vx_starlark::ProviderContext::new("codegraph", std::env::temp_dir().join("vx-test"))
+}
+
+// ── provider loading ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_load_codegraph_provider() {
+    let (star_path, _) = load_provider_content("codegraph");
+    let provider = StarlarkProvider::load(&star_path).await.unwrap();
+    assert_eq!(provider.name(), "codegraph");
+}
+
+// ── download_url checks ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_codegraph_download_url_windows_x64() {
+    let (star_path, content) = load_provider_content("codegraph");
+    let engine = StarlarkEngine::new();
+    let mut ctx = make_ctx();
+    ctx.platform.os = "windows".to_string();
+    ctx.platform.arch = "x64".to_string();
+
+    let result = engine
+        .call_function(
+            &star_path,
+            &content,
+            "download_url",
+            &ctx,
+            &[serde_json::json!("0.9.9")],
+        )
+        .unwrap();
+
+    assert_eq!(
+        result.as_str().unwrap(),
+        "https://github.com/colbymchenry/codegraph/releases/download/v0.9.9/codegraph-win32-x64.zip"
+    );
+}
+
+#[tokio::test]
+async fn test_codegraph_download_url_linux_x64() {
+    let (star_path, content) = load_provider_content("codegraph");
+    let engine = StarlarkEngine::new();
+    let mut ctx = make_ctx();
+    ctx.platform.os = "linux".to_string();
+    ctx.platform.arch = "x64".to_string();
+
+    let result = engine
+        .call_function(
+            &star_path,
+            &content,
+            "download_url",
+            &ctx,
+            &[serde_json::json!("0.9.9")],
+        )
+        .unwrap();
+
+    assert_eq!(
+        result.as_str().unwrap(),
+        "https://github.com/colbymchenry/codegraph/releases/download/v0.9.9/codegraph-linux-x64.tar.gz"
+    );
+}
+
+#[tokio::test]
+async fn test_codegraph_download_url_macos_arm64() {
+    let (star_path, content) = load_provider_content("codegraph");
+    let engine = StarlarkEngine::new();
+    let mut ctx = make_ctx();
+    ctx.platform.os = "macos".to_string();
+    ctx.platform.arch = "arm64".to_string();
+
+    let result = engine
+        .call_function(
+            &star_path,
+            &content,
+            "download_url",
+            &ctx,
+            &[serde_json::json!("0.9.9")],
+        )
+        .unwrap();
+
+    assert_eq!(
+        result.as_str().unwrap(),
+        "https://github.com/colbymchenry/codegraph/releases/download/v0.9.9/codegraph-darwin-arm64.tar.gz"
+    );
+}
+
+#[tokio::test]
+async fn test_codegraph_download_url_unsupported_platform() {
+    let (star_path, content) = load_provider_content("codegraph");
+    let engine = StarlarkEngine::new();
+    let mut ctx = make_ctx();
+    ctx.platform.os = "freebsd".to_string();
+    ctx.platform.arch = "x64".to_string();
+
+    let result = engine
+        .call_function(
+            &star_path,
+            &content,
+            "download_url",
+            &ctx,
+            &[serde_json::json!("0.9.9")],
+        )
+        .unwrap();
+
+    assert!(result.is_null(), "Unsupported platform should return None");
+}
+
+// ── install_layout checks ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_codegraph_install_layout_windows_x64() {
+    let (star_path, content) = load_provider_content("codegraph");
+    let engine = StarlarkEngine::new();
+    let mut ctx = make_ctx();
+    ctx.platform.os = "windows".to_string();
+    ctx.platform.arch = "x64".to_string();
+
+    let result = engine
+        .call_function(
+            &star_path,
+            &content,
+            "install_layout",
+            &ctx,
+            &[serde_json::json!("0.9.9")],
+        )
+        .unwrap();
+
+    let obj = result.as_object().unwrap();
+    assert_eq!(obj["type"].as_str().unwrap(), "archive");
+    assert_eq!(obj["strip_prefix"].as_str().unwrap(), "codegraph-win32-x64");
+    let paths: Vec<&str> = obj["executable_paths"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p.as_str().unwrap())
+        .collect();
+    assert!(
+        paths.contains(&"bin/codegraph.cmd"),
+        "Windows layout should include bin/codegraph.cmd, got: {:?}",
+        paths
+    );
+}
+
+#[tokio::test]
+async fn test_codegraph_install_layout_linux_x64() {
+    let (star_path, content) = load_provider_content("codegraph");
+    let engine = StarlarkEngine::new();
+    let mut ctx = make_ctx();
+    ctx.platform.os = "linux".to_string();
+    ctx.platform.arch = "x64".to_string();
+
+    let result = engine
+        .call_function(
+            &star_path,
+            &content,
+            "install_layout",
+            &ctx,
+            &[serde_json::json!("0.9.9")],
+        )
+        .unwrap();
+
+    let obj = result.as_object().unwrap();
+    assert_eq!(obj["type"].as_str().unwrap(), "archive");
+    assert_eq!(obj["strip_prefix"].as_str().unwrap(), "codegraph-linux-x64");
+    let paths: Vec<&str> = obj["executable_paths"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p.as_str().unwrap())
+        .collect();
+    assert!(
+        paths.contains(&"bin/codegraph"),
+        "Linux layout should include bin/codegraph, got: {:?}",
+        paths
+    );
+}
+
+#[tokio::test]
+async fn test_codegraph_install_layout_macos_arm64() {
+    let (star_path, content) = load_provider_content("codegraph");
+    let engine = StarlarkEngine::new();
+    let mut ctx = make_ctx();
+    ctx.platform.os = "macos".to_string();
+    ctx.platform.arch = "arm64".to_string();
+
+    let result = engine
+        .call_function(
+            &star_path,
+            &content,
+            "install_layout",
+            &ctx,
+            &[serde_json::json!("0.9.9")],
+        )
+        .unwrap();
+
+    let obj = result.as_object().unwrap();
+    assert_eq!(obj["type"].as_str().unwrap(), "archive");
+    assert_eq!(
+        obj["strip_prefix"].as_str().unwrap(),
+        "codegraph-darwin-arm64"
+    );
+    let paths: Vec<&str> = obj["executable_paths"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p.as_str().unwrap())
+        .collect();
+    assert!(
+        paths.contains(&"bin/codegraph"),
+        "macOS layout should include bin/codegraph, got: {:?}",
+        paths
+    );
+}


### PR DESCRIPTION
## Summary

Add a new provider for [CodeGraph](https://github.com/colbymchenry/codegraph) - a pre-indexed code knowledge graph for AI coding agents.

## Changes

- **New provider**: `crates/vx-providers/codegraph/provider.star`
  - Supports all major platforms: win32/darwin/linux × x64/arm64
  - Version discovery via GitHub releases with `v` tag prefix
  - Archive extraction with platform-correct strip prefixes
  - Platform-appropriate executable paths (`.cmd` on Windows, shell script on Unix)
  - PATH environment setup via `bin/` subdirectory
  - Bundled Node.js runtime (no external Node.js dependency needed)

- **Tests**: `crates/vx-starlark/tests/codegraph_tests.rs`
  - Provider loading test
  - Download URL generation for windows/linux/macos
  - Unsupported platform handling
  - Install layout verification for all major platforms

## Usage

```bash
# Install codegraph
vx codegraph install

# Or use directly
vx codegraph --version
```

Closes PIP-530