### PR TITLE
feat(starlark): implement github_smart_provider MVP per RFC 0041

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5801,7 +5801,6 @@ dependencies = [
  "futures-executor",
  "futures-sink",
  "futures-util",
- "getrandom 0.3.4",
  "getrandom 0.4.2",
  "hashbrown 0.14.5",
  "hyper",

--- a/crates/vx-starlark/src/engine.rs
+++ b/crates/vx-starlark/src/engine.rs
@@ -208,6 +208,55 @@ impl StarlarkEngine {
         Ok(result)
     }
 
+    /// Call a function from a stdlib module by name.
+    ///
+    /// Loads the stdlib module source via [`VxModuleLoader`], evaluates it,
+    /// looks up the named function, and calls it with the given positional
+    /// JSON arguments.
+    ///
+    /// # Args
+    ///
+    /// * `module_path` — e.g. `"@vx//stdlib:smart_detect.star"`
+    /// * `func_name` — e.g. `"detect_best_asset"`
+    /// * `args` — positional JSON arguments passed to the function
+    ///
+    /// # Returns
+    ///
+    /// The function's return value as a JSON value.
+    pub fn call_stdlib_function(
+        &self,
+        module_path: &str,
+        func_name: &str,
+        args: &[JsonValue],
+    ) -> Result<JsonValue> {
+        let loader = crate::loader::VxModuleLoader::new();
+        let module = loader
+            .evaluable_module(module_path, &self.dialect)
+            .map_err(|e| Error::EvalError(e.to_string()))?;
+
+        let func_value = module
+            .get(func_name)
+            .ok_or_else(|| Error::function_not_found(func_name))?;
+
+        let heap = module.heap();
+        let pos_args: Vec<Value> = args
+            .iter()
+            .map(|a| self.json_to_starlark_value(heap, a))
+            .collect();
+
+        let mut eval = Evaluator::new(&module);
+        let result = eval
+            .eval_function(func_value, &pos_args, &[])
+            .map_err(|e| {
+                Error::EvalError(format!(
+                    "Error calling '{}' in '{}': {}",
+                    func_name, module_path, e
+                ))
+            })?;
+
+        Ok(self.starlark_value_to_json(result))
+    }
+
     /// Get a named variable from a Starlark script (e.g. `runtimes`, `permissions`)
     ///
     /// Evaluates the script and returns the value of the named variable as JSON.

--- a/crates/vx-starlark/src/loader.rs
+++ b/crates/vx-starlark/src/loader.rs
@@ -26,6 +26,7 @@ const PROVIDER_TEMPLATES_STAR: &str = include_str!("../stdlib/provider_templates
 const RUNTIME_STAR: &str = include_str!("../stdlib/runtime.star");
 const SCRIPT_INSTALL_STAR: &str = include_str!("../stdlib/script_install.star");
 const SYSTEM_INSTALL_STAR: &str = include_str!("../stdlib/system_install.star");
+const SMART_DETECT_STAR: &str = include_str!("../stdlib/smart_detect.star");
 const TEST_STAR: &str = include_str!("../stdlib/test.star");
 
 /// Module loader for `@vx//stdlib:*` virtual modules.
@@ -64,6 +65,10 @@ impl VxModuleLoader {
             SYSTEM_INSTALL_STAR,
         );
         stdlib_modules.insert("@vx//stdlib:test.star".to_string(), TEST_STAR);
+        stdlib_modules.insert(
+            "@vx//stdlib:smart_detect.star".to_string(),
+            SMART_DETECT_STAR,
+        );
 
         Self { stdlib_modules }
     }
@@ -113,6 +118,45 @@ impl VxModuleLoader {
         module
             .freeze()
             .map_err(|e| anyhow::anyhow!("Failed to freeze vx module '{}': {:?}", path, e))
+    }
+
+    /// Load and evaluate a vx virtual module, returning a non-frozen Module.
+    ///
+    /// Unlike [`load_module`], this returns a thawed `Module` that allows
+    /// individual function lookups and calls. Used by the Rust runtime to
+    /// invoke scoring functions in `smart_detect.star`.
+    pub fn evaluable_module(
+        &self,
+        path: &str,
+        dialect: &Dialect,
+    ) -> anyhow::Result<starlark::environment::Module> {
+        let source = self.get_source(path).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Unknown vx module: '{}'. Available modules: {}",
+                path,
+                self.available_modules().join(", ")
+            )
+        })?;
+
+        let ast = AstModule::parse(path, source.to_string(), dialect)
+            .map_err(|e| anyhow::anyhow!("Failed to parse vx module '{}': {}", path, e))?;
+
+        let globals = starlark::environment::GlobalsBuilder::standard().build();
+        let module = starlark::environment::Module::new();
+        {
+            let recursive_loader = VxModuleLoader::new();
+            let dialect_clone = dialect.clone();
+            let file_loader = RecursiveVxLoader {
+                loader: recursive_loader,
+                dialect: dialect_clone,
+            };
+            let mut eval = starlark::eval::Evaluator::new(&module);
+            eval.set_loader(&file_loader);
+            eval.eval_module(ast, &globals)
+                .map_err(|e| anyhow::anyhow!("Failed to evaluate vx module '{}': {}", path, e))?;
+        }
+
+        Ok(module)
     }
 
     /// List all available stdlib vx modules.

--- a/crates/vx-starlark/src/provider/execute.rs
+++ b/crates/vx-starlark/src/provider/execute.rs
@@ -201,6 +201,10 @@ impl StarlarkProvider {
             Ok(json) => {
                 if json.is_null() {
                     Ok(None)
+                } else if let Some(type_str) = json.get("__type").and_then(|t| t.as_str())
+                    && type_str == "github_smart_detect"
+                {
+                    Box::pin(self.resolve_smart_detect_descriptor(ctx, &json)).await
                 } else if let Some(url) = json.as_str() {
                     Ok(Some(url.to_string()))
                 } else {
@@ -737,4 +741,251 @@ impl StarlarkProvider {
             Err(e) => Err(e),
         }
     }
+
+    // ──────────────────────────────────────────────────────────────────
+    // RFC 0041: github_smart_provider asset scoring & fallback resolution
+    // ──────────────────────────────────────────────────────────────────
+
+    /// Resolve a `github_smart_detect` descriptor: fetch release assets from
+    /// GitHub API, score them via Starlark `detect_best_asset`, return the
+    /// best asset URL or fallback.
+    async fn resolve_smart_detect_descriptor(
+        &self,
+        core_ctx: &ProviderContext,
+        descriptor: &serde_json::Value,
+    ) -> Result<Option<String>> {
+        use tracing::{debug, warn};
+        use vx_version_fetcher::GitHubReleasesFetcher;
+
+        let owner = descriptor
+            .get("owner")
+            .and_then(|o| o.as_str())
+            .unwrap_or("");
+        let repo = descriptor
+            .get("repo")
+            .and_then(|r| r.as_str())
+            .unwrap_or("");
+        let tag = descriptor.get("tag").and_then(|t| t.as_str()).unwrap_or("");
+        let version = descriptor
+            .get("version")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let linux_libc = descriptor
+            .get("linux_libc")
+            .and_then(|l| l.as_str())
+            .unwrap_or("musl");
+        let threshold = descriptor
+            .get("score_threshold")
+            .and_then(|t| t.as_u64())
+            .unwrap_or(40);
+        let extra_excludes: Vec<String> = descriptor
+            .get("extra_excludes")
+            .and_then(|e| e.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Step 1: Fetch assets from GitHub API
+        let runtime_ctx = super::versions::build_minimal_runtime_ctx();
+
+        let assets =
+            match GitHubReleasesFetcher::fetch_release_assets(owner, repo, tag, &runtime_ctx).await
+            {
+                Ok(assets) => {
+                    debug!(
+                        provider = %self.meta.name,
+                        tag = %tag,
+                        count = %assets.len(),
+                        "Fetched release assets for smart detect"
+                    );
+                    assets
+                }
+                Err(e) => {
+                    warn!(
+                        provider = %self.meta.name,
+                        tag = %tag,
+                        error = %e,
+                        "Failed to fetch release assets, trying fallback"
+                    );
+                    return self.try_fallback_asset_url(core_ctx, descriptor).await;
+                }
+            };
+
+        if assets.is_empty() {
+            debug!(provider = %self.meta.name, tag = %tag, "No assets found for release");
+            return self.try_fallback_asset_url(core_ctx, descriptor).await;
+        }
+
+        // Step 2: Build assets JSON array for Starlark
+        let assets_json: Vec<serde_json::Value> = assets
+            .iter()
+            .map(|a| {
+                serde_json::json!({
+                    "name": a.name,
+                    "size": a.size,
+                    "browser_download_url": a.browser_download_url,
+                })
+            })
+            .collect();
+
+        // Step 3: Build platform ctx dict for Starlark scoring
+        let platform_ctx = serde_json::json!({
+            "platform": {
+                "os": core_ctx.platform.os,
+                "arch": core_ctx.platform.arch,
+                "target": core_ctx.platform.target,
+            },
+        });
+
+        // Step 4: Call Starlark scoring
+        let engine = StarlarkEngine::new();
+        let scoring_result = engine.call_stdlib_function(
+            "@vx//stdlib:smart_detect.star",
+            "detect_best_asset",
+            &[
+                serde_json::json!(assets_json),
+                platform_ctx,
+                serde_json::json!(version),
+                serde_json::json!(threshold),
+                serde_json::json!(linux_libc),
+                serde_json::json!(extra_excludes),
+            ],
+        );
+
+        match scoring_result {
+            Ok(json) => {
+                if json.is_null() {
+                    debug!(
+                        provider = %self.meta.name,
+                        tag = %tag,
+                        "Smart detect: no asset above threshold"
+                    );
+                    return self.try_fallback_asset_url(core_ctx, descriptor).await;
+                }
+                let url = json.get("browser_download_url").and_then(|u| u.as_str());
+                if let Some(url) = url {
+                    let name = json.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                    let score = json.get("score").and_then(|s| s.as_i64()).unwrap_or(0);
+                    debug!(
+                        provider = %self.meta.name,
+                        asset = %name,
+                        score = %score,
+                        "Smart detect selected best asset"
+                    );
+                    return Ok(Some(url.to_string()));
+                }
+                debug!(provider = %self.meta.name, "Smart detect result missing URL");
+                self.try_fallback_asset_url(core_ctx, descriptor).await
+            }
+            Err(e) => {
+                warn!(
+                    provider = %self.meta.name,
+                    error = %e,
+                    "Starlark scoring failed, trying fallback"
+                );
+                self.try_fallback_asset_url(core_ctx, descriptor).await
+            }
+        }
+    }
+
+    /// Try the fallback asset template when smart detect fails.
+    async fn try_fallback_asset_url(
+        &self,
+        core_ctx: &ProviderContext,
+        descriptor: &serde_json::Value,
+    ) -> Result<Option<String>> {
+        use tracing::debug;
+
+        let fallback_asset = descriptor
+            .get("fallback_asset")
+            .and_then(|a| a.as_str())
+            .filter(|s| !s.is_empty());
+
+        let template = match fallback_asset {
+            Some(t) => t,
+            None => {
+                debug!(
+                    provider = %self.meta.name,
+                    "No fallback asset template — returning None"
+                );
+                return Ok(None);
+            }
+        };
+
+        let owner = descriptor
+            .get("owner")
+            .and_then(|o| o.as_str())
+            .unwrap_or("");
+        let repo = descriptor
+            .get("repo")
+            .and_then(|r| r.as_str())
+            .unwrap_or("");
+        let tag = descriptor.get("tag").and_then(|t| t.as_str()).unwrap_or("");
+        let version = descriptor
+            .get("version")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        let fname = expand_asset_template(template, core_ctx, version);
+
+        let url = format!(
+            "https://github.com/{}/{}/releases/download/{}/{}",
+            owner, repo, tag, fname
+        );
+
+        debug!(
+            provider = %self.meta.name,
+            template = %template,
+            filename = %fname,
+            "Smart detect fallback: using explicit asset template"
+        );
+
+        Ok(Some(url))
+    }
+}
+
+/// Expand an asset filename template with platform-specific values.
+///
+/// Mirrors `expand_asset()` from `platform.star` for use in the Rust
+/// fallback path (so we don't need another Starlark roundtrip).
+///
+/// Supported placeholders: `{version}`, `{vversion}`, `{triple}`, `{os}`,
+/// `{arch}`, `{ext}`, `{exe}`.
+fn expand_asset_template(template: &str, ctx: &ProviderContext, version: &str) -> String {
+    let triple = ctx.platform.target.as_str();
+    let ext = if ctx.platform.os == "windows" {
+        "zip"
+    } else {
+        "tar.gz"
+    };
+    let exe = if ctx.platform.os == "windows" {
+        ".exe"
+    } else {
+        ""
+    };
+
+    let go_os = match ctx.platform.os.as_str() {
+        "windows" => "windows",
+        "macos" => "darwin",
+        "linux" => "linux",
+        _ => "linux",
+    };
+    let go_arch = match ctx.platform.arch.as_str() {
+        "x64" => "amd64",
+        "arm64" => "arm64",
+        "x86" => "386",
+        _ => "amd64",
+    };
+
+    template
+        .replace("{version}", version)
+        .replace("{vversion}", &format!("v{}", version))
+        .replace("{triple}", triple)
+        .replace("{os}", go_os)
+        .replace("{arch}", go_arch)
+        .replace("{ext}", ext)
+        .replace("{exe}", exe)
 }

--- a/crates/vx-starlark/src/provider/versions.rs
+++ b/crates/vx-starlark/src/provider/versions.rs
@@ -1146,7 +1146,7 @@ impl StarlarkProvider {
 /// This context only has a real HTTP client; all other fields use lightweight
 /// no-op implementations. It is used to drive `vx-version-fetcher` fetchers
 /// without pulling in the full `vx-runtime-http` dependency.
-fn build_minimal_runtime_ctx() -> vx_runtime::RuntimeContext {
+pub(crate) fn build_minimal_runtime_ctx() -> vx_runtime::RuntimeContext {
     use std::sync::Arc;
     use vx_runtime::{MockFileSystem, MockInstaller, MockPathProvider, RuntimeContext};
 

--- a/crates/vx-starlark/stdlib/provider.star
+++ b/crates/vx-starlark/stdlib/provider.star
@@ -169,4 +169,5 @@ load("@vx//stdlib:provider_templates.star",
      "github_rust_provider",
      "github_go_provider",
      "github_binary_provider",
+     "github_smart_provider",
      "system_provider")

--- a/crates/vx-starlark/stdlib/provider_templates.star
+++ b/crates/vx-starlark/stdlib/provider_templates.star
@@ -440,3 +440,109 @@ def system_provider(store_name, executable = None,
     fns["download_url"]   = _download_url
     fns["install_layout"] = _install_layout
     return fns
+
+# ---------------------------------------------------------------------------
+# Template 5: github_smart_provider
+#   GitHub releases with automatic asset scoring (RFC 0041).
+#   No asset template needed — the system inspects release assets and picks
+#   the best match for the current platform.
+# ---------------------------------------------------------------------------
+
+def github_smart_provider(owner, repo,
+                          executable = None,
+                          store = None,
+                          asset = None,
+                          tag_prefix = "v",
+                          linux_libc = "musl",
+                          prereleases = False,
+                          strip = None,
+                          path_env = True,
+                          score_threshold = 40,
+                          extra_excludes = None):
+    """Provider template for GitHub releases with automatic asset detection.
+
+    Unlike github_rust_provider / github_go_provider, you do NOT provide an
+    asset filename template.  Instead the system fetches the release assets
+    from the GitHub API, scores each one against the current platform, and
+    picks the best match automatically (RFC 0041).
+
+    When the optional ``asset`` fallback template IS provided it is only used
+    as a last resort — when the GitHub API call fails or no asset scores
+    above the threshold.
+
+    Args:
+        owner:           GitHub owner (e.g. "BurntSushi")
+        repo:            GitHub repo name (e.g. "ripgrep")
+        executable:      Executable name; defaults to `repo`
+        store:           Store directory name; defaults to `repo`
+        asset:           Fallback asset filename template.
+                         Only used when the GitHub API call fails or no asset
+                         scores above `score_threshold`.
+                         Placeholders: {version}, {vversion}, {triple}, {os},
+                         {arch}, {ext}, {exe}
+        tag_prefix:      Tag prefix before version (default: "v")
+        linux_libc:      Linux C library preference: "musl" (default) or "gnu"
+        prereleases:     Include pre-release versions (default: False)
+        strip:           Archive top-level directory prefix to strip (string).
+                         None = no stripping.
+        path_env:        Prepend install_dir to PATH (default: True)
+        score_threshold: Minimum score to accept an asset (0-100, default: 40)
+        extra_excludes:  Extra filename keywords to exclude (list of strings)
+
+    Returns:
+        A dict with all standard provider functions:
+        fetch_versions, download_url, install_layout,
+        store_root, get_execute_path, post_install, environment, deps
+
+    Example:
+        # ripgrep — no asset template, fully automatic
+        _p = github_smart_provider("BurntSushi", "ripgrep")
+
+        # Custom tool — with a fallback template
+        _p = github_smart_provider(
+            "myorg", "mytool",
+            asset      = "mytool-{vversion}-{triple}.{ext}",
+            executable = "mt",
+        )
+    """
+    exe_name   = executable if executable != None else repo
+    store_name = store      if store      != None else repo
+
+    def _fetch_versions(ctx):
+        from_github = make_fetch_versions(owner, repo, prereleases)
+        return from_github(ctx)
+
+    def _download_url(ctx, version):
+        tag = tag_prefix + version
+        desc = {
+            "__type":          "github_smart_detect",
+            "owner":           owner,
+            "repo":            repo,
+            "tag":             tag,
+            "version":         version,
+            "linux_libc":      linux_libc,
+            "score_threshold": score_threshold,
+        }
+        if extra_excludes != None:
+            desc["extra_excludes"] = extra_excludes
+        if asset != None:
+            desc["fallback_asset"] = asset
+        return desc
+
+    def _install_layout(ctx, version):
+        exe = exe_name + _exe_suffix(ctx)
+        layout = {
+            "__type":           "archive",
+            "executable_paths": [exe, exe_name],
+        }
+        if strip != None:
+            layout["strip_prefix"] = strip
+        else:
+            layout["strip_prefix"] = ""
+        return layout
+
+    fns = _std_provider_fns(store_name, exe_name, path_env, None)
+    fns["fetch_versions"] = _fetch_versions
+    fns["download_url"]   = _download_url
+    fns["install_layout"] = _install_layout
+    return fns

--- a/crates/vx-starlark/stdlib/smart_detect.star
+++ b/crates/vx-starlark/stdlib/smart_detect.star
@@ -1,0 +1,331 @@
+# @vx//stdlib:smart_detect.star
+# Asset scoring and smart detection for GitHub releases
+#
+# Pure computation — no I/O. The Rust runtime fetches release assets via
+# GitHub API, then calls into this module to score and select the best match.
+#
+# Usage:
+#   load("@vx//stdlib:smart_detect.star", "score_asset", "detect_best_asset")
+
+# ── Hard exclusion keywords (checked case-insensitive in filename) ──
+_EXCLUDE_KEYWORDS = [
+    "checksum", "sha256", "sha512", "md5", "sha1",
+    "sbom", "attestation", "spdx",
+    "source", "src.tar", "-src.",
+    ".deb", ".rpm", ".apk", ".msi", ".pkg", ".dmg", ".appimage",
+    ".sig", ".asc", ".pem",
+]
+
+# ── OS alias mapping: canonical OS → list of filename substrings ──
+_OS_ALIASES = {
+    "windows": ["windows", "win64", "win32", "windows-x64", "pc-windows", "win"],
+    "darwin":  ["darwin", "macos", "macosx", "mac", "apple-darwin", "osx"],
+    "linux":   ["linux", "unknown-linux", "linux-gnu", "linux-musl"],
+}
+
+# ── Arch alias mapping: canonical arch → list of filename substrings ──
+_ARCH_ALIASES = {
+    "x86_64":  ["x86_64", "x64", "amd64", "x86-64", "win64"],
+    "aarch64": ["arm64", "aarch64", "armv8", "arm64-v8a"],
+    "i686":    ["x86", "i686", "i386", "386", "win32"],
+}
+
+# ── Universal / multi-arch markers ──
+_UNIVERSAL_MARKERS = ["all", "any", "portable", "multi", "universal", "fat"]
+
+# ── Libc detection markers ──
+_LIBC_MUSL = ["musl", "static", "alpine"]
+_LIBC_GNU  = ["gnu", "glibc", "gnueabihf"]
+
+# ── Platform-aware format preferences: {os: {extension: points, ...}} ──
+_FORMAT_PREFS = {
+    "linux":   {".tar.gz": 15, ".tar.xz": 10, ".tar.bz2": 5, ".tgz": 5, ".zip": 2},
+    "darwin":  {".tar.gz": 15, ".tar.xz": 10, ".zip": 5, ".tar.bz2": 2},
+    "windows": {".zip": 15, ".tar.gz": 10, ".7z": 5, ".tar.xz": 2, ".tar.bz2": 2},
+}
+
+# ── Keyword bonus table ──
+_KEYWORD_BONUS = {
+    "static": 3,
+    "portable": 3,
+    "standalone": 3,
+}
+
+# ── Vx platform → canonical OS for asset matching ──
+def _canonical_os(ctx):
+    """Map vx platform.os to the canonical OS used in asset filenames."""
+    os = ctx.platform.os
+    if os == "macos":
+        return "darwin"
+    return os
+
+# ── Vx arch → canonical arch for asset matching ──
+def _canonical_arch(ctx):
+    """Map vx platform.arch to canonical arch used in asset filenames."""
+    arch = ctx.platform.arch
+    if arch == "x64":
+        return "x86_64"
+    if arch == "arm64":
+        return "aarch64"
+    if arch == "x86":
+        return "i686"
+    return arch
+
+# ── Helpers ──
+
+def _lc(name):
+    return name.lower()
+
+def _contains(name_lower, markers):
+    """Check if a lowercased name contains any of the given marker substrings."""
+    for m in markers:
+        if m in name_lower:
+            return True
+    return False
+
+def _find_alias(name_lower, alias_map):
+    """Find the canonical key whose alias list matches the name.
+
+    Returns (canonical_key, is_full_match) where is_full_match means
+    the longest alias matched (preferring full token matches over partial).
+    """
+    best_key = None
+    best_score = 0
+    for key, aliases in alias_map.items():
+        for alias in aliases:
+            if alias in name_lower:
+                # Score: prefer longer alias matches (more specific)
+                score = len(alias)
+                if score > best_score:
+                    best_score = score
+                    best_key = key
+    return best_key
+
+# ── Scoring sub-functions ──
+
+def _score_os(name_lower, ctx, target_os):
+    """Score OS match. Returns (points, is_mismatch) where mismatch means
+    the asset matches a different OS entirely."""
+    detected_os = _find_alias(name_lower, _OS_ALIASES)
+
+    if detected_os == None:
+        return (0, False)  # No OS detected, neutral
+
+    if detected_os == target_os:
+        # Full alias match
+        # Check if it's a substring match within a compound name
+        return (35, False)
+
+    # Detected a different OS — this asset is for another platform
+    return (0, True)
+
+
+def _score_arch(name_lower, ctx, target_arch):
+    """Score arch match."""
+    # Check universal/multi-arch markers first
+    if _contains(name_lower, _UNIVERSAL_MARKERS):
+        return 15  # Universal binary, neutral score
+
+    detected_arch = _find_alias(name_lower, _ARCH_ALIASES)
+
+    if detected_arch == None:
+        return 0
+
+    if detected_arch == target_arch:
+        return 30  # Full match
+
+    return 0  # Different arch, doesn't match
+
+
+def _score_libc(name_lower, ctx, linux_libc):
+    """Score libc preference on Linux. Non-Linux always +15."""
+    if ctx.platform.os != "linux":
+        return 15
+
+    has_musl = _contains(name_lower, _LIBC_MUSL)
+    has_gnu  = _contains(name_lower, _LIBC_GNU)
+
+    if linux_libc == "musl":
+        if has_musl:
+            return 15
+        if has_gnu:
+            return 5  # gnu asset on musl-preferred system
+        return 8  # No libc marker detected
+
+    if linux_libc == "gnu":
+        if has_gnu:
+            return 15
+        if has_musl:
+            return 5
+        return 8
+
+    return 8  # Unknown libc preference
+
+
+def _score_format(name_lower, ctx, target_os):
+    """Score archive format preference."""
+    prefs = _FORMAT_PREFS.get(target_os, {})
+
+    for ext, points in prefs.items():
+        if name_lower.endswith(ext):
+            return points
+
+    # Acceptable format not in preference list
+    if name_lower.endswith(".tar.gz"):
+        return 2
+    if name_lower.endswith(".tar.xz"):
+        return 2
+    if name_lower.endswith(".tar.bz2"):
+        return 2
+    if name_lower.endswith(".tgz"):
+        return 2
+    if name_lower.endswith(".zip"):
+        return 2
+    if name_lower.endswith(".7z"):
+        return 2
+
+    return 0
+
+
+def _score_keywords(name_lower):
+    """Score keyword bonuses, capped at 5 total."""
+    bonus = 0
+    for keyword, points in _KEYWORD_BONUS.items():
+        if keyword in name_lower:
+            bonus = bonus + points
+    if bonus > 5:
+        bonus = 5
+    return bonus
+
+
+def _version_appears(name_lower, version):
+    """Check that the version appears in the filename (after stripping 'v' prefix)."""
+    v = version
+    if v.startswith("v"):
+        v = v[1:]
+    return v in name_lower
+
+
+# ── Public API ──
+
+def score_asset(name, ctx, version, linux_libc = "musl", extra_excludes = None):
+    """Score a single asset filename against the current platform.
+
+    Args:
+        name:          Asset filename (e.g. "ripgrep-14.1.1-x86_64-unknown-linux-musl.tar.gz")
+        ctx:           Provider context with .platform.os and .platform.arch
+        version:       Version string (e.g. "14.1.1" or "v14.1.1")
+        linux_libc:    "musl" (default) or "gnu"
+        extra_excludes: Optional list of extra exclusion substrings
+
+    Returns:
+        None if the asset is excluded (hard-excluded, version missing, OS mismatch).
+        Otherwise a dict: {"os_score": int, "arch_score": int, "libc_score": int,
+                           "format_score": int, "keyword_score": int, "total": int}
+    """
+    name_lower = _lc(name)
+
+    # ── Hard exclusion check ──
+    for kw in _EXCLUDE_KEYWORDS:
+        if kw in name_lower:
+            return None
+
+    if extra_excludes != None:
+        for ex in extra_excludes:
+            if ex.lower() in name_lower:
+                return None
+
+    # ── Version must appear ──
+    if not _version_appears(name_lower, version):
+        return None
+
+    target_os = _canonical_os(ctx)
+    target_arch = _canonical_arch(ctx)
+
+    # ── OS scoring ──
+    os_score, os_mismatch = _score_os(name_lower, ctx, target_os)
+    if os_mismatch:
+        return None  # Exclude assets for a different OS
+
+    # ── Arch scoring ──
+    arch_score = _score_arch(name_lower, ctx, target_arch)
+
+    # ── Libc scoring ──
+    libc_score = _score_libc(name_lower, ctx, linux_libc)
+
+    # ── Format scoring ──
+    format_score = _score_format(name_lower, ctx, target_os)
+
+    # ── Keyword bonus ──
+    keyword_score = _score_keywords(name_lower)
+
+    total = os_score + arch_score + libc_score + format_score + keyword_score
+
+    return {
+        "os_score":      os_score,
+        "arch_score":    arch_score,
+        "libc_score":    libc_score,
+        "format_score":  format_score,
+        "keyword_score": keyword_score,
+        "total":         total,
+    }
+
+
+def _tie_break_key(item):
+    """Sort key for tie-breaking: (score desc, size asc, name_length asc, name asc)."""
+    score = item.get("total", 0)
+    size  = item.get("size", 0)
+    name  = item.get("name", "")
+    # Higher score first, smaller size first, shorter name first, alphabetical
+    return (-score, size, len(name), name)
+
+
+def detect_best_asset(assets, ctx, version,
+                      threshold = 40,
+                      linux_libc = "musl",
+                      extra_excludes = None):
+    """Score all assets and return the best match.
+
+    Args:
+        assets:         List of asset dicts, each with "name", "size", "browser_download_url"
+        ctx:            Provider context with .platform.os and .platform.arch
+        version:        Version string
+        threshold:      Minimum total score to accept (default: 40)
+        linux_libc:     "musl" (default) or "gnu"
+        extra_excludes: Optional list of extra exclusion substrings
+
+    Returns:
+        The best asset dict (with "score" and "scores" fields added) if score >= threshold.
+        None if no asset meets the threshold.
+    """
+    candidates = []
+
+    for asset in assets:
+        # Assets are Starlark structs (converted from JSON by the Rust layer).
+        # Use getattr for safe field access with defaults.
+        name = getattr(asset, "name", "")
+        if not name:
+            continue
+
+        scores = score_asset(name, ctx, version, linux_libc, extra_excludes)
+        if scores == None:
+            continue
+
+        total = scores.get("total", 0)
+        if total < threshold:
+            continue
+
+        candidates.append({
+            "name":                 name,
+            "size":                 getattr(asset, "size", 0),
+            "browser_download_url": getattr(asset, "browser_download_url", ""),
+            "score":                total,
+            "scores":               scores,
+        })
+
+    if len(candidates) == 0:
+        return None
+
+    # Sort: highest score first, tie-break by size → name length → alphabetical
+    candidates = sorted(candidates, key = _tie_break_key)
+    return candidates[0]

--- a/crates/vx-starlark/tests/loader_tests.rs
+++ b/crates/vx-starlark/tests/loader_tests.rs
@@ -158,11 +158,11 @@ fn test_available_modules_contains_all_builtins() {
 fn test_available_modules_count() {
     let loader = VxModuleLoader::new();
     let modules = loader.available_modules();
-    // We have 14 built-in modules:
+    // We have 15 built-in modules:
     // semver, platform, http, github, install, env,
     // layout, permissions, provider, provider_templates,
-    // runtime, script_install, system_install, test
-    assert_eq!(modules.len(), 14, "Should have exactly 14 built-in modules");
+    // runtime, script_install, system_install, test, smart_detect
+    assert_eq!(modules.len(), 15, "Should have exactly 15 built-in modules");
 }
 
 // ============================================================

--- a/crates/vx-starlark/tests/provider_tests.rs
+++ b/crates/vx-starlark/tests/provider_tests.rs
@@ -674,6 +674,137 @@ async fn test_cargo_nextest_download_url() {
     }
 }
 
+// ============================================================
+// github_smart_provider template tests (RFC 0041)
+// ============================================================
+
+#[tokio::test]
+async fn test_smart_provider_download_url_returns_descriptor() {
+    let content = r#"
+load("@vx//stdlib:provider_templates.star", "github_smart_provider")
+
+_p = github_smart_provider("BurntSushi", "ripgrep",
+    executable = "rg",
+    asset      = "ripgrep-{version}-{triple}.{ext}",
+)
+
+name = "ripgrep"
+description = "ripgrep test"
+runtimes = [{"name": "ripgrep", "executable": "rg"}]
+fetch_versions = _p["fetch_versions"]
+download_url   = _p["download_url"]
+install_layout = _p["install_layout"]
+"#;
+
+    let provider = vx_starlark::StarlarkProvider::from_content("ripgrep", content)
+        .await
+        .unwrap();
+
+    // download_url through StarlarkProvider resolves the descriptor via
+    // GitHub API (real HTTP). We test via the Starlark engine instead.
+    let _ = provider.download_url("14.1.1").await;
+    // download_url returns a descriptor (dict), not a URL string
+    // The Rust side resolves the descriptor into a real URL.
+    // In unit tests without real HTTP, it returns None because
+    // resolve_smart_detect_descriptor fails to fetch from GitHub API.
+    // So we test via the Starlark engine directly instead:
+    let engine = vx_starlark::StarlarkEngine::new();
+    let ctx = vx_starlark::ProviderContext::new("ripgrep", std::env::temp_dir().join("vx-test"));
+    let result = engine
+        .call_function(
+            &provider.script_path(),
+            &content,
+            "download_url",
+            &ctx,
+            &[serde_json::json!("14.1.1")],
+        )
+        .unwrap();
+
+    // Verify the descriptor shape
+    assert_eq!(result["__type"].as_str().unwrap(), "github_smart_detect");
+    assert_eq!(result["owner"].as_str().unwrap(), "BurntSushi");
+    assert_eq!(result["repo"].as_str().unwrap(), "ripgrep");
+    assert_eq!(result["tag"].as_str().unwrap(), "v14.1.1");
+    assert_eq!(result["version"].as_str().unwrap(), "14.1.1");
+    assert_eq!(result["linux_libc"].as_str().unwrap(), "musl");
+    assert_eq!(result["score_threshold"].as_i64().unwrap(), 40);
+    assert_eq!(
+        result["fallback_asset"].as_str().unwrap(),
+        "ripgrep-{version}-{triple}.{ext}"
+    );
+}
+
+#[tokio::test]
+async fn test_smart_provider_minimal_no_asset() {
+    let content = r#"
+load("@vx//stdlib:provider_templates.star", "github_smart_provider")
+
+_p = github_smart_provider("myorg", "mytool")
+
+name = "mytool"
+description = "Smart provider without fallback"
+runtimes = [{"name": "mytool", "executable": "mytool"}]
+fetch_versions = _p["fetch_versions"]
+download_url   = _p["download_url"]
+install_layout = _p["install_layout"]
+"#;
+
+    let engine = vx_starlark::StarlarkEngine::new();
+    let ctx = vx_starlark::ProviderContext::new("mytool", std::env::temp_dir().join("vx-test"));
+    let result = engine
+        .call_function(
+            &std::path::PathBuf::from("<builtin:mytool>"),
+            content,
+            "download_url",
+            &ctx,
+            &[serde_json::json!("1.0.0")],
+        )
+        .unwrap();
+
+    assert_eq!(result["__type"].as_str().unwrap(), "github_smart_detect");
+    assert_eq!(result["owner"].as_str().unwrap(), "myorg");
+    assert_eq!(result["repo"].as_str().unwrap(), "mytool");
+    // No fallback_asset when asset=None
+    assert!(result.get("fallback_asset").is_none());
+}
+
+#[tokio::test]
+async fn test_smart_provider_install_layout() {
+    let content = r#"
+load("@vx//stdlib:provider_templates.star", "github_smart_provider")
+
+_p = github_smart_provider("myorg", "mytool",
+    executable = "mt",
+    strip      = "mytool-{vversion}-{triple}",
+)
+
+name = "mytool"
+description = "Smart provider install_layout test"
+runtimes = [{"name": "mytool", "executable": "mt"}]
+fetch_versions = _p["fetch_versions"]
+download_url   = _p["download_url"]
+install_layout = _p["install_layout"]
+"#;
+
+    let engine = vx_starlark::StarlarkEngine::new();
+    let ctx = vx_starlark::ProviderContext::new("mytool", std::env::temp_dir().join("vx-test"));
+    let result = engine
+        .call_function(
+            &std::path::PathBuf::from("<builtin:mytool2>"),
+            content,
+            "install_layout",
+            &ctx,
+            &[serde_json::json!("1.0.0")],
+        )
+        .unwrap();
+
+    assert_eq!(result["__type"].as_str().unwrap(), "archive");
+    assert_eq!(
+        result["strip_prefix"].as_str().unwrap(),
+        "mytool-{vversion}-{triple}"
+    );
+}
+
 #[tokio::test]
 async fn test_cargo_deny_download_url() {
     let (star_path, content) = load_provider_content("cargo-deny");

--- a/crates/vx-starlark/tests/smart_detect_tests.rs
+++ b/crates/vx-starlark/tests/smart_detect_tests.rs
@@ -1,0 +1,517 @@
+//! Unit tests for smart_detect.star — the Starlark asset scoring engine (RFC 0041).
+//!
+//! These tests validate the pure Starlark scoring logic via `call_stdlib_function`.
+//! No real HTTP calls are made.
+
+use serde_json::json;
+use vx_starlark::engine::StarlarkEngine;
+
+/// Build a minimal platform context dict matching what `smart_detect.star` expects.
+fn ctx(os: &str, arch: &str) -> serde_json::Value {
+    json!({
+        "platform": {
+            "os": os,
+            "arch": arch,
+        }
+    })
+}
+
+/// Call `score_asset` in smart_detect.star with the given arguments.
+fn score(
+    engine: &StarlarkEngine,
+    name: &str,
+    ctx: &serde_json::Value,
+    version: &str,
+    linux_libc: &str,
+) -> Option<serde_json::Value> {
+    let result = engine
+        .call_stdlib_function(
+            "@vx//stdlib:smart_detect.star",
+            "score_asset",
+            &[
+                json!(name),
+                ctx.clone(),
+                json!(version),
+                json!(linux_libc),
+                json!(null), // extra_excludes
+            ],
+        )
+        .unwrap();
+    if result.is_null() { None } else { Some(result) }
+}
+
+/// Call `detect_best_asset` in smart_detect.star.
+fn detect(
+    engine: &StarlarkEngine,
+    assets: &[serde_json::Value],
+    ctx: &serde_json::Value,
+    version: &str,
+    threshold: u64,
+) -> Option<serde_json::Value> {
+    let result = engine
+        .call_stdlib_function(
+            "@vx//stdlib:smart_detect.star",
+            "detect_best_asset",
+            &[
+                json!(assets),
+                ctx.clone(),
+                json!(version),
+                json!(threshold),
+                json!("musl"),
+                json!(null),
+            ],
+        )
+        .unwrap();
+    if result.is_null() { None } else { Some(result) }
+}
+
+// ── Hard exclusion tests ──
+
+#[test]
+fn test_exclude_checksum() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    assert!(
+        score(
+            &engine,
+            "mytool-1.0.0-linux-amd64.tar.gz.sha256",
+            &c,
+            "1.0.0",
+            "musl"
+        )
+        .is_none()
+    );
+}
+
+#[test]
+fn test_exclude_deb() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    assert!(score(&engine, "mytool_1.0.0_amd64.deb", &c, "1.0.0", "musl").is_none());
+}
+
+#[test]
+fn test_exclude_rpm() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    assert!(score(&engine, "mytool-1.0.0-1.x86_64.rpm", &c, "1.0.0", "musl").is_none());
+}
+
+#[test]
+fn test_exclude_msi() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("windows", "x64");
+    assert!(score(&engine, "mytool-1.0.0-x64.msi", &c, "1.0.0", "musl").is_none());
+}
+
+#[test]
+fn test_exclude_sbom() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    assert!(score(&engine, "mytool-1.0.0-sbom.spdx.json", &c, "1.0.0", "musl").is_none());
+}
+
+#[test]
+fn test_exclude_source() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    assert!(score(&engine, "mytool-1.0.0-src.tar.gz", &c, "1.0.0", "musl").is_none());
+}
+
+// ── Version presence test ──
+
+#[test]
+fn test_version_must_appear_in_filename() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    // Asset for v1.0.0 but we ask for v2.0.0
+    assert!(
+        score(
+            &engine,
+            "mytool-1.0.0-x86_64-linux.tar.gz",
+            &c,
+            "2.0.0",
+            "musl"
+        )
+        .is_none()
+    );
+}
+
+#[test]
+fn test_version_without_v_prefix() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    let r = score(
+        &engine,
+        "mytool-1.0.0-x86_64-linux.tar.gz",
+        &c,
+        "1.0.0",
+        "musl",
+    );
+    assert!(
+        r.is_some(),
+        "version 1.0.0 should match '1.0.0' in filename"
+    );
+}
+
+#[test]
+fn test_version_with_v_prefix_in_query() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    let r = score(
+        &engine,
+        "mytool-1.0.0-x86_64-linux.tar.gz",
+        &c,
+        "v1.0.0",
+        "musl",
+    );
+    assert!(
+        r.is_some(),
+        "query 'v1.0.0' should match '1.0.0' in filename"
+    );
+}
+
+// ── OS scoring tests ──
+
+#[test]
+fn test_os_match_linux() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    let r = score(
+        &engine,
+        "mytool-1.0.0-x86_64-unknown-linux-musl.tar.gz",
+        &c,
+        "1.0.0",
+        "musl",
+    );
+    let s = r.unwrap();
+    assert_eq!(s["os_score"].as_i64().unwrap(), 35);
+}
+
+#[test]
+fn test_os_match_windows() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("windows", "x64");
+    let r = score(
+        &engine,
+        "mytool-1.0.0-x86_64-pc-windows-msvc.zip",
+        &c,
+        "1.0.0",
+        "musl",
+    );
+    let s = r.unwrap();
+    assert_eq!(s["os_score"].as_i64().unwrap(), 35);
+}
+
+#[test]
+fn test_os_match_darwin() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("macos", "x64");
+    let r = score(
+        &engine,
+        "mytool-1.0.0-x86_64-apple-darwin.tar.gz",
+        &c,
+        "1.0.0",
+        "musl",
+    );
+    let s = r.unwrap();
+    assert_eq!(s["os_score"].as_i64().unwrap(), 35);
+}
+
+#[test]
+fn test_os_mismatch_excludes() {
+    let engine = StarlarkEngine::new();
+    // Windows asset on Linux system
+    let c = ctx("linux", "x64");
+    assert!(
+        score(
+            &engine,
+            "mytool-1.0.0-x86_64-pc-windows-msvc.zip",
+            &c,
+            "1.0.0",
+            "musl"
+        )
+        .is_none()
+    );
+}
+
+// ── Arch scoring tests ──
+
+#[test]
+fn test_arch_match_x86_64() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    let r = score(
+        &engine,
+        "mytool-1.0.0-x86_64-linux.tar.gz",
+        &c,
+        "1.0.0",
+        "musl",
+    );
+    let s = r.unwrap();
+    assert_eq!(s["arch_score"].as_i64().unwrap(), 30);
+}
+
+#[test]
+fn test_arch_match_amd64() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    let r = score(
+        &engine,
+        "mytool-1.0.0-linux-amd64.tar.gz",
+        &c,
+        "1.0.0",
+        "musl",
+    );
+    let s = r.unwrap();
+    assert_eq!(s["arch_score"].as_i64().unwrap(), 30);
+}
+
+#[test]
+fn test_arch_match_arm64() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "arm64");
+    let r = score(
+        &engine,
+        "mytool-1.0.0-aarch64-linux.tar.gz",
+        &c,
+        "1.0.0",
+        "musl",
+    );
+    let s = r.unwrap();
+    assert_eq!(s["arch_score"].as_i64().unwrap(), 30);
+}
+
+#[test]
+fn test_arch_universal() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    let r = score(&engine, "mytool-1.0.0-portable.tar.gz", &c, "1.0.0", "musl");
+    let s = r.unwrap();
+    assert_eq!(s["arch_score"].as_i64().unwrap(), 15);
+}
+
+// ── Libc scoring tests ──
+
+#[test]
+fn test_libc_musl_preference_on_linux() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    let r = score(
+        &engine,
+        "mytool-1.0.0-x86_64-unknown-linux-musl.tar.gz",
+        &c,
+        "1.0.0",
+        "musl",
+    );
+    let s = r.unwrap();
+    assert_eq!(s["libc_score"].as_i64().unwrap(), 15);
+}
+
+#[test]
+fn test_libc_gnu_on_musl_pref() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    let r = score(
+        &engine,
+        "mytool-1.0.0-x86_64-unknown-linux-gnu.tar.gz",
+        &c,
+        "1.0.0",
+        "musl",
+    );
+    let s = r.unwrap();
+    assert_eq!(s["libc_score"].as_i64().unwrap(), 5);
+}
+
+#[test]
+fn test_libc_gnu_preference() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    let r = score(
+        &engine,
+        "mytool-1.0.0-x86_64-unknown-linux-gnu.tar.gz",
+        &c,
+        "1.0.0",
+        "gnu",
+    );
+    let s = r.unwrap();
+    assert_eq!(s["libc_score"].as_i64().unwrap(), 15);
+}
+
+#[test]
+fn test_libc_non_linux_always_full() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("windows", "x64");
+    let r = score(
+        &engine,
+        "mytool-1.0.0-x86_64-pc-windows-msvc.zip",
+        &c,
+        "1.0.0",
+        "musl",
+    );
+    let s = r.unwrap();
+    assert_eq!(s["libc_score"].as_i64().unwrap(), 15);
+}
+
+// ── Format scoring tests ──
+
+#[test]
+fn test_format_tar_gz_linux() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    let r = score(
+        &engine,
+        "mytool-1.0.0-x86_64-linux.tar.gz",
+        &c,
+        "1.0.0",
+        "musl",
+    );
+    let s = r.unwrap();
+    assert_eq!(s["format_score"].as_i64().unwrap(), 15);
+}
+
+#[test]
+fn test_format_zip_windows() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("windows", "x64");
+    let r = score(
+        &engine,
+        "mytool-1.0.0-x86_64-windows.zip",
+        &c,
+        "1.0.0",
+        "musl",
+    );
+    let s = r.unwrap();
+    assert_eq!(s["format_score"].as_i64().unwrap(), 15);
+}
+
+// ── Keyword bonus tests ──
+
+#[test]
+fn test_keyword_static() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    let r = score(
+        &engine,
+        "mytool-1.0.0-x86_64-unknown-linux-musl-static.tar.gz",
+        &c,
+        "1.0.0",
+        "musl",
+    );
+    let s = r.unwrap();
+    assert_eq!(s["keyword_score"].as_i64().unwrap(), 3);
+}
+
+#[test]
+fn test_keyword_capped_at_5() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    // Contains "static", "portable", "standalone" → 3+3+3=9, capped at 5
+    let r = score(
+        &engine,
+        "mytool-1.0.0-x86_64-static-portable-standalone.tar.gz",
+        &c,
+        "1.0.0",
+        "musl",
+    );
+    let s = r.unwrap();
+    assert!(s["keyword_score"].as_i64().unwrap() <= 5);
+}
+
+// ── Full scoring example (ripgrep-like) ──
+
+#[test]
+fn test_full_score_linux_musl() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    let r = score(
+        &engine,
+        "rg-14.1.1-x86_64-unknown-linux-musl.tar.gz",
+        &c,
+        "14.1.1",
+        "musl",
+    );
+    let s = r.unwrap();
+    // OS 35 + Arch 30 + Libc 15 + Format 15 = 95
+    assert!(s["total"].as_i64().unwrap() >= 90);
+    assert_eq!(s["os_score"].as_i64().unwrap(), 35);
+    assert_eq!(s["arch_score"].as_i64().unwrap(), 30);
+    assert_eq!(s["libc_score"].as_i64().unwrap(), 15);
+    assert_eq!(s["format_score"].as_i64().unwrap(), 15);
+}
+
+// ── detect_best_asset integration tests ──
+
+fn make_test_assets() -> Vec<serde_json::Value> {
+    vec![
+        json!({"name": "rg-14.1.1-x86_64-unknown-linux-musl.tar.gz", "size": 2000000, "browser_download_url": "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/rg-14.1.1-x86_64-unknown-linux-musl.tar.gz"}),
+        json!({"name": "rg-14.1.1-x86_64-unknown-linux-gnu.tar.gz", "size": 2100000, "browser_download_url": "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/rg-14.1.1-x86_64-unknown-linux-gnu.tar.gz"}),
+        json!({"name": "rg-14.1.1-x86_64-pc-windows-msvc.zip", "size": 3000000, "browser_download_url": "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/rg-14.1.1-x86_64-pc-windows-msvc.zip"}),
+        json!({"name": "ripgrep-14.1.1-x86_64-apple-darwin.tar.gz", "size": 1800000, "browser_download_url": "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-x86_64-apple-darwin.tar.gz"}),
+    ]
+}
+
+#[test]
+fn test_detect_best_linux_musl() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    let assets = make_test_assets();
+    let best = detect(&engine, &assets, &c, "14.1.1", 40);
+    let b = best.unwrap();
+    assert!(
+        b["name"].as_str().unwrap().contains("musl"),
+        "Should pick musl asset on Linux"
+    );
+    assert!(b["score"].as_i64().unwrap() >= 90);
+}
+
+#[test]
+fn test_detect_best_windows() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("windows", "x64");
+    let assets = make_test_assets();
+    let best = detect(&engine, &assets, &c, "14.1.1", 40);
+    let b = best.unwrap();
+    assert!(
+        b["name"].as_str().unwrap().contains("windows"),
+        "Should pick windows asset on Windows"
+    );
+}
+
+#[test]
+fn test_detect_below_threshold() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    let assets = make_test_assets();
+    let best = detect(&engine, &assets, &c, "14.1.1", 100);
+    assert!(best.is_none(), "No asset should score >= 100");
+}
+
+#[test]
+fn test_detect_no_assets() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    let assets: Vec<serde_json::Value> = vec![];
+    let best = detect(&engine, &assets, &c, "14.1.1", 40);
+    assert!(best.is_none());
+}
+
+#[test]
+fn test_extra_excludes_work() {
+    let engine = StarlarkEngine::new();
+    let c = ctx("linux", "x64");
+    let result = engine
+        .call_stdlib_function(
+            "@vx//stdlib:smart_detect.star",
+            "score_asset",
+            &[
+                json!("mytool-1.0.0-x86_64-linux-nightly.tar.gz"),
+                c.clone(),
+                json!("1.0.0"),
+                json!("musl"),
+                json!(["nightly"]),
+            ],
+        )
+        .unwrap();
+    assert!(result.is_null(), "Asset with 'nightly' should be excluded");
+}

--- a/crates/vx-version-fetcher/src/fetchers/github.rs
+++ b/crates/vx-version-fetcher/src/fetchers/github.rs
@@ -293,6 +293,78 @@ impl GitHubReleasesFetcher {
     }
 }
 
+/// Asset information from a GitHub release
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct GitHubAssetInfo {
+    pub name: String,
+    pub size: u64,
+    pub browser_download_url: String,
+}
+
+impl GitHubReleasesFetcher {
+    /// Fetch assets for a specific release tag.
+    ///
+    /// Calls `GET /repos/{owner}/{repo}/releases/tags/{tag}` and extracts
+    /// the `assets[]` array from the response.
+    pub async fn fetch_release_assets(
+        owner: &str,
+        repo: &str,
+        tag: &str,
+        ctx: &dyn FetchContext,
+    ) -> FetchResult<Vec<GitHubAssetInfo>> {
+        let url = format!(
+            "https://api.github.com/repos/{}/{}/releases/tags/{}",
+            owner, repo, tag
+        );
+
+        tracing::debug!(
+            owner = %owner,
+            repo = %repo,
+            tag = %tag,
+            "Fetching release assets"
+        );
+
+        let response = ctx
+            .get_json_value(&url)
+            .await
+            .map_err(|e| FetchError::network(e.to_string()))?;
+
+        let assets = response
+            .get("assets")
+            .and_then(|a| a.as_array())
+            .ok_or_else(|| {
+                FetchError::invalid_format("GitHub", "Expected assets array in release response")
+            })?;
+
+        let result: Vec<GitHubAssetInfo> = assets
+            .iter()
+            .filter_map(|a| {
+                let name = a.get("name")?.as_str()?.to_string();
+                let size = a.get("size").and_then(|s| s.as_u64()).unwrap_or(0);
+                let browser_download_url = a
+                    .get("browser_download_url")
+                    .and_then(|u| u.as_str())
+                    .map(|s| s.to_string())?;
+                Some(GitHubAssetInfo {
+                    name,
+                    size,
+                    browser_download_url,
+                })
+            })
+            .collect();
+
+        tracing::debug!(
+            owner = %owner,
+            repo = %repo,
+            tag = %tag,
+            count = %result.len(),
+            "Fetched release assets"
+        );
+
+        Ok(result)
+    }
+}
+
 #[async_trait]
 impl VersionFetcher for GitHubReleasesFetcher {
     async fn fetch(&self, ctx: &dyn FetchContext) -> FetchResult<Vec<VersionInfo>> {

--- a/crates/vx-version-fetcher/src/fetchers/mod.rs
+++ b/crates/vx-version-fetcher/src/fetchers/mod.rs
@@ -7,7 +7,7 @@ pub mod npm;
 pub mod pypi;
 
 pub use custom::CustomApiFetcher;
-pub use github::{GitHubReleasesConfig, GitHubReleasesFetcher};
+pub use github::{GitHubAssetInfo, GitHubReleasesConfig, GitHubReleasesFetcher};
 pub use jsdelivr::{JsDelivrConfig, JsDelivrFetcher};
 pub use npm::{NpmConfig, NpmFetcher};
 pub use pypi::{PyPiConfig, PyPiFetcher};

--- a/crates/vx-version-fetcher/src/lib.rs
+++ b/crates/vx-version-fetcher/src/lib.rs
@@ -47,8 +47,8 @@ pub use builder::VersionFetcherBuilder;
 pub use error::{FetchError, FetchResult};
 pub use fetcher::VersionFetcher;
 pub use fetchers::{
-    CustomApiFetcher, GitHubReleasesConfig, GitHubReleasesFetcher, JsDelivrConfig, JsDelivrFetcher,
-    NpmConfig, NpmFetcher, PyPiConfig, PyPiFetcher,
+    CustomApiFetcher, GitHubAssetInfo, GitHubReleasesConfig, GitHubReleasesFetcher, JsDelivrConfig,
+    JsDelivrFetcher, NpmConfig, NpmFetcher, PyPiConfig, PyPiFetcher,
 };
 pub use utils::version_utils;
 

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -111,8 +111,7 @@ zerocopy = { version = "0.8", default-features = false, features = ["derive", "s
 
 [target.x86_64-pc-windows-msvc.dependencies]
 flate2 = { version = "1", features = ["zlib-rs"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
+getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "1", features = ["client", "http1", "http2"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "http1", "http2", "tls12"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "http2"] }
@@ -131,8 +130,7 @@ windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61", feat
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
 flate2 = { version = "1", features = ["zlib-rs"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
+getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "1", features = ["client", "http1", "http2"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "http1", "http2", "tls12"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "http2"] }
@@ -151,8 +149,7 @@ windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61", feat
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 flate2 = { version = "1", features = ["zlib-rs"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
+getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "1", features = ["client", "http1", "http2"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "http1", "http2", "tls12"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "http2"] }
@@ -170,8 +167,7 @@ tower-http = { version = "0.6", default-features = false, features = ["decompres
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 flate2 = { version = "1", features = ["zlib-rs"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
+getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "1", features = ["client", "http1", "http2"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "http1", "http2", "tls12"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "http2"] }
@@ -190,8 +186,7 @@ tower-http = { version = "0.6", default-features = false, features = ["decompres
 [target.x86_64-apple-darwin.dependencies]
 errno = { version = "0.3" }
 flate2 = { version = "1", features = ["zlib-rs"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
+getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "1", features = ["client", "http1", "http2"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "http1", "http2", "tls12"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "http2"] }
@@ -210,8 +205,7 @@ tower-http = { version = "0.6", default-features = false, features = ["decompres
 [target.x86_64-apple-darwin.build-dependencies]
 errno = { version = "0.3" }
 flate2 = { version = "1", features = ["zlib-rs"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
+getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "1", features = ["client", "http1", "http2"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "http1", "http2", "tls12"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "http2"] }
@@ -230,8 +224,7 @@ tower-http = { version = "0.6", default-features = false, features = ["decompres
 [target.aarch64-apple-darwin.dependencies]
 errno = { version = "0.3" }
 flate2 = { version = "1", features = ["zlib-rs"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
+getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "1", features = ["client", "http1", "http2"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "http1", "http2", "tls12"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "http2"] }
@@ -250,8 +243,7 @@ tower-http = { version = "0.6", default-features = false, features = ["decompres
 [target.aarch64-apple-darwin.build-dependencies]
 errno = { version = "0.3" }
 flate2 = { version = "1", features = ["zlib-rs"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
+getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "1", features = ["client", "http1", "http2"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "http1", "http2", "tls12"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "http2"] }


### PR DESCRIPTION
## Summary

Implement the `github_smart_provider` MVP as designed in RFC 0041. This adds automatic GitHub release asset scoring and selection, eliminating the need for manual asset filename templates.

## Changes

### New files
- **`smart_detect.star`** — Pure Starlark scoring engine (OS 35pt + Arch 30pt + Libc 15pt + Format 15pt + Keywords 5pt, threshold 40)
- **`smart_detect_tests.rs`** — 31 scoring unit tests

### Modified files
- **`loader.rs`** — Register `smart_detect.star` + `evaluable_module()` for non-frozen module access
- **`engine.rs`** — `call_stdlib_function()` Rust→Starlark callback bridge
- **`execute.rs`** — `resolve_smart_detect_descriptor()` + `try_fallback_asset_url()` + `expand_asset_template()`
- **`github.rs`** (vx-version-fetcher) — `GitHubAssetInfo` struct + `fetch_release_assets()` static method
- **`provider_templates.star`** — `github_smart_provider()` template
- **`provider.star`** — Re-export `github_smart_provider`
- **Tests** — 3 provider template integration tests + 31 scoring unit tests

### Architecture
```
Provider.star  ──download_url──→  github_smart_detect descriptor
                                        │
Rust (execute.rs)                       ▼
  1. fetch_release_assets()  ←── GitHub API (GET /repos/:owner/:repo/releases/tags/:tag)
  2. call_stdlib_function()   ←── Starlark (detect_best_asset → score_asset)
  3. return best URL or fallback to explicit template
```

## Test plan
- [x] `cargo test -p vx-starlark` — all tests pass
- [x] `cargo test -p vx-version-fetcher` — all tests pass
- [x] `cargo build` — full build passes
- [x] 31 smart_detect unit tests (exclusion, version, OS, arch, libc, format, keywords, integration)
- [x] 3 template integration tests (descriptor shape, minimal config, install_layout)