### PR TITLE
feat(ai): add vx ai headroom CLI skeleton with bridge runner

### DIFF
--- a/crates/vx-cli/src/cli.rs
+++ b/crates/vx-cli/src/cli.rs
@@ -1604,7 +1604,7 @@ pub enum HeadroomCommand {
         #[arg(long)]
         dry_run: bool,
         /// Write MCP configuration to agent config files
-        #[arg(long, conflicts_with = "dry_run")]
+        #[arg(long, overrides_with = "dry_run")]
         apply: bool,
         /// Proxy port (default: 8787)
         #[arg(long, default_value = "8787")]

--- a/crates/vx-cli/src/commands/ai.rs
+++ b/crates/vx-cli/src/commands/ai.rs
@@ -988,7 +988,10 @@ async fn handle_headroom_install(
         UI::hint(
             "Try running manually: vx uv tool install --python <version> --from 'headroom-ai[proxy]==<version>' headroom",
         );
-        std::process::exit(code);
+        return Err(anyhow::anyhow!(
+            "headroom install failed with exit code {}",
+            code
+        ));
     }
 
     UI::success(&format!(
@@ -1192,7 +1195,7 @@ async fn handle_headroom_doctor(quick: bool, json: bool, port: u16, mcp_port: u1
 /// Handle `vx ai headroom setup` — generate MCP config templates.
 ///
 /// Stub in PIP-601; full implementation in PIP-604.
-async fn handle_headroom_setup(
+pub async fn handle_headroom_setup(
     agents: &[String],
     _dry_run: bool,
     apply: bool,
@@ -1290,7 +1293,7 @@ async fn handle_headroom_mcp(_ctx: &CommandContext, command: &HeadroomMcpCommand
             UI::hint(
                 "Run 'vx ai headroom install' first, then 'vx ai headroom mcp test' to verify.",
             );
-            Ok(())
+            Err(anyhow::anyhow!("headroom mcp stdio not yet implemented"))
         }
         HeadroomMcpCommand::Test {
             url,

--- a/crates/vx-cli/src/commands/ai.rs
+++ b/crates/vx-cli/src/commands/ai.rs
@@ -896,135 +896,6 @@ const DEFAULT_PYTHON_VERSION: &str = "3.11";
 /// Default mcpcall version
 #[allow(dead_code)]
 const DEFAULT_MCPCALL_VERSION: &str = "0.4.0";
-/// Default proxy host
-const DEFAULT_PROXY_HOST: &str = "127.0.0.1";
-/// Default proxy port
-#[allow(dead_code)]
-const DEFAULT_PROXY_PORT: u16 = 8787;
-
-// ---------------------------------------------------------------------------
-// Proxy state management helpers
-// ---------------------------------------------------------------------------
-
-/// Returns the headroom state directory: `~/.vx/state/headroom/`
-fn headroom_state_dir() -> Result<std::path::PathBuf> {
-    let home = dirs::home_dir().context("Could not determine home directory")?;
-    Ok(home.join(".vx").join("state").join("headroom"))
-}
-
-/// Returns the PID file path for a given proxy port
-fn proxy_pid_path(port: u16) -> Result<std::path::PathBuf> {
-    let dir = headroom_state_dir()?;
-    std::fs::create_dir_all(&dir)
-        .with_context(|| format!("Failed to create state directory: {}", dir.display()))?;
-    Ok(dir.join(format!("proxy-{}.pid", port)))
-}
-
-/// Returns the default log file path for a given proxy port
-fn proxy_log_path(port: u16) -> Result<std::path::PathBuf> {
-    let dir = headroom_state_dir()?;
-    std::fs::create_dir_all(&dir)
-        .with_context(|| format!("Failed to create state directory: {}", dir.display()))?;
-    Ok(dir.join(format!("proxy-{}.log", port)))
-}
-
-/// Reads a PID from a PID file. Returns `None` if the file does not exist or is unreadable.
-fn read_pid(path: &std::path::Path) -> Option<u32> {
-    let content = std::fs::read_to_string(path).ok()?;
-    content.trim().parse::<u32>().ok()
-}
-
-/// Checks whether a process with the given PID is running on this platform.
-#[cfg(unix)]
-fn is_process_running(pid: u32) -> bool {
-    unsafe { libc::kill(pid as i32, 0) == 0 }
-}
-
-#[cfg(windows)]
-fn is_process_running(pid: u32) -> bool {
-    let output = std::process::Command::new("tasklist")
-        .args(["/FI", &format!("PID eq {}", pid)])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .output();
-    match output {
-        Ok(out) => {
-            let stdout = String::from_utf8_lossy(&out.stdout);
-            stdout.contains(&format!("{}", pid))
-        }
-        Err(_) => false,
-    }
-}
-
-/// Tries to connect to the proxy's TCP port. Returns `Ok` if the port is reachable.
-fn check_port(host: &str, port: u16) -> Result<()> {
-    use std::net::TcpStream;
-    use std::time::Duration;
-    let addr = format!("{}:{}", host, port);
-    TcpStream::connect_timeout(&addr.parse()?, Duration::from_secs(2))
-        .with_context(|| format!("Port {}:{} is not reachable", host, port))?;
-    Ok(())
-}
-
-/// Performs a minimal HTTP health check: `GET /health`. Returns `true` if status is 200 OK.
-fn check_health_endpoint(host: &str, port: u16) -> bool {
-    use std::io::{Read, Write};
-    use std::net::TcpStream;
-    use std::time::Duration;
-
-    let addr = format!("{}:{}", host, port);
-    let mut stream =
-        match TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(2)) {
-            Ok(s) => s,
-            Err(_) => return false,
-        };
-    stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
-    stream.set_write_timeout(Some(Duration::from_secs(2))).ok();
-
-    let request = format!(
-        "GET /health HTTP/1.0\r\nHost: {}:{}\r\nConnection: close\r\n\r\n",
-        host, port
-    );
-    if stream.write_all(request.as_bytes()).is_err() {
-        return false;
-    }
-    let mut response = String::new();
-    if stream.read_to_string(&mut response).is_err() {
-        return false;
-    }
-    response.contains("200 OK")
-}
-
-/// Build the `headroom proxy` command with the given arguments.
-/// Returns the command and a human-readable label.
-fn build_proxy_command(
-    host: &str,
-    port: u16,
-    log_file: Option<&str>,
-    no_optimize: bool,
-) -> (std::process::Command, String) {
-    let mut cmd = std::process::Command::new("headroom");
-    cmd.args(["proxy", "--host", host, "--port", &port.to_string()]);
-
-    if no_optimize {
-        cmd.arg("--no-optimize");
-    }
-
-    // Headroom telemetry is disabled by default per PIP-584 product decision
-    cmd.env("HEADROOM_TELEMETRY", "off");
-
-    let log_path = if let Some(lf) = log_file {
-        std::path::PathBuf::from(lf)
-    } else {
-        proxy_log_path(port).unwrap_or_else(|_| std::path::PathBuf::from("headroom-proxy.log"))
-    };
-
-    cmd.arg("--log-file");
-    cmd.arg(log_path.to_string_lossy().as_ref());
-
-    let label = format!("headroom proxy --host {} --port {}", host, port);
-    (cmd, label)
-}
 
 /// Handle `vx ai headroom` command — dispatches to subcommands.
 pub async fn handle_headroom(ctx: &CommandContext, command: &HeadroomCommand) -> Result<()> {
@@ -1270,99 +1141,7 @@ async fn handle_headroom_doctor(quick: bool, json: bool, port: u16, mcp_port: u1
 /// Handle `vx ai headroom setup` — generate MCP config templates.
 ///
 /// Stub in PIP-601; full implementation in PIP-604.
-// ---------------------------------------------------------------------------
-// Headroom setup: MCP config templates for AI agents
-// ---------------------------------------------------------------------------
-
-/// MCP server entry for headroom — what gets written into agent configs.
-#[derive(Debug, serde::Serialize)]
-struct HeadroomMcpEntry {
-    command: &'static str,
-    args: Vec<&'static str>,
-    env: std::collections::BTreeMap<&'static str, &'static str>,
-}
-
-fn headroom_mcp_entry() -> HeadroomMcpEntry {
-    let mut env = std::collections::BTreeMap::new();
-    env.insert("HEADROOM_TELEMETRY", "off");
-    HeadroomMcpEntry {
-        command: "vx",
-        args: vec!["ai", "headroom", "mcp", "stdio"],
-        env,
-    }
-}
-
-/// Agent MCP config target — maps agent name to config file path (relative to CWD).
-struct McpAgentTarget {
-    name: &'static str,
-    config_path: &'static str,
-}
-
-const MCP_AGENT_TARGETS: &[McpAgentTarget] = &[
-    McpAgentTarget {
-        name: "codex",
-        config_path: ".codex/mcp.json",
-    },
-    McpAgentTarget {
-        name: "claude-code",
-        config_path: ".claude/settings.json",
-    },
-    McpAgentTarget {
-        name: "cursor",
-        config_path: ".cursor/mcp.json",
-    },
-];
-
-/// Format a single MCP server entry as a pretty-printed JSON snippet.
-fn format_mcp_snippet(entry: &HeadroomMcpEntry) -> Result<String> {
-    let mut servers = serde_json::Map::new();
-    servers.insert("headroom".to_string(), serde_json::to_value(entry)?);
-    let mut root = serde_json::Map::new();
-    root.insert("mcpServers".to_string(), serde_json::Value::Object(servers));
-    serde_json::to_string_pretty(&serde_json::Value::Object(root))
-        .context("Failed to serialize MCP config")
-}
-
-/// Merge the headroom MCP entry into an existing config file.
-///
-/// Reads the file (JSON object), sets `mcpServers.headroom`, writes back.
-/// If the file doesn't exist, creates it fresh.
-fn apply_mcp_config(path: &std::path::Path, entry: &HeadroomMcpEntry) -> Result<()> {
-    let mut root: serde_json::Value = if path.exists() {
-        let content = std::fs::read_to_string(path)
-            .with_context(|| format!("Failed to read {}", path.display()))?;
-        serde_json::from_str(&content).with_context(|| {
-            format!(
-                "{} is not valid JSON — refusing to overwrite. Fix or remove the file before retrying.",
-                path.display()
-            )
-        })?
-    } else {
-        serde_json::Value::Object(Default::default())
-    };
-
-    // Ensure mcpServers exists
-    let mcp_servers = root
-        .as_object_mut()
-        .context("Config file is not a JSON object")?
-        .entry("mcpServers")
-        .or_insert_with(|| serde_json::Value::Object(Default::default()));
-
-    mcp_servers["headroom"] = serde_json::to_value(entry)?;
-
-    // Create parent directory if needed
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create {}", parent.display()))?;
-    }
-
-    std::fs::write(path, serde_json::to_string_pretty(&root)? + "\n")
-        .with_context(|| format!("Failed to write {}", path.display()))?;
-
-    Ok(())
-}
-
-pub async fn handle_headroom_setup(
+async fn handle_headroom_setup(
     agents: &[String],
     _dry_run: bool,
     apply: bool,
@@ -1372,104 +1151,36 @@ pub async fn handle_headroom_setup(
 ) -> Result<()> {
     UI::header("headroom setup");
     println!();
-
-    // Resolve target agents
-    let targets: Vec<&McpAgentTarget> = if agents.is_empty() {
-        // Default: all three
-        MCP_AGENT_TARGETS.iter().collect()
-    } else {
-        agents
-            .iter()
-            .filter_map(|name| MCP_AGENT_TARGETS.iter().find(|t| t.name == name.as_str()))
-            .collect()
-    };
-
-    if targets.is_empty() {
-        UI::warn("No matching agents found. Supported: codex, claude-code, cursor.");
-        return Ok(());
-    }
-
-    let entry = headroom_mcp_entry();
-    let snippet = format_mcp_snippet(&entry)?;
-    let cwd = std::env::current_dir().context("Failed to get current directory")?;
-
+    UI::info("setup: not yet implemented (PIP-604)");
     UI::info(&format!(
-        "MCP command: {} {}",
-        entry.command,
-        entry.args.join(" ")
+        "Would configure MCP for agents: {}",
+        if agents.is_empty() {
+            "codex, claude-code, cursor (default)"
+        } else {
+            ""
+        }
     ));
+    if !agents.is_empty() {
+        UI::info(&format!("  requested agents: {}", agents.join(", ")));
+    }
     UI::info(&format!("  proxy port: {}", port));
     UI::info(&format!("  MCP port: {}", mcp_port));
     UI::info(&format!("  headroom version: {}", headroom_version));
-    println!();
-
-    if apply {
-        UI::info("Applying MCP configuration...");
-        println!();
-
-        let mut errors: Vec<String> = Vec::new();
-        for target in &targets {
-            let config_path = cwd.join(target.config_path);
-            match apply_mcp_config(&config_path, &entry) {
-                Ok(()) => {
-                    UI::success(&format!(
-                        "{}: updated {}",
-                        target.name,
-                        config_path.display()
-                    ));
-                }
-                Err(e) => {
-                    let msg = format!(
-                        "{}: failed to update {} — {}",
-                        target.name,
-                        config_path.display(),
-                        e
-                    );
-                    UI::error(&msg);
-                    errors.push(msg);
-                }
-            }
+    UI::info(&format!(
+        "  mode: {}",
+        if apply {
+            "--apply"
+        } else {
+            "--dry-run (default)"
         }
-        if !errors.is_empty() {
-            return Err(anyhow::anyhow!(
-                "Failed to write {} agent config(s):\n{}",
-                errors.len(),
-                errors.join("\n")
-            ));
-        }
-    } else {
-        // dry-run (default)
-        UI::info("Dry-run mode. Use --apply to write config files.");
-        println!();
-
-        for target in &targets {
-            let config_path = cwd.join(target.config_path);
-            let status = if config_path.exists() {
-                "(exists — would merge)"
-            } else {
-                "(new file)"
-            };
-            UI::info(&format!(
-                "{}: {} {}",
-                target.name,
-                config_path.display(),
-                status
-            ));
-        }
-
-        println!();
-        UI::header("Configuration to be written");
-        println!();
-        println!("{}", snippet);
-    }
-
+    ));
+    UI::hint("This command will be fully implemented in PIP-604.");
     Ok(())
 }
 
 /// Handle `vx ai headroom proxy` — dispatch to proxy subcommands.
 ///
-/// Manages the headroom proxy lifecycle: start (detached or foreground),
-/// status (process + health probe), and stop.
+/// Stubs in PIP-601; full implementation in PIP-602.
 async fn handle_headroom_proxy(command: &HeadroomProxyCommand) -> Result<()> {
     match command {
         HeadroomProxyCommand::Start {
@@ -1481,243 +1192,33 @@ async fn handle_headroom_proxy(command: &HeadroomProxyCommand) -> Result<()> {
         } => {
             UI::header("headroom proxy start");
             println!();
-
-            // Check if already running
-            let pid_path = proxy_pid_path(*port)?;
-            if let Some(pid) = read_pid(&pid_path) {
-                if is_process_running(pid) {
-                    UI::warn(&format!(
-                        "A headroom proxy appears to be running on port {} (PID {})",
-                        port, pid
-                    ));
-                    UI::hint("Run 'vx ai headroom proxy stop' to stop it first.");
-                    return Ok(());
-                }
+            UI::info("proxy start: not yet implemented (PIP-602)");
+            UI::info(&format!("  host: {}", host));
+            UI::info(&format!("  port: {}", port));
+            UI::info(&format!("  foreground: {}", foreground));
+            if let Some(log) = log_file {
+                UI::info(&format!("  log file: {}", log));
             }
-
-            // Verify headroom is installed
-            UI::step("Checking headroom availability...");
-            let version_check = std::process::Command::new("headroom")
-                .arg("--version")
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .output();
-
-            match version_check {
-                Ok(out) if out.status.success() => {
-                    let v = String::from_utf8_lossy(&out.stdout);
-                    UI::success(&format!("headroom: {}", v.trim()));
-                }
-                _ => {
-                    UI::error("headroom is not installed or not in PATH");
-                    UI::hint("Run 'vx ai headroom install' to install headroom-ai[proxy].");
-                    return Ok(());
-                }
-            }
-
-            let (mut cmd, _label) =
-                build_proxy_command(host, *port, log_file.as_deref(), *no_optimize);
-
-            if *foreground {
-                UI::info(&format!(
-                    "Starting headroom proxy in foreground on {}:{}...",
-                    host, port
-                ));
-                let status = cmd
-                    .stdin(std::process::Stdio::inherit())
-                    .stdout(std::process::Stdio::inherit())
-                    .stderr(std::process::Stdio::inherit())
-                    .status()
-                    .context("Failed to start headroom proxy in foreground")?;
-
-                if !status.success() {
-                    UI::error(&format!(
-                        "headroom proxy exited with code: {:?}",
-                        status.code()
-                    ));
-                }
-            } else {
-                UI::info(&format!(
-                    "Starting headroom proxy (detached) on {}:{}...",
-                    host, port
-                ));
-
-                let child = cmd
-                    .stdin(std::process::Stdio::null())
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .spawn()
-                    .context("Failed to spawn headroom proxy process")?;
-
-                let pid = child.id();
-                std::fs::write(&pid_path, pid.to_string())
-                    .with_context(|| format!("Failed to write PID file: {}", pid_path.display()))?;
-
-                UI::success(&format!(
-                    "headroom proxy started (PID {}) on {}:{}",
-                    pid, host, port
-                ));
-                UI::item(&format!("PID file: {}", pid_path.display()));
-
-                let log = log_file
-                    .as_deref()
-                    .map(std::path::PathBuf::from)
-                    .unwrap_or_else(|| {
-                        proxy_log_path(*port)
-                            .unwrap_or_else(|_| std::path::PathBuf::from("headroom-proxy.log"))
-                    });
-                UI::item(&format!("Log file: {}", log.display()));
-
-                // Verify the proxy responds
-                UI::step("Waiting for proxy to become ready...");
-                for i in 1..=10 {
-                    if check_port(host, *port).is_ok() && check_health_endpoint(host, *port) {
-                        UI::success("headroom proxy is healthy and accepting connections");
-                        break;
-                    }
-                    if i == 10 {
-                        UI::warn("headroom proxy started but health check timed out");
-                        UI::hint("Check logs and run 'vx ai headroom proxy status' to diagnose.");
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(500));
-                }
-            }
+            UI::info(&format!("  optimize: {}", !no_optimize));
+            UI::hint("This command will be fully implemented in PIP-602.");
         }
-
         HeadroomProxyCommand::Status { port, json } => {
-            let pid_path = proxy_pid_path(*port)?;
-            let pid = read_pid(&pid_path);
-            let running = pid.map_or(false, is_process_running);
-            let port_open = check_port(DEFAULT_PROXY_HOST, *port).is_ok();
-            let healthy = port_open && check_health_endpoint(DEFAULT_PROXY_HOST, *port);
-
+            UI::header("headroom proxy status");
+            println!();
+            UI::info("proxy status: not yet implemented (PIP-602)");
+            UI::info(&format!("  checking port: {}", port));
             if *json {
-                let status = if healthy {
-                    "healthy"
-                } else if running && port_open {
-                    "unhealthy"
-                } else if running {
-                    "not_listening"
-                } else if pid.is_some() {
-                    "stale_pid"
-                } else {
-                    "not_running"
-                };
-                println!(
-                    "{}",
-                    serde_json::json!({
-                        "status": status,
-                        "port": port,
-                        "pid": pid,
-                        "process_running": running,
-                        "port_open": port_open,
-                        "health_check": healthy,
-                        "pid_file": pid_path.display().to_string(),
-                    })
-                );
-            } else {
-                UI::header("headroom proxy status");
-                println!();
-
-                match (running, port_open, healthy) {
-                    (true, true, true) => {
-                        UI::success(&format!(
-                            "headroom proxy is running on port {} (PID {}) — healthy",
-                            port,
-                            pid.unwrap()
-                        ));
-                    }
-                    (true, true, false) => {
-                        UI::warn("headroom proxy is running but health check failed");
-                        UI::item(&format!("Port {} is open, PID {}", port, pid.unwrap()));
-                        UI::hint("Check the proxy logs for errors.");
-                    }
-                    (true, false, _) => {
-                        UI::warn("headroom proxy process exists but port is not open");
-                        UI::item(&format!("PID: {} (found in pid file)", pid.unwrap()));
-                    }
-                    (false, _, _) if pid.is_some() => {
-                        UI::warn(&format!(
-                            "headroom proxy is not running (stale PID file for {})",
-                            pid.unwrap()
-                        ));
-                        UI::hint(&format!("Remove stale PID file: {}", pid_path.display()));
-                    }
-                    _ => {
-                        UI::info("headroom proxy is not running");
-                    }
-                }
-
-                UI::item(&format!("Port: {}", port));
-                UI::item(&format!("PID file: {}", pid_path.display()));
+                println!("{}", serde_json::json!({"status": "unknown", "port": port}));
             }
+            UI::hint("This command will be fully implemented in PIP-602.");
         }
-
         HeadroomProxyCommand::Stop { port } => {
             UI::header("headroom proxy stop");
             println!();
-
-            let pid_path = proxy_pid_path(*port)?;
-            let pid = read_pid(&pid_path);
-
-            match pid {
-                Some(p) if is_process_running(p) => {
-                    UI::info(&format!(
-                        "Stopping headroom proxy on port {} (PID {})...",
-                        port, p
-                    ));
-                    kill_process(p)?;
-                    let _ = std::fs::remove_file(&pid_path);
-                    UI::success(&format!("headroom proxy (PID {}) stopped", p));
-                }
-                Some(p) => {
-                    UI::warn(&format!(
-                        "PID {} found in PID file but process is not running (stale PID)",
-                        p
-                    ));
-                    let _ = std::fs::remove_file(&pid_path);
-                    UI::info("Cleaned up stale PID file.");
-                }
-                None => {
-                    // Try to find by port in use
-                    if check_port(DEFAULT_PROXY_HOST, *port).is_ok() {
-                        UI::warn(&format!("Port {} is in use but no PID file found", port));
-                        UI::hint(
-                            "The proxy may have been started outside of vx. Stop it manually.",
-                        );
-                    } else {
-                        UI::info("headroom proxy is not running.");
-                    }
-                }
-            }
+            UI::info("proxy stop: not yet implemented (PIP-602)");
+            UI::info(&format!("  stopping on port: {}", port));
+            UI::hint("This command will be fully implemented in PIP-602.");
         }
-    }
-    Ok(())
-}
-
-/// Kill a process by PID. Platform-specific implementation.
-#[cfg(unix)]
-fn kill_process(pid: u32) -> Result<()> {
-    unsafe {
-        if libc::kill(pid as i32, libc::SIGTERM) != 0 {
-            let err = std::io::Error::last_os_error();
-            anyhow::bail!("Failed to send SIGTERM to PID {}: {}", pid, err);
-        }
-    }
-    Ok(())
-}
-
-#[cfg(windows)]
-fn kill_process(pid: u32) -> Result<()> {
-    let status = std::process::Command::new("taskkill")
-        .args(["/PID", &pid.to_string(), "/F"])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .with_context(|| format!("Failed to run taskkill for PID {}", pid))?;
-
-    if !status.success() {
-        anyhow::bail!("taskkill failed for PID {}", pid);
     }
     Ok(())
 }

--- a/crates/vx-cli/src/commands/ai.rs
+++ b/crates/vx-cli/src/commands/ai.rs
@@ -1003,7 +1003,7 @@ async fn handle_headroom_install(
     ));
 
     let mcpcall_status = std::process::Command::new(&vx_exe)
-        .args(["install", "mcpcall", mcpcall_version])
+        .args(["install", &format!("mcpcall@{}", mcpcall_version)])
         .status()
         .context("Failed to install mcpcall")?;
 
@@ -1032,33 +1032,41 @@ async fn handle_headroom_install(
 /// Handle `vx ai headroom doctor` — environment diagnostic checks.
 ///
 /// Three-layer check: environment, proxy, MCP.
-/// This is a stub in PIP-601; full implementation in PIP-603.
+/// Environment layer is fully implemented; proxy and MCP layers are stubs (PIP-602/PIP-603).
+/// When `--json` is set, outputs pure machine-readable JSON on stdout.
 async fn handle_headroom_doctor(quick: bool, json: bool, port: u16, mcp_port: u16) -> Result<()> {
     let vx_exe = std::env::current_exe().context("Could not determine vx executable path")?;
 
-    UI::header("headroom doctor");
+    if !json {
+        UI::header("headroom doctor");
+        println!();
+        UI::info("--- Environment ---");
+    }
 
-    // Layer 1: Environment checks
-    println!();
-    UI::info("--- Environment ---");
-
-    // Check uv availability
+    // Layer 1: Environment checks (always run — data collection)
     let uv_check = std::process::Command::new(&vx_exe)
         .args(["uv", "--version"])
         .output();
-    match uv_check {
+    let uv_version = match &uv_check {
         Ok(output) if output.status.success() => {
             let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            UI::success(&format!("uv: {}", ver));
+            if !json {
+                UI::success(&format!("uv: {}", ver));
+            }
+            Some(ver)
         }
-        _ => UI::error("uv: not available"),
-    }
+        _ => {
+            if !json {
+                UI::error("uv: not available");
+            }
+            None
+        }
+    };
 
-    // Check python availability
     let py_check = std::process::Command::new(&vx_exe)
         .args(["python", "--version"])
         .output();
-    match py_check {
+    let py_version = match &py_check {
         Ok(output) if output.status.success() => {
             let ver = String::from_utf8_lossy(&output.stderr).trim().to_string();
             let ver = if ver.is_empty() {
@@ -1066,12 +1074,19 @@ async fn handle_headroom_doctor(quick: bool, json: bool, port: u16, mcp_port: u1
             } else {
                 ver
             };
-            UI::success(&format!("python: {}", ver));
+            if !json {
+                UI::success(&format!("python: {}", ver));
+            }
+            Some(ver)
         }
-        _ => UI::warn("python: check skipped (may not be installed via vx)"),
-    }
+        _ => {
+            if !json {
+                UI::warn("python: check skipped (may not be installed via vx)");
+            }
+            None
+        }
+    };
 
-    // Check headroom availability
     let hr_check = std::process::Command::new(&vx_exe)
         .args([
             "uv",
@@ -1083,56 +1098,92 @@ async fn handle_headroom_doctor(quick: bool, json: bool, port: u16, mcp_port: u1
             "--version",
         ])
         .output();
-    match hr_check {
+    let hr_version = match &hr_check {
         Ok(output) if output.status.success() => {
             let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            UI::success(&format!("headroom-ai: {}", ver));
+            if !json {
+                UI::success(&format!("headroom-ai: {}", ver));
+            }
+            Some(ver)
         }
-        _ => UI::error(&format!(
-            "headroom-ai[proxy] {}: not installed",
-            DEFAULT_HEADROOM_VERSION
-        )),
-    }
+        _ => {
+            if !json {
+                UI::error(&format!(
+                    "headroom-ai[proxy] {}: not installed",
+                    DEFAULT_HEADROOM_VERSION
+                ));
+            }
+            None
+        }
+    };
 
-    // Check mcpcall availability
     let mcpcall_check = std::process::Command::new(&vx_exe)
         .args(["mcpcall", "--version"])
         .output();
-    match mcpcall_check {
+    let mcpcall_version = match &mcpcall_check {
         Ok(output) if output.status.success() => {
             let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            UI::success(&format!("mcpcall: {}", ver));
+            if !json {
+                UI::success(&format!("mcpcall: {}", ver));
+            }
+            Some(ver)
         }
-        _ => UI::warn("mcpcall: not installed (run 'vx ai headroom install' to set up)"),
+        _ => {
+            if !json {
+                UI::warn("mcpcall: not installed (run 'vx ai headroom install' to set up)");
+            }
+            None
+        }
+    };
+
+    // Build and emit JSON output when requested — always before any early return
+    if json {
+        let mut env = serde_json::Map::new();
+        env.insert("uv".into(), serde_json::json!(uv_version));
+        env.insert("python".into(), serde_json::json!(py_version));
+        env.insert("headroom".into(), serde_json::json!(hr_version));
+        env.insert("mcpcall".into(), serde_json::json!(mcpcall_version));
+
+        let mut result = serde_json::Map::new();
+        result.insert("environment".into(), serde_json::Value::Object(env));
+        result.insert(
+            "headroom_version".into(),
+            serde_json::json!(DEFAULT_HEADROOM_VERSION),
+        );
+
+        if !quick {
+            result.insert(
+                "proxy".into(),
+                serde_json::json!({"status": "not_implemented", "port": port}),
+            );
+            result.insert(
+                "mcp".into(),
+                serde_json::json!({"status": "not_implemented", "port": mcp_port}),
+            );
+        }
+
+        println!("{}", serde_json::Value::Object(result));
     }
 
     if quick {
-        UI::hint("Quick check complete. Run without --quick for proxy and MCP checks.");
+        if !json {
+            UI::hint("Quick check complete. Run without --quick for proxy and MCP checks.");
+        }
         return Ok(());
     }
 
-    // Layer 2: Proxy checks
-    println!();
-    UI::info(&format!("--- Proxy (port {}) ---", port));
-    UI::info("proxy check: not yet implemented (PIP-602)");
-    UI::hint("Run 'vx ai headroom proxy start' to start the proxy service.");
+    if !json {
+        // Layer 2: Proxy checks
+        println!();
+        UI::info(&format!("--- Proxy (port {}) ---", port));
+        UI::info("proxy check: not yet implemented (PIP-602)");
+        UI::hint("Run 'vx ai headroom proxy start' to start the proxy service.");
 
-    // Layer 3: MCP checks
-    println!();
-    UI::info(&format!("--- MCP (port {}) ---", mcp_port));
-    UI::info("MCP check: not yet implemented (PIP-603)");
-    UI::hint("Run 'vx ai headroom mcp test' to validate MCP tools.");
-
-    if json {
-        println!(
-            "{}",
-            serde_json::json!({
-                "status": "ok",
-                "headroom_version": DEFAULT_HEADROOM_VERSION,
-                "proxy_port": port,
-                "mcp_port": mcp_port,
-            })
-        );
+        // Layer 3: MCP checks
+        println!();
+        UI::info(&format!("--- MCP (port {}) ---", mcp_port));
+        UI::info("MCP check: not yet implemented (PIP-603)");
+        UI::hint("Run 'vx ai headroom mcp test' to validate MCP tools.");
     }
 
     Ok(())
@@ -1203,14 +1254,18 @@ async fn handle_headroom_proxy(command: &HeadroomProxyCommand) -> Result<()> {
             UI::hint("This command will be fully implemented in PIP-602.");
         }
         HeadroomProxyCommand::Status { port, json } => {
-            UI::header("headroom proxy status");
-            println!();
-            UI::info("proxy status: not yet implemented (PIP-602)");
-            UI::info(&format!("  checking port: {}", port));
             if *json {
-                println!("{}", serde_json::json!({"status": "unknown", "port": port}));
+                println!(
+                    "{}",
+                    serde_json::json!({"status": "not_implemented", "port": port})
+                );
+            } else {
+                UI::header("headroom proxy status");
+                println!();
+                UI::info("proxy status: not yet implemented (PIP-602)");
+                UI::info(&format!("  checking port: {}", port));
+                UI::hint("This command will be fully implemented in PIP-602.");
             }
-            UI::hint("This command will be fully implemented in PIP-602.");
         }
         HeadroomProxyCommand::Stop { port } => {
             UI::header("headroom proxy stop");

--- a/crates/vx-cli/tests/headroom_cli_tests.rs
+++ b/crates/vx-cli/tests/headroom_cli_tests.rs
@@ -1,0 +1,373 @@
+//! Tests for `vx ai headroom` CLI parsing and subcommand routing.
+
+use clap::Parser;
+use vx_cli::cli::*;
+
+// ============================================
+// Headroom root command
+// ============================================
+
+#[test]
+fn test_headroom_root_parses() {
+    // Headroom requires a subcommand; parse with one
+    let args = vec!["vx", "ai", "headroom", "doctor"];
+    let cli = Cli::try_parse_from(args).unwrap();
+    assert!(matches!(cli.command, Some(Commands::Ai { .. })));
+}
+
+// ============================================
+// headroom install
+// ============================================
+
+#[test]
+fn test_headroom_install_defaults() {
+    let args = vec!["vx", "ai", "headroom", "install"];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Ai {
+        command:
+            AiCommand::Headroom(HeadroomCommand::Install {
+                version,
+                python,
+                mcpcall_version,
+                force,
+            }),
+    }) = cli.command
+    else {
+        panic!("unexpected command");
+    };
+    assert_eq!(version, "latest");
+    assert_eq!(python, "3.11");
+    assert_eq!(mcpcall_version, "0.4.0");
+    assert!(!force);
+}
+
+#[test]
+fn test_headroom_install_with_flags() {
+    let args = vec![
+        "vx",
+        "ai",
+        "headroom",
+        "install",
+        "--version",
+        "0.5.0",
+        "--python",
+        "3.12",
+        "--mcpcall-version",
+        "0.5.0",
+        "--force",
+    ];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Ai {
+        command:
+            AiCommand::Headroom(HeadroomCommand::Install {
+                version,
+                python,
+                mcpcall_version,
+                force,
+            }),
+    }) = cli.command
+    else {
+        panic!("unexpected command");
+    };
+    assert_eq!(version, "0.5.0");
+    assert_eq!(python, "3.12");
+    assert_eq!(mcpcall_version, "0.5.0");
+    assert!(force);
+}
+
+#[test]
+fn test_headroom_install_help() {
+    // clap Err(DisplayHelp) for --help; verify command routing without --help flag
+    let args = vec!["vx", "ai", "headroom", "install", "--force"];
+    let cli = Cli::try_parse_from(args).unwrap();
+    assert!(matches!(cli.command, Some(Commands::Ai { .. })));
+}
+
+// ============================================
+// headroom doctor
+// ============================================
+
+#[test]
+fn test_headroom_doctor_defaults() {
+    let args = vec!["vx", "ai", "headroom", "doctor"];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Ai {
+        command:
+            AiCommand::Headroom(HeadroomCommand::Doctor {
+                quick,
+                json,
+                port,
+                mcp_port,
+            }),
+    }) = cli.command
+    else {
+        panic!("unexpected command");
+    };
+    assert!(!quick);
+    assert!(!json);
+    assert_eq!(port, 8787);
+    assert_eq!(mcp_port, 8765);
+}
+
+#[test]
+fn test_headroom_doctor_quick() {
+    let args = vec!["vx", "ai", "headroom", "doctor", "--quick"];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Ai {
+        command: AiCommand::Headroom(HeadroomCommand::Doctor { quick, .. }),
+    }) = cli.command
+    else {
+        panic!("unexpected command");
+    };
+    assert!(quick);
+}
+
+#[test]
+fn test_headroom_doctor_json() {
+    let args = vec!["vx", "ai", "headroom", "doctor", "--json"];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Ai {
+        command: AiCommand::Headroom(HeadroomCommand::Doctor { json, .. }),
+    }) = cli.command
+    else {
+        panic!("unexpected command");
+    };
+    assert!(json);
+}
+
+#[test]
+fn test_headroom_doctor_json_quick() {
+    let args = vec!["vx", "ai", "headroom", "doctor", "--json", "--quick"];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Ai {
+        command: AiCommand::Headroom(HeadroomCommand::Doctor { quick, json, .. }),
+    }) = cli.command
+    else {
+        panic!("unexpected command");
+    };
+    assert!(quick);
+    assert!(json);
+}
+
+#[test]
+fn test_headroom_doctor_custom_ports() {
+    let args = vec![
+        "vx",
+        "ai",
+        "headroom",
+        "doctor",
+        "--port",
+        "9999",
+        "--mcp-port",
+        "8888",
+    ];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Ai {
+        command: AiCommand::Headroom(HeadroomCommand::Doctor { port, mcp_port, .. }),
+    }) = cli.command
+    else {
+        panic!("unexpected command");
+    };
+    assert_eq!(port, 9999);
+    assert_eq!(mcp_port, 8888);
+}
+
+// ============================================
+// headroom setup
+// ============================================
+
+#[test]
+fn test_headroom_setup_defaults() {
+    let args = vec!["vx", "ai", "headroom", "setup"];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Ai {
+        command:
+            AiCommand::Headroom(HeadroomCommand::Setup {
+                agent,
+                dry_run,
+                apply,
+                port,
+                mcp_port,
+                headroom_version,
+            }),
+    }) = cli.command
+    else {
+        panic!("unexpected command");
+    };
+    assert!(agent.is_empty());
+    assert!(!dry_run);
+    assert!(!apply);
+    assert_eq!(port, 8787);
+    assert_eq!(mcp_port, 8765);
+    assert_eq!(headroom_version, "latest");
+}
+
+#[test]
+fn test_headroom_setup_with_agents() {
+    let args = vec![
+        "vx",
+        "ai",
+        "headroom",
+        "setup",
+        "-a",
+        "codex",
+        "-a",
+        "claude-code",
+    ];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Ai {
+        command: AiCommand::Headroom(HeadroomCommand::Setup { agent, .. }),
+    }) = cli.command
+    else {
+        panic!("unexpected command");
+    };
+    assert_eq!(agent, vec!["codex", "claude-code"]);
+}
+
+#[test]
+fn test_headroom_setup_apply() {
+    let args = vec!["vx", "ai", "headroom", "setup", "--apply"];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Ai {
+        command: AiCommand::Headroom(HeadroomCommand::Setup { dry_run, apply, .. }),
+    }) = cli.command
+    else {
+        panic!("unexpected command");
+    };
+    assert!(!dry_run);
+    assert!(apply);
+}
+
+// ============================================
+// headroom proxy
+// ============================================
+
+#[test]
+fn test_headroom_proxy_start_defaults() {
+    let args = vec!["vx", "ai", "headroom", "proxy", "start"];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Ai {
+        command:
+            AiCommand::Headroom(HeadroomCommand::Proxy(HeadroomProxyCommand::Start {
+                host,
+                port,
+                foreground,
+                log_file,
+                no_optimize,
+            })),
+    }) = cli.command
+    else {
+        panic!("unexpected command");
+    };
+    assert_eq!(host, "127.0.0.1");
+    assert_eq!(port, 8787);
+    assert!(!foreground);
+    assert!(log_file.is_none());
+    assert!(!no_optimize);
+}
+
+#[test]
+fn test_headroom_proxy_status_defaults() {
+    let args = vec!["vx", "ai", "headroom", "proxy", "status"];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Ai {
+        command:
+            AiCommand::Headroom(HeadroomCommand::Proxy(HeadroomProxyCommand::Status { port, json })),
+    }) = cli.command
+    else {
+        panic!("unexpected command");
+    };
+    assert_eq!(port, 8787);
+    assert!(!json);
+}
+
+#[test]
+fn test_headroom_proxy_status_json() {
+    let args = vec!["vx", "ai", "headroom", "proxy", "status", "--json"];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Ai {
+        command:
+            AiCommand::Headroom(HeadroomCommand::Proxy(HeadroomProxyCommand::Status { json, .. })),
+    }) = cli.command
+    else {
+        panic!("unexpected command");
+    };
+    assert!(json);
+}
+
+#[test]
+fn test_headroom_proxy_stop() {
+    let args = vec!["vx", "ai", "headroom", "proxy", "stop", "--port", "9090"];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Ai {
+        command: AiCommand::Headroom(HeadroomCommand::Proxy(HeadroomProxyCommand::Stop { port })),
+    }) = cli.command
+    else {
+        panic!("unexpected command");
+    };
+    assert_eq!(port, 9090);
+}
+
+// ============================================
+// headroom mcp
+// ============================================
+
+#[test]
+fn test_headroom_mcp_stdio() {
+    let args = vec!["vx", "ai", "headroom", "mcp", "stdio"];
+    let cli = Cli::try_parse_from(args).unwrap();
+    assert!(matches!(
+        cli.command,
+        Some(Commands::Ai {
+            command: AiCommand::Headroom(HeadroomCommand::Mcp(HeadroomMcpCommand::Stdio))
+        })
+    ));
+}
+
+#[test]
+fn test_headroom_mcp_test_defaults() {
+    let args = vec!["vx", "ai", "headroom", "mcp", "test"];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Ai {
+        command:
+            AiCommand::Headroom(HeadroomCommand::Mcp(HeadroomMcpCommand::Test {
+                url,
+                json,
+                sample_file,
+            })),
+    }) = cli.command
+    else {
+        panic!("unexpected command");
+    };
+    assert_eq!(url, "http://127.0.0.1:8765/mcp");
+    assert!(!json);
+    assert!(sample_file.is_none());
+}
+
+#[test]
+fn test_headroom_mcp_test_json() {
+    let args = vec![
+        "vx",
+        "ai",
+        "headroom",
+        "mcp",
+        "test",
+        "--json",
+        "--sample-file",
+        "test_data.json",
+    ];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Ai {
+        command:
+            AiCommand::Headroom(HeadroomCommand::Mcp(HeadroomMcpCommand::Test {
+                json,
+                sample_file,
+                ..
+            })),
+    }) = cli.command
+    else {
+        panic!("unexpected command");
+    };
+    assert!(json);
+    assert_eq!(sample_file.unwrap(), "test_data.json");
+}


### PR DESCRIPTION
## Summary

Add the `vx ai headroom` CLI command tree as Phase 1 of headroom context compression integration (PIP-584). This provides the command skeleton and bridge runner infrastructure:

- **`vx ai headroom install`** — bridge runner delegates to `vx uv tool install --from 'headroom-ai[proxy]==<version>' headroom` with environment checks
- **`vx ai headroom doctor`** — three-layer diagnostic (environment/proxy/MCP), environment layer fully implemented
- **`vx ai headroom setup`** — MCP config template generator (stub, full in PIP-604)
- **`vx ai headroom proxy start|status|stop`** — proxy lifecycle management (stub, full in PIP-602)
- **`vx ai headroom mcp stdio|test`** — MCP operations (stub, full in PIP-603)

## Architecture

- New `HeadroomCommand`, `HeadroomProxyCommand`, `HeadroomMcpCommand` enums in `cli.rs`
- Dispatch wired through `AiCommand::Headroom` variant
- Bridge runner follows the same `std::process::Command` pattern as `handle_skills`
- Doctor's environment layer performs real checks (uv/python/headroom/mcpcall availability)

## Linked GitHub issues

- PIP-584: headroom integration feasibility (parent issue)
- PIP-601: this PR

## Test plan

- [x] `vx ai headroom --help` shows complete command tree
- [x] Each subcommand `--help` displays correctly
- [x] `vx ai headroom doctor --quick` performs real environment checks
- [x] `vx ai headroom setup --dry-run` stub works
- [x] `vx ai headroom proxy status` stub works
- [x] `vx cargo check -p vx-cli` clean
- [x] `vx cargo test -p vx-cli` passes