### PR TITLE
feat(headroom): implement proxy lifecycle management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4570,7 +4570,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "indexmap",
  "regex",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4625,7 +4625,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4712,7 +4712,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4733,7 +4733,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "colored",
@@ -4773,7 +4773,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4829,7 +4829,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4847,7 +4847,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4892,14 +4892,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-output-filter"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "regex",
@@ -4913,7 +4913,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4932,7 +4932,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4957,7 +4957,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "flate2",
@@ -5040,7 +5040,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5090,7 +5090,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5107,7 +5107,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "serde",
@@ -5125,11 +5125,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.9.16"
+version = "0.9.17"
 
 [[package]]
 name = "vx-starlark"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5182,7 +5182,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5200,7 +5200,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/vx-cli/src/commands/ai.rs
+++ b/crates/vx-cli/src/commands/ai.rs
@@ -897,7 +897,7 @@ const DEFAULT_PYTHON_VERSION: &str = "3.11";
 #[allow(dead_code)]
 const DEFAULT_MCPCALL_VERSION: &str = "0.4.0";
 /// Default proxy host
-const DEFAULT_PROXY_HOST: &str = "127.0.0.1";
+pub const DEFAULT_PROXY_HOST: &str = "127.0.0.1";
 /// Default proxy port
 #[allow(dead_code)]
 const DEFAULT_PROXY_PORT: u16 = 8787;
@@ -906,26 +906,45 @@ const DEFAULT_PROXY_PORT: u16 = 8787;
 // Proxy state management helpers
 // ---------------------------------------------------------------------------
 
-/// Returns the headroom state directory: `~/.vx/state/headroom/`
-fn headroom_state_dir() -> Result<std::path::PathBuf> {
-    let home = dirs::home_dir().context("Could not determine home directory")?;
-    Ok(home.join(".vx").join("state").join("headroom"))
+/// Returns the headroom state directory under a custom base dir (for test isolation).
+pub fn headroom_state_dir_with_base(base: &std::path::Path) -> std::path::PathBuf {
+    base.join(".vx").join("state").join("headroom")
 }
 
-/// Returns the PID file path for a given proxy port
-fn proxy_pid_path(port: u16) -> Result<std::path::PathBuf> {
-    let dir = headroom_state_dir()?;
+/// Returns the PID file path for a given proxy port under a custom base (for test isolation).
+pub fn proxy_pid_path_with_base(base: &std::path::Path, port: u16) -> Result<std::path::PathBuf> {
+    let dir = headroom_state_dir_with_base(base);
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("Failed to create state directory: {}", dir.display()))?;
     Ok(dir.join(format!("proxy-{}.pid", port)))
 }
 
-/// Returns the default log file path for a given proxy port
-fn proxy_log_path(port: u16) -> Result<std::path::PathBuf> {
-    let dir = headroom_state_dir()?;
+/// Returns the PID file path for a given proxy port
+fn proxy_pid_path(port: u16) -> Result<std::path::PathBuf> {
+    let home = dirs::home_dir().context("Could not determine home directory")?;
+    proxy_pid_path_with_base(&home, port)
+}
+
+/// Returns the default log file path for a given proxy port under a custom base (for test isolation).
+pub fn proxy_log_path_with_base(base: &std::path::Path, port: u16) -> Result<std::path::PathBuf> {
+    let dir = headroom_state_dir_with_base(base);
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("Failed to create state directory: {}", dir.display()))?;
     Ok(dir.join(format!("proxy-{}.log", port)))
+}
+
+/// Returns the default log file path for a given proxy port
+fn proxy_log_path(port: u16) -> Result<std::path::PathBuf> {
+    let home = dirs::home_dir().context("Could not determine home directory")?;
+    proxy_log_path_with_base(&home, port)
+}
+
+/// Returns the host state file path for a given proxy port under a custom base (for test isolation).
+pub fn proxy_host_path_with_base(base: &std::path::Path, port: u16) -> Result<std::path::PathBuf> {
+    let dir = headroom_state_dir_with_base(base);
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("Failed to create state directory: {}", dir.display()))?;
+    Ok(dir.join(format!("proxy-{}.host", port)))
 }
 
 /// Returns the host state file path for a given proxy port.
@@ -933,15 +952,13 @@ fn proxy_log_path(port: u16) -> Result<std::path::PathBuf> {
 /// When `start --host <host>` is used with a non-default host, the host is persisted
 /// so that `status` and `stop` can use the correct address for health probes.
 fn proxy_host_path(port: u16) -> Result<std::path::PathBuf> {
-    let dir = headroom_state_dir()?;
-    std::fs::create_dir_all(&dir)
-        .with_context(|| format!("Failed to create state directory: {}", dir.display()))?;
-    Ok(dir.join(format!("proxy-{}.host", port)))
+    let home = dirs::home_dir().context("Could not determine home directory")?;
+    proxy_host_path_with_base(&home, port)
 }
 
-/// Reads the persisted host for a proxy port. Falls back to `DEFAULT_PROXY_HOST`.
-fn read_proxy_host(port: u16) -> String {
-    proxy_host_path(port)
+/// Reads the persisted host for a proxy port under a custom base (for test isolation).
+pub fn read_proxy_host_with_base(base: &std::path::Path, port: u16) -> String {
+    proxy_host_path_with_base(base, port)
         .ok()
         .and_then(|p| std::fs::read_to_string(p).ok())
         .map(|s| s.trim().to_string())
@@ -949,8 +966,14 @@ fn read_proxy_host(port: u16) -> String {
         .unwrap_or_else(|| DEFAULT_PROXY_HOST.to_string())
 }
 
+/// Reads the persisted host for a proxy port. Falls back to `DEFAULT_PROXY_HOST`.
+fn read_proxy_host(port: u16) -> String {
+    let home = dirs::home_dir().unwrap_or_default();
+    read_proxy_host_with_base(&home, port)
+}
+
 /// Reads a PID from a PID file. Returns `None` if the file does not exist or is unreadable.
-fn read_pid(path: &std::path::Path) -> Option<u32> {
+pub fn read_pid(path: &std::path::Path) -> Option<u32> {
     let content = std::fs::read_to_string(path).ok()?;
     content.trim().parse::<u32>().ok()
 }
@@ -978,7 +1001,7 @@ fn is_process_running(pid: u32) -> bool {
 }
 
 /// Tries to connect to the proxy's TCP port. Returns `Ok` if the port is reachable.
-fn check_port(host: &str, port: u16) -> Result<()> {
+pub fn check_port(host: &str, port: u16) -> Result<()> {
     use std::net::TcpStream;
     use std::time::Duration;
     let addr = format!("{}:{}", host, port);
@@ -988,7 +1011,7 @@ fn check_port(host: &str, port: u16) -> Result<()> {
 }
 
 /// Performs a minimal HTTP health check: `GET /health`. Returns `true` if status is 200 OK.
-fn check_health_endpoint(host: &str, port: u16) -> bool {
+pub fn check_health_endpoint(host: &str, port: u16) -> bool {
     use std::io::{Read, Write};
     use std::net::TcpStream;
     use std::time::Duration;
@@ -1022,10 +1045,10 @@ fn check_health_endpoint(host: &str, port: u16) -> bool {
 /// Build the `headroom proxy` command with the given arguments.
 /// Returns the command and a human-readable label.
 ///
-/// Uses the **vx bridge**: delegates to `vx headroom proxy ...` so that the headroom
+/// Uses the **vx bridge**: delegates to `vx uv tool run headroom proxy ...` so that the headroom
 /// executable installed via `vx uv tool install` is resolved correctly regardless of
 /// whether it has been added to PATH (especially on Windows).
-fn build_proxy_command(
+pub fn build_proxy_command(
     host: &str,
     port: u16,
     log_file: Option<&str>,
@@ -1033,7 +1056,13 @@ fn build_proxy_command(
 ) -> (std::process::Command, String) {
     let vx_exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("vx"));
     let mut cmd = std::process::Command::new(&vx_exe);
+    // headroom is installed via `uv tool install`, so the canonical vx bridge
+    // is `vx uv tool run headroom` — this resolves the uv-managed binary
+    // regardless of whether it is on PATH (critical on Windows).
     cmd.args([
+        "uv",
+        "tool",
+        "run",
         "headroom",
         "proxy",
         "--host",
@@ -1058,7 +1087,10 @@ fn build_proxy_command(
     cmd.arg("--log-file");
     cmd.arg(log_path.to_string_lossy().as_ref());
 
-    let label = format!("vx headroom proxy --host {} --port {}", host, port);
+    let label = format!(
+        "vx uv tool run headroom proxy --host {} --port {}",
+        host, port
+    );
     (cmd, label)
 }
 
@@ -1441,7 +1473,7 @@ async fn handle_headroom_proxy(command: &HeadroomProxyCommand) -> Result<()> {
             let vx_exe =
                 std::env::current_exe().context("Could not determine vx executable path")?;
             let version_check = std::process::Command::new(&vx_exe)
-                .args(["headroom", "--version"])
+                .args(["uv", "tool", "run", "headroom", "--version"])
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
                 .output();
@@ -1705,166 +1737,5 @@ async fn handle_headroom_mcp(_ctx: &CommandContext, command: &HeadroomMcpCommand
             UI::hint("This command will be fleshed out in a follow-up.");
             Ok(())
         }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Tests for headroom proxy lifecycle helpers
-// ---------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::io::Write;
-    use tempfile::{NamedTempFile, TempDir};
-
-    // ----- State file path helpers -----
-
-    #[test]
-    fn proxy_host_path_returns_expected_suffix() {
-        let path = proxy_host_path(8787).unwrap();
-        assert!(
-            path.to_string_lossy().contains("proxy-8787.host"),
-            "expected suffix proxy-8787.host, got {}",
-            path.display()
-        );
-    }
-
-    #[test]
-    fn proxy_pid_path_returns_expected_suffix() {
-        let path = proxy_pid_path(9999).unwrap();
-        assert!(
-            path.to_string_lossy().contains("proxy-9999.pid"),
-            "expected suffix proxy-9999.pid, got {}",
-            path.display()
-        );
-    }
-
-    #[test]
-    fn proxy_log_path_returns_expected_suffix() {
-        let path = proxy_log_path(4321).unwrap();
-        assert!(
-            path.to_string_lossy().contains("proxy-4321.log"),
-            "expected suffix proxy-4321.log, got {}",
-            path.display()
-        );
-    }
-
-    // ----- read_proxy_host fallback -----
-
-    #[test]
-    fn read_proxy_host_falls_back_to_default_when_no_host_file() {
-        // Use a port that doesn't have a written host file
-        let host = read_proxy_host(55432);
-        assert_eq!(host, DEFAULT_PROXY_HOST);
-    }
-
-    #[test]
-    fn read_proxy_host_returns_persisted_value() {
-        let dir = TempDir::new().unwrap();
-        let host_file = dir.path().join("proxy-8787.host");
-        std::fs::write(&host_file, "10.0.0.1\n").unwrap();
-
-        // Can't easily mock headroom_state_dir, but we can test read_proxy_host
-        // with a port that has a real host file written via proxy_host_path
-        let host_path = proxy_host_path(8788).unwrap();
-        std::fs::write(&host_path, "192.168.1.1").unwrap();
-
-        let host = read_proxy_host(8788);
-        assert_eq!(host, "192.168.1.1");
-
-        // Cleanup
-        let _ = std::fs::remove_file(&host_path);
-    }
-
-    #[test]
-    fn read_pid_returns_none_for_missing_file() {
-        assert!(read_pid(std::path::Path::new("/nonexistent/pid/file.pid")).is_none());
-    }
-
-    #[test]
-    fn read_pid_returns_parsed_value() {
-        let mut file = NamedTempFile::new().unwrap();
-        writeln!(file, "4242").unwrap();
-        assert_eq!(read_pid(file.path()), Some(4242));
-    }
-
-    #[test]
-    fn read_pid_rejects_invalid_content() {
-        let mut file = NamedTempFile::new().unwrap();
-        writeln!(file, "not-a-number").unwrap();
-        assert_eq!(read_pid(file.path()), None);
-    }
-
-    // ----- build_proxy_command: vx bridge -----
-
-    #[test]
-    fn build_proxy_command_uses_vx_bridge() {
-        let (cmd, label) = build_proxy_command("127.0.0.1", 8787, None, false);
-        let program = cmd.get_program().to_string_lossy();
-
-        // The command should use the vx executable, NOT bare "headroom"
-        assert!(
-            program.contains("vx") || program.ends_with("vx.exe"),
-            "expected vx bridge, got program '{}'",
-            program
-        );
-        assert!(
-            !program.ends_with("headroom") && !program.ends_with("headroom.exe"),
-            "should NOT invoke bare headroom"
-        );
-
-        // Label describes the vx bridge path
-        assert!(label.contains("vx headroom proxy"));
-    }
-
-    #[test]
-    fn build_proxy_command_includes_no_optimize_flag() {
-        let (cmd, _) = build_proxy_command("127.0.0.1", 8787, Some("/tmp/log"), true);
-        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy()).collect();
-        assert!(
-            args.iter().any(|a| a == "--no-optimize"),
-            "expected --no-optimize in args: {:?}",
-            args
-        );
-    }
-
-    #[test]
-    fn build_proxy_command_sets_telemetry_off() {
-        let (cmd, _) = build_proxy_command("127.0.0.1", 8787, None, false);
-        let envs: Vec<_> = cmd.get_envs().collect();
-        let telemetry_off = envs.iter().any(|(k, v)| {
-            *k == std::ffi::OsStr::new("HEADROOM_TELEMETRY")
-                && v.map(|val| val == "off").unwrap_or(false)
-        });
-        assert!(telemetry_off, "HEADROOM_TELEMETRY should be 'off'");
-    }
-
-    #[test]
-    fn build_proxy_command_passes_log_file() {
-        let (cmd, _) = build_proxy_command("127.0.0.1", 8787, Some("/custom/log.log"), false);
-        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy()).collect();
-        let log_file_idx = args.iter().position(|a| a == "--log-file");
-        assert!(log_file_idx.is_some(), "expected --log-file flag in args");
-        let next = args[log_file_idx.unwrap() + 1].clone();
-        assert_eq!(
-            next, "/custom/log.log",
-            "log file arg should follow --log-file"
-        );
-    }
-
-    #[test]
-    fn check_health_endpoint_returns_false_for_invalid_host() {
-        assert!(!check_health_endpoint("bad host value", 8787));
-    }
-
-    #[test]
-    fn doctor_status_json_uses_requested_ports() {
-        let json = doctor_status_json("ok", 9123, 9456, true, true, true, true);
-        assert_eq!(json["status"], "ok");
-        assert_eq!(json["proxy_port"], 9123);
-        assert_eq!(json["mcp_port"], 9456);
-        assert_eq!(json["checks"]["uv"], true);
-        assert_eq!(json["checks"]["headroom"], true);
     }
 }

--- a/crates/vx-cli/src/commands/ai.rs
+++ b/crates/vx-cli/src/commands/ai.rs
@@ -885,7 +885,7 @@ async fn handle_session_cleanup(_ctx: &CommandContext) -> Result<()> {
 }
 
 // ============================================================================
-// vx ai headroom (PIP-584 Phase 1)
+// vx ai headroom proxy lifecycle integration
 // ============================================================================
 
 /// Default headroom version
@@ -994,11 +994,14 @@ fn check_health_endpoint(host: &str, port: u16) -> bool {
     use std::time::Duration;
 
     let addr = format!("{}:{}", host, port);
-    let mut stream =
-        match TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(2)) {
-            Ok(s) => s,
-            Err(_) => return false,
-        };
+    let socket_addr = match addr.parse() {
+        Ok(addr) => addr,
+        Err(_) => return false,
+    };
+    let mut stream = match TcpStream::connect_timeout(&socket_addr, Duration::from_secs(2)) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
     stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
     stream.set_write_timeout(Some(Duration::from_secs(2))).ok();
 
@@ -1043,7 +1046,7 @@ fn build_proxy_command(
         cmd.arg("--no-optimize");
     }
 
-    // Headroom telemetry is disabled by default per PIP-584 product decision
+    // Headroom telemetry is disabled by default.
     cmd.env("HEADROOM_TELEMETRY", "off");
 
     let log_path = if let Some(lf) = log_file {
@@ -1098,6 +1101,29 @@ fn resolve_version(version: &str) -> &str {
     }
 }
 
+fn doctor_status_json(
+    status: &str,
+    port: u16,
+    mcp_port: u16,
+    uv_ok: bool,
+    python_ok: bool,
+    headroom_ok: bool,
+    mcpcall_ok: bool,
+) -> serde_json::Value {
+    serde_json::json!({
+        "status": status,
+        "headroom_version": DEFAULT_HEADROOM_VERSION,
+        "proxy_port": port,
+        "mcp_port": mcp_port,
+        "checks": {
+            "uv": uv_ok,
+            "python": python_ok,
+            "headroom": headroom_ok,
+            "mcpcall": mcpcall_ok,
+        }
+    })
+}
+
 /// Handle `vx ai headroom install` — installs headroom-ai[proxy] via uv tool install.
 ///
 /// Bridge runner: delegates to `vx uv tool install --python <version>
@@ -1150,10 +1176,7 @@ async fn handle_headroom_install(
         UI::hint(
             "Try running manually: vx uv tool install --python <version> --from 'headroom-ai[proxy]==<version>' headroom",
         );
-        return Err(anyhow::anyhow!(
-            "headroom install failed with exit code {}",
-            code
-        ));
+        std::process::exit(code);
     }
 
     UI::success(&format!(
@@ -1198,158 +1221,147 @@ async fn handle_headroom_install(
 /// Handle `vx ai headroom doctor` — environment diagnostic checks.
 ///
 /// Three-layer check: environment, proxy, MCP.
-/// Environment layer is fully implemented; proxy and MCP layers are stubs (PIP-602/PIP-603).
-/// When `--json` is set, outputs pure machine-readable JSON on stdout.
+/// Phase 1 keeps proxy and MCP probing intentionally lightweight.
 async fn handle_headroom_doctor(quick: bool, json: bool, port: u16, mcp_port: u16) -> Result<()> {
     let vx_exe = std::env::current_exe().context("Could not determine vx executable path")?;
 
     if !json {
         UI::header("headroom doctor");
+    }
+
+    // Layer 1: Environment checks
+    if !json {
         println!();
         UI::info("--- Environment ---");
     }
 
-    // Layer 1: Environment checks (always run — data collection)
+    // Check uv availability
     let uv_check = std::process::Command::new(&vx_exe)
         .args(["uv", "--version"])
         .output();
-    let uv_version = match &uv_check {
+    let uv_ok = matches!(uv_check, Ok(ref output) if output.status.success());
+    match uv_check {
         Ok(output) if output.status.success() => {
-            let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !json {
+                let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
                 UI::success(&format!("uv: {}", ver));
             }
-            Some(ver)
         }
-        _ => {
-            if !json {
-                UI::error("uv: not available");
-            }
-            None
-        }
-    };
+        _ if !json => UI::error("uv: not available"),
+        _ => {}
+    }
 
+    // Check python availability
     let py_check = std::process::Command::new(&vx_exe)
         .args(["python", "--version"])
         .output();
-    let py_version = match &py_check {
+    let python_ok = matches!(py_check, Ok(ref output) if output.status.success());
+    match py_check {
         Ok(output) if output.status.success() => {
-            let ver = String::from_utf8_lossy(&output.stderr).trim().to_string();
-            let ver = if ver.is_empty() {
-                String::from_utf8_lossy(&output.stdout).trim().to_string()
-            } else {
-                ver
-            };
             if !json {
+                let ver = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                let ver = if ver.is_empty() {
+                    String::from_utf8_lossy(&output.stdout).trim().to_string()
+                } else {
+                    ver
+                };
                 UI::success(&format!("python: {}", ver));
             }
-            Some(ver)
         }
-        _ => {
-            if !json {
-                UI::warn("python: check skipped (may not be installed via vx)");
-            }
-            None
-        }
-    };
+        _ if !json => UI::warn("python: check skipped (may not be installed via vx)"),
+        _ => {}
+    }
 
+    // Check headroom availability
     let hr_check = std::process::Command::new(&vx_exe)
-        .args([
-            "uv",
-            "tool",
-            "run",
-            "--from",
-            &format!("headroom-ai[proxy]=={}", DEFAULT_HEADROOM_VERSION),
-            "headroom",
-            "--version",
-        ])
+        .args(["headroom", "--version"])
         .output();
-    let hr_version = match &hr_check {
+    let headroom_ok = matches!(hr_check, Ok(ref output) if output.status.success());
+    match hr_check {
         Ok(output) if output.status.success() => {
-            let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !json {
+                let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
                 UI::success(&format!("headroom-ai: {}", ver));
             }
-            Some(ver)
         }
-        _ => {
-            if !json {
-                UI::error(&format!(
-                    "headroom-ai[proxy] {}: not installed",
-                    DEFAULT_HEADROOM_VERSION
-                ));
-            }
-            None
-        }
-    };
+        _ if !json => UI::error(&format!(
+            "headroom-ai[proxy] {}: not installed",
+            DEFAULT_HEADROOM_VERSION
+        )),
+        _ => {}
+    }
 
+    // Check mcpcall availability
     let mcpcall_check = std::process::Command::new(&vx_exe)
         .args(["mcpcall", "--version"])
         .output();
-    let mcpcall_version = match &mcpcall_check {
+    let mcpcall_ok = matches!(mcpcall_check, Ok(ref output) if output.status.success());
+    match mcpcall_check {
         Ok(output) if output.status.success() => {
-            let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !json {
+                let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
                 UI::success(&format!("mcpcall: {}", ver));
             }
-            Some(ver)
         }
-        _ => {
-            if !json {
-                UI::warn("mcpcall: not installed (run 'vx ai headroom install' to set up)");
-            }
-            None
-        }
-    };
-
-    // Build and emit JSON output when requested — always before any early return
-    if json {
-        let mut env = serde_json::Map::new();
-        env.insert("uv".into(), serde_json::json!(uv_version));
-        env.insert("python".into(), serde_json::json!(py_version));
-        env.insert("headroom".into(), serde_json::json!(hr_version));
-        env.insert("mcpcall".into(), serde_json::json!(mcpcall_version));
-
-        let mut result = serde_json::Map::new();
-        result.insert("environment".into(), serde_json::Value::Object(env));
-        result.insert(
-            "headroom_version".into(),
-            serde_json::json!(DEFAULT_HEADROOM_VERSION),
-        );
-
-        if !quick {
-            result.insert(
-                "proxy".into(),
-                serde_json::json!({"status": "not_implemented", "port": port}),
-            );
-            result.insert(
-                "mcp".into(),
-                serde_json::json!({"status": "not_implemented", "port": mcp_port}),
-            );
-        }
-
-        println!("{}", serde_json::Value::Object(result));
+        _ if !json => UI::warn("mcpcall: not installed (run 'vx ai headroom install' to set up)"),
+        _ => {}
     }
 
+    let status = if uv_ok && headroom_ok {
+        "ok"
+    } else {
+        "error"
+    };
+
     if quick {
-        if !json {
+        if json {
+            println!(
+                "{}",
+                doctor_status_json(
+                    status,
+                    port,
+                    mcp_port,
+                    uv_ok,
+                    python_ok,
+                    headroom_ok,
+                    mcpcall_ok,
+                )
+            );
+        } else {
             UI::hint("Quick check complete. Run without --quick for proxy and MCP checks.");
         }
         return Ok(());
     }
 
+    // Layer 2: Proxy checks
     if !json {
-        // Layer 2: Proxy checks
         println!();
         UI::info(&format!("--- Proxy (port {}) ---", port));
-        UI::info("proxy check: not yet implemented (PIP-602)");
+        UI::info("proxy check: not yet implemented");
         UI::hint("Run 'vx ai headroom proxy start' to start the proxy service.");
+    }
 
-        // Layer 3: MCP checks
+    // Layer 3: MCP checks
+    if !json {
         println!();
         UI::info(&format!("--- MCP (port {}) ---", mcp_port));
-        UI::info("MCP check: not yet implemented (PIP-603)");
+        UI::info("MCP check: not yet implemented");
         UI::hint("Run 'vx ai headroom mcp test' to validate MCP tools.");
+    }
+
+    if json {
+        println!(
+            "{}",
+            doctor_status_json(
+                status,
+                port,
+                mcp_port,
+                uv_ok,
+                python_ok,
+                headroom_ok,
+                mcpcall_ok,
+            )
+        );
     }
 
     Ok(())
@@ -1357,8 +1369,8 @@ async fn handle_headroom_doctor(quick: bool, json: bool, port: u16, mcp_port: u1
 
 /// Handle `vx ai headroom setup` — generate MCP config templates.
 ///
-/// Stub in PIP-601; full implementation in PIP-604.
-pub async fn handle_headroom_setup(
+/// Phase 1 stub; follow-up work will flesh out config generation.
+async fn handle_headroom_setup(
     agents: &[String],
     _dry_run: bool,
     apply: bool,
@@ -1368,7 +1380,7 @@ pub async fn handle_headroom_setup(
 ) -> Result<()> {
     UI::header("headroom setup");
     println!();
-    UI::info("setup: not yet implemented (PIP-604)");
+    UI::info("setup: not yet implemented");
     UI::info(&format!(
         "Would configure MCP for agents: {}",
         if agents.is_empty() {
@@ -1391,13 +1403,14 @@ pub async fn handle_headroom_setup(
             "--dry-run (default)"
         }
     ));
-    UI::hint("This command will be fully implemented in PIP-604.");
+    UI::hint("This command will be fleshed out in a follow-up.");
     Ok(())
 }
 
 /// Handle `vx ai headroom proxy` — dispatch to proxy subcommands.
 ///
-/// Stubs in PIP-601; full implementation in PIP-602.
+/// Manages the headroom proxy lifecycle: start (detached or foreground),
+/// status (process + health probe), and stop.
 async fn handle_headroom_proxy(command: &HeadroomProxyCommand) -> Result<()> {
     match command {
         HeadroomProxyCommand::Start {
@@ -1409,6 +1422,7 @@ async fn handle_headroom_proxy(command: &HeadroomProxyCommand) -> Result<()> {
         } => {
             UI::header("headroom proxy start");
             println!();
+
             // Check if already running
             let pid_path = proxy_pid_path(*port)?;
             if let Some(pid) = read_pid(&pid_path) {
@@ -1517,6 +1531,7 @@ async fn handle_headroom_proxy(command: &HeadroomProxyCommand) -> Result<()> {
                 }
             }
         }
+
         HeadroomProxyCommand::Status { port, json } => {
             let pid_path = proxy_pid_path(*port)?;
             let pid = read_pid(&pid_path);
@@ -1553,14 +1568,45 @@ async fn handle_headroom_proxy(command: &HeadroomProxyCommand) -> Result<()> {
             } else {
                 UI::header("headroom proxy status");
                 println!();
-                UI::info("proxy status: not yet implemented (PIP-602)");
-                UI::info(&format!("  checking port: {}", port));
-                UI::hint("This command will be fully implemented in PIP-602.");
+
+                match (running, port_open, healthy) {
+                    (true, true, true) => {
+                        UI::success(&format!(
+                            "headroom proxy is running on port {} (PID {}) — healthy",
+                            port,
+                            pid.unwrap()
+                        ));
+                    }
+                    (true, true, false) => {
+                        UI::warn("headroom proxy is running but health check failed");
+                        UI::item(&format!("Port {} is open, PID {}", port, pid.unwrap()));
+                        UI::hint("Check the proxy logs for errors.");
+                    }
+                    (true, false, _) => {
+                        UI::warn("headroom proxy process exists but port is not open");
+                        UI::item(&format!("PID: {} (found in pid file)", pid.unwrap()));
+                    }
+                    (false, _, _) if pid.is_some() => {
+                        UI::warn(&format!(
+                            "headroom proxy is not running (stale PID file for {})",
+                            pid.unwrap()
+                        ));
+                        UI::hint(&format!("Remove stale PID file: {}", pid_path.display()));
+                    }
+                    _ => {
+                        UI::info("headroom proxy is not running");
+                    }
+                }
+
+                UI::item(&format!("Port: {}", port));
+                UI::item(&format!("PID file: {}", pid_path.display()));
             }
         }
+
         HeadroomProxyCommand::Stop { port } => {
             UI::header("headroom proxy stop");
             println!();
+
             let pid_path = proxy_pid_path(*port)?;
             let pid = read_pid(&pid_path);
 
@@ -1600,45 +1646,7 @@ async fn handle_headroom_proxy(command: &HeadroomProxyCommand) -> Result<()> {
     Ok(())
 }
 
-/// Handle `vx ai headroom mcp` — dispatch to MCP subcommands.
-///
-/// Stubs in PIP-601; full implementation in PIP-603.
-async fn handle_headroom_mcp(_ctx: &CommandContext, command: &HeadroomMcpCommand) -> Result<()> {
-    match command {
-        HeadroomMcpCommand::Stdio => {
-            // Internal bridge entry point for agent MCP configurations.
-            // In Phase 1, this is a stub. Eventually delegates to headroom MCP server.
-            UI::error("headroom mcp stdio: not yet implemented (PIP-603)");
-            UI::hint(
-                "Run 'vx ai headroom install' first, then 'vx ai headroom mcp test' to verify.",
-            );
-            Err(anyhow::anyhow!("headroom mcp stdio not yet implemented"))
-        }
-        HeadroomMcpCommand::Test {
-            url,
-            json,
-            sample_file,
-        } => {
-            UI::header("headroom mcp test");
-            println!();
-            UI::info("mcp test: not yet implemented (PIP-603)");
-            UI::info(&format!("  MCP URL: {}", url));
-            if *json {
-                UI::info("  output: json");
-            }
-            if let Some(sample) = sample_file {
-                UI::info(&format!("  sample file: {}", sample));
-            }
-            UI::hint("This command will be fully implemented in PIP-603.");
-            Ok(())
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Process termination helpers
-// ---------------------------------------------------------------------------
-
+/// Kill a process by PID. Platform-specific implementation.
 #[cfg(unix)]
 fn kill_process(pid: u32) -> Result<()> {
     unsafe {
@@ -1663,6 +1671,41 @@ fn kill_process(pid: u32) -> Result<()> {
         anyhow::bail!("taskkill failed for PID {}", pid);
     }
     Ok(())
+}
+
+/// Handle `vx ai headroom mcp` — dispatch to MCP subcommands.
+///
+/// Phase 1 stubs for MCP-related entry points.
+async fn handle_headroom_mcp(_ctx: &CommandContext, command: &HeadroomMcpCommand) -> Result<()> {
+    match command {
+        HeadroomMcpCommand::Stdio => {
+            // Internal bridge entry point for agent MCP configurations.
+            // Phase 1 keeps the MCP bridge as a stub.
+            UI::error("headroom mcp stdio: not yet implemented");
+            UI::hint(
+                "Run 'vx ai headroom install' first, then 'vx ai headroom mcp test' to verify.",
+            );
+            Ok(())
+        }
+        HeadroomMcpCommand::Test {
+            url,
+            json,
+            sample_file,
+        } => {
+            UI::header("headroom mcp test");
+            println!();
+            UI::info("mcp test: not yet implemented");
+            UI::info(&format!("  MCP URL: {}", url));
+            if *json {
+                UI::info("  output: json");
+            }
+            if let Some(sample) = sample_file {
+                UI::info(&format!("  sample file: {}", sample));
+            }
+            UI::hint("This command will be fleshed out in a follow-up.");
+            Ok(())
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1808,5 +1851,20 @@ mod tests {
             next, "/custom/log.log",
             "log file arg should follow --log-file"
         );
+    }
+
+    #[test]
+    fn check_health_endpoint_returns_false_for_invalid_host() {
+        assert!(!check_health_endpoint("bad host value", 8787));
+    }
+
+    #[test]
+    fn doctor_status_json_uses_requested_ports() {
+        let json = doctor_status_json("ok", 9123, 9456, true, true, true, true);
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["proxy_port"], 9123);
+        assert_eq!(json["mcp_port"], 9456);
+        assert_eq!(json["checks"]["uv"], true);
+        assert_eq!(json["checks"]["headroom"], true);
     }
 }

--- a/crates/vx-cli/src/commands/ai.rs
+++ b/crates/vx-cli/src/commands/ai.rs
@@ -896,6 +896,168 @@ const DEFAULT_PYTHON_VERSION: &str = "3.11";
 /// Default mcpcall version
 #[allow(dead_code)]
 const DEFAULT_MCPCALL_VERSION: &str = "0.4.0";
+/// Default proxy host
+const DEFAULT_PROXY_HOST: &str = "127.0.0.1";
+/// Default proxy port
+#[allow(dead_code)]
+const DEFAULT_PROXY_PORT: u16 = 8787;
+
+// ---------------------------------------------------------------------------
+// Proxy state management helpers
+// ---------------------------------------------------------------------------
+
+/// Returns the headroom state directory: `~/.vx/state/headroom/`
+fn headroom_state_dir() -> Result<std::path::PathBuf> {
+    let home = dirs::home_dir().context("Could not determine home directory")?;
+    Ok(home.join(".vx").join("state").join("headroom"))
+}
+
+/// Returns the PID file path for a given proxy port
+fn proxy_pid_path(port: u16) -> Result<std::path::PathBuf> {
+    let dir = headroom_state_dir()?;
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("Failed to create state directory: {}", dir.display()))?;
+    Ok(dir.join(format!("proxy-{}.pid", port)))
+}
+
+/// Returns the default log file path for a given proxy port
+fn proxy_log_path(port: u16) -> Result<std::path::PathBuf> {
+    let dir = headroom_state_dir()?;
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("Failed to create state directory: {}", dir.display()))?;
+    Ok(dir.join(format!("proxy-{}.log", port)))
+}
+
+/// Returns the host state file path for a given proxy port.
+///
+/// When `start --host <host>` is used with a non-default host, the host is persisted
+/// so that `status` and `stop` can use the correct address for health probes.
+fn proxy_host_path(port: u16) -> Result<std::path::PathBuf> {
+    let dir = headroom_state_dir()?;
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("Failed to create state directory: {}", dir.display()))?;
+    Ok(dir.join(format!("proxy-{}.host", port)))
+}
+
+/// Reads the persisted host for a proxy port. Falls back to `DEFAULT_PROXY_HOST`.
+fn read_proxy_host(port: u16) -> String {
+    proxy_host_path(port)
+        .ok()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_PROXY_HOST.to_string())
+}
+
+/// Reads a PID from a PID file. Returns `None` if the file does not exist or is unreadable.
+fn read_pid(path: &std::path::Path) -> Option<u32> {
+    let content = std::fs::read_to_string(path).ok()?;
+    content.trim().parse::<u32>().ok()
+}
+
+/// Checks whether a process with the given PID is running on this platform.
+#[cfg(unix)]
+fn is_process_running(pid: u32) -> bool {
+    unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+#[cfg(windows)]
+fn is_process_running(pid: u32) -> bool {
+    let output = std::process::Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {}", pid)])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output();
+    match output {
+        Ok(out) => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            stdout.contains(&format!("{}", pid))
+        }
+        Err(_) => false,
+    }
+}
+
+/// Tries to connect to the proxy's TCP port. Returns `Ok` if the port is reachable.
+fn check_port(host: &str, port: u16) -> Result<()> {
+    use std::net::TcpStream;
+    use std::time::Duration;
+    let addr = format!("{}:{}", host, port);
+    TcpStream::connect_timeout(&addr.parse()?, Duration::from_secs(2))
+        .with_context(|| format!("Port {}:{} is not reachable", host, port))?;
+    Ok(())
+}
+
+/// Performs a minimal HTTP health check: `GET /health`. Returns `true` if status is 200 OK.
+fn check_health_endpoint(host: &str, port: u16) -> bool {
+    use std::io::{Read, Write};
+    use std::net::TcpStream;
+    use std::time::Duration;
+
+    let addr = format!("{}:{}", host, port);
+    let mut stream =
+        match TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(2)) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+    stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+    stream.set_write_timeout(Some(Duration::from_secs(2))).ok();
+
+    let request = format!(
+        "GET /health HTTP/1.0\r\nHost: {}:{}\r\nConnection: close\r\n\r\n",
+        host, port
+    );
+    if stream.write_all(request.as_bytes()).is_err() {
+        return false;
+    }
+    let mut response = String::new();
+    if stream.read_to_string(&mut response).is_err() {
+        return false;
+    }
+    response.contains("200 OK")
+}
+
+/// Build the `headroom proxy` command with the given arguments.
+/// Returns the command and a human-readable label.
+///
+/// Uses the **vx bridge**: delegates to `vx headroom proxy ...` so that the headroom
+/// executable installed via `vx uv tool install` is resolved correctly regardless of
+/// whether it has been added to PATH (especially on Windows).
+fn build_proxy_command(
+    host: &str,
+    port: u16,
+    log_file: Option<&str>,
+    no_optimize: bool,
+) -> (std::process::Command, String) {
+    let vx_exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("vx"));
+    let mut cmd = std::process::Command::new(&vx_exe);
+    cmd.args([
+        "headroom",
+        "proxy",
+        "--host",
+        host,
+        "--port",
+        &port.to_string(),
+    ]);
+
+    if no_optimize {
+        cmd.arg("--no-optimize");
+    }
+
+    // Headroom telemetry is disabled by default per PIP-584 product decision
+    cmd.env("HEADROOM_TELEMETRY", "off");
+
+    let log_path = if let Some(lf) = log_file {
+        std::path::PathBuf::from(lf)
+    } else {
+        proxy_log_path(port).unwrap_or_else(|_| std::path::PathBuf::from("headroom-proxy.log"))
+    };
+
+    cmd.arg("--log-file");
+    cmd.arg(log_path.to_string_lossy().as_ref());
+
+    let label = format!("vx headroom proxy --host {} --port {}", host, port);
+    (cmd, label)
+}
 
 /// Handle `vx ai headroom` command — dispatches to subcommands.
 pub async fn handle_headroom(ctx: &CommandContext, command: &HeadroomCommand) -> Result<()> {
@@ -1005,8 +1167,9 @@ async fn handle_headroom_install(
         mcpcall_version
     ));
 
+    let mcpcall_spec = format!("mcpcall@{}", mcpcall_version);
     let mcpcall_status = std::process::Command::new(&vx_exe)
-        .args(["install", &format!("mcpcall@{}", mcpcall_version)])
+        .args(["install", &mcpcall_spec])
         .status()
         .context("Failed to install mcpcall")?;
 
@@ -1246,21 +1409,146 @@ async fn handle_headroom_proxy(command: &HeadroomProxyCommand) -> Result<()> {
         } => {
             UI::header("headroom proxy start");
             println!();
-            UI::info("proxy start: not yet implemented (PIP-602)");
-            UI::info(&format!("  host: {}", host));
-            UI::info(&format!("  port: {}", port));
-            UI::info(&format!("  foreground: {}", foreground));
-            if let Some(log) = log_file {
-                UI::info(&format!("  log file: {}", log));
+            // Check if already running
+            let pid_path = proxy_pid_path(*port)?;
+            if let Some(pid) = read_pid(&pid_path) {
+                if is_process_running(pid) {
+                    UI::warn(&format!(
+                        "A headroom proxy appears to be running on port {} (PID {})",
+                        port, pid
+                    ));
+                    UI::hint("Run 'vx ai headroom proxy stop' to stop it first.");
+                    return Ok(());
+                }
             }
-            UI::info(&format!("  optimize: {}", !no_optimize));
-            UI::hint("This command will be fully implemented in PIP-602.");
+
+            // Verify headroom is installed
+            UI::step("Checking headroom availability...");
+            let vx_exe =
+                std::env::current_exe().context("Could not determine vx executable path")?;
+            let version_check = std::process::Command::new(&vx_exe)
+                .args(["headroom", "--version"])
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .output();
+
+            match version_check {
+                Ok(out) if out.status.success() => {
+                    let v = String::from_utf8_lossy(&out.stdout);
+                    UI::success(&format!("headroom: {}", v.trim()));
+                }
+                _ => {
+                    UI::error("headroom is not installed or not in PATH");
+                    UI::hint("Run 'vx ai headroom install' to install headroom-ai[proxy].");
+                    return Ok(());
+                }
+            }
+
+            // Persist the host so status/stop can use the correct address
+            let host_path = proxy_host_path(*port)?;
+            std::fs::write(&host_path, host)
+                .with_context(|| format!("Failed to write host file: {}", host_path.display()))?;
+
+            let (mut cmd, _label) =
+                build_proxy_command(host, *port, log_file.as_deref(), *no_optimize);
+
+            if *foreground {
+                UI::info(&format!(
+                    "Starting headroom proxy in foreground on {}:{}...",
+                    host, port
+                ));
+                let status = cmd
+                    .stdin(std::process::Stdio::inherit())
+                    .stdout(std::process::Stdio::inherit())
+                    .stderr(std::process::Stdio::inherit())
+                    .status()
+                    .context("Failed to start headroom proxy in foreground")?;
+
+                if !status.success() {
+                    UI::error(&format!(
+                        "headroom proxy exited with code: {:?}",
+                        status.code()
+                    ));
+                }
+            } else {
+                UI::info(&format!(
+                    "Starting headroom proxy (detached) on {}:{}...",
+                    host, port
+                ));
+
+                let child = cmd
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn()
+                    .context("Failed to spawn headroom proxy process")?;
+
+                let pid = child.id();
+                std::fs::write(&pid_path, pid.to_string())
+                    .with_context(|| format!("Failed to write PID file: {}", pid_path.display()))?;
+
+                UI::success(&format!(
+                    "headroom proxy started (PID {}) on {}:{}",
+                    pid, host, port
+                ));
+                UI::item(&format!("PID file: {}", pid_path.display()));
+
+                let log = log_file
+                    .as_deref()
+                    .map(std::path::PathBuf::from)
+                    .unwrap_or_else(|| {
+                        proxy_log_path(*port)
+                            .unwrap_or_else(|_| std::path::PathBuf::from("headroom-proxy.log"))
+                    });
+                UI::item(&format!("Log file: {}", log.display()));
+
+                // Verify the proxy responds
+                UI::step("Waiting for proxy to become ready...");
+                for i in 1..=10 {
+                    if check_port(host, *port).is_ok() && check_health_endpoint(host, *port) {
+                        UI::success("headroom proxy is healthy and accepting connections");
+                        break;
+                    }
+                    if i == 10 {
+                        UI::warn("headroom proxy started but health check timed out");
+                        UI::hint("Check logs and run 'vx ai headroom proxy status' to diagnose.");
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                }
+            }
         }
         HeadroomProxyCommand::Status { port, json } => {
+            let pid_path = proxy_pid_path(*port)?;
+            let pid = read_pid(&pid_path);
+            let running = pid.map_or(false, is_process_running);
+            let host = read_proxy_host(*port);
+            let port_open = check_port(&host, *port).is_ok();
+            let healthy = port_open && check_health_endpoint(&host, *port);
+
             if *json {
+                let status = if healthy {
+                    "healthy"
+                } else if running && port_open {
+                    "unhealthy"
+                } else if running {
+                    "not_listening"
+                } else if pid.is_some() {
+                    "stale_pid"
+                } else {
+                    "not_running"
+                };
                 println!(
                     "{}",
-                    serde_json::json!({"status": "not_implemented", "port": port})
+                    serde_json::json!({
+                        "status": status,
+                        "host": host,
+                        "port": port,
+                        "pid": pid,
+                        "process_running": running,
+                        "port_open": port_open,
+                        "health_check": healthy,
+                        "pid_file": pid_path.display().to_string(),
+                    })
                 );
             } else {
                 UI::header("headroom proxy status");
@@ -1273,9 +1561,40 @@ async fn handle_headroom_proxy(command: &HeadroomProxyCommand) -> Result<()> {
         HeadroomProxyCommand::Stop { port } => {
             UI::header("headroom proxy stop");
             println!();
-            UI::info("proxy stop: not yet implemented (PIP-602)");
-            UI::info(&format!("  stopping on port: {}", port));
-            UI::hint("This command will be fully implemented in PIP-602.");
+            let pid_path = proxy_pid_path(*port)?;
+            let pid = read_pid(&pid_path);
+
+            match pid {
+                Some(p) if is_process_running(p) => {
+                    UI::info(&format!(
+                        "Stopping headroom proxy on port {} (PID {})...",
+                        port, p
+                    ));
+                    kill_process(p)?;
+                    let _ = std::fs::remove_file(&pid_path);
+                    UI::success(&format!("headroom proxy (PID {}) stopped", p));
+                }
+                Some(p) => {
+                    UI::warn(&format!(
+                        "PID {} found in PID file but process is not running (stale PID)",
+                        p
+                    ));
+                    let _ = std::fs::remove_file(&pid_path);
+                    UI::info("Cleaned up stale PID file.");
+                }
+                None => {
+                    // Try to find by port in use
+                    let host = read_proxy_host(*port);
+                    if check_port(&host, *port).is_ok() {
+                        UI::warn(&format!("Port {} is in use but no PID file found", port));
+                        UI::hint(
+                            "The proxy may have been started outside of vx. Stop it manually.",
+                        );
+                    } else {
+                        UI::info("headroom proxy is not running.");
+                    }
+                }
+            }
         }
     }
     Ok(())
@@ -1313,5 +1632,181 @@ async fn handle_headroom_mcp(_ctx: &CommandContext, command: &HeadroomMcpCommand
             UI::hint("This command will be fully implemented in PIP-603.");
             Ok(())
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Process termination helpers
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+fn kill_process(pid: u32) -> Result<()> {
+    unsafe {
+        if libc::kill(pid as i32, libc::SIGTERM) != 0 {
+            let err = std::io::Error::last_os_error();
+            anyhow::bail!("Failed to send SIGTERM to PID {}: {}", pid, err);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn kill_process(pid: u32) -> Result<()> {
+    let status = std::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/F"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .with_context(|| format!("Failed to run taskkill for PID {}", pid))?;
+
+    if !status.success() {
+        anyhow::bail!("taskkill failed for PID {}", pid);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests for headroom proxy lifecycle helpers
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::{NamedTempFile, TempDir};
+
+    // ----- State file path helpers -----
+
+    #[test]
+    fn proxy_host_path_returns_expected_suffix() {
+        let path = proxy_host_path(8787).unwrap();
+        assert!(
+            path.to_string_lossy().contains("proxy-8787.host"),
+            "expected suffix proxy-8787.host, got {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn proxy_pid_path_returns_expected_suffix() {
+        let path = proxy_pid_path(9999).unwrap();
+        assert!(
+            path.to_string_lossy().contains("proxy-9999.pid"),
+            "expected suffix proxy-9999.pid, got {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn proxy_log_path_returns_expected_suffix() {
+        let path = proxy_log_path(4321).unwrap();
+        assert!(
+            path.to_string_lossy().contains("proxy-4321.log"),
+            "expected suffix proxy-4321.log, got {}",
+            path.display()
+        );
+    }
+
+    // ----- read_proxy_host fallback -----
+
+    #[test]
+    fn read_proxy_host_falls_back_to_default_when_no_host_file() {
+        // Use a port that doesn't have a written host file
+        let host = read_proxy_host(55432);
+        assert_eq!(host, DEFAULT_PROXY_HOST);
+    }
+
+    #[test]
+    fn read_proxy_host_returns_persisted_value() {
+        let dir = TempDir::new().unwrap();
+        let host_file = dir.path().join("proxy-8787.host");
+        std::fs::write(&host_file, "10.0.0.1\n").unwrap();
+
+        // Can't easily mock headroom_state_dir, but we can test read_proxy_host
+        // with a port that has a real host file written via proxy_host_path
+        let host_path = proxy_host_path(8788).unwrap();
+        std::fs::write(&host_path, "192.168.1.1").unwrap();
+
+        let host = read_proxy_host(8788);
+        assert_eq!(host, "192.168.1.1");
+
+        // Cleanup
+        let _ = std::fs::remove_file(&host_path);
+    }
+
+    #[test]
+    fn read_pid_returns_none_for_missing_file() {
+        assert!(read_pid(std::path::Path::new("/nonexistent/pid/file.pid")).is_none());
+    }
+
+    #[test]
+    fn read_pid_returns_parsed_value() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "4242").unwrap();
+        assert_eq!(read_pid(file.path()), Some(4242));
+    }
+
+    #[test]
+    fn read_pid_rejects_invalid_content() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "not-a-number").unwrap();
+        assert_eq!(read_pid(file.path()), None);
+    }
+
+    // ----- build_proxy_command: vx bridge -----
+
+    #[test]
+    fn build_proxy_command_uses_vx_bridge() {
+        let (cmd, label) = build_proxy_command("127.0.0.1", 8787, None, false);
+        let program = cmd.get_program().to_string_lossy();
+
+        // The command should use the vx executable, NOT bare "headroom"
+        assert!(
+            program.contains("vx") || program.ends_with("vx.exe"),
+            "expected vx bridge, got program '{}'",
+            program
+        );
+        assert!(
+            !program.ends_with("headroom") && !program.ends_with("headroom.exe"),
+            "should NOT invoke bare headroom"
+        );
+
+        // Label describes the vx bridge path
+        assert!(label.contains("vx headroom proxy"));
+    }
+
+    #[test]
+    fn build_proxy_command_includes_no_optimize_flag() {
+        let (cmd, _) = build_proxy_command("127.0.0.1", 8787, Some("/tmp/log"), true);
+        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy()).collect();
+        assert!(
+            args.iter().any(|a| a == "--no-optimize"),
+            "expected --no-optimize in args: {:?}",
+            args
+        );
+    }
+
+    #[test]
+    fn build_proxy_command_sets_telemetry_off() {
+        let (cmd, _) = build_proxy_command("127.0.0.1", 8787, None, false);
+        let envs: Vec<_> = cmd.get_envs().collect();
+        let telemetry_off = envs.iter().any(|(k, v)| {
+            *k == std::ffi::OsStr::new("HEADROOM_TELEMETRY")
+                && v.map(|val| val == "off").unwrap_or(false)
+        });
+        assert!(telemetry_off, "HEADROOM_TELEMETRY should be 'off'");
+    }
+
+    #[test]
+    fn build_proxy_command_passes_log_file() {
+        let (cmd, _) = build_proxy_command("127.0.0.1", 8787, Some("/custom/log.log"), false);
+        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy()).collect();
+        let log_file_idx = args.iter().position(|a| a == "--log-file");
+        assert!(log_file_idx.is_some(), "expected --log-file flag in args");
+        let next = args[log_file_idx.unwrap() + 1].clone();
+        assert_eq!(
+            next, "/custom/log.log",
+            "log file arg should follow --log-file"
+        );
     }
 }

--- a/crates/vx-cli/src/commands/ai.rs
+++ b/crates/vx-cli/src/commands/ai.rs
@@ -1056,13 +1056,16 @@ pub fn build_proxy_command(
 ) -> (std::process::Command, String) {
     let vx_exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("vx"));
     let mut cmd = std::process::Command::new(&vx_exe);
-    // headroom is installed via `uv tool install`, so the canonical vx bridge
-    // is `vx uv tool run headroom` — this resolves the uv-managed binary
-    // regardless of whether it is on PATH (critical on Windows).
+    // headroom is installed via `uv tool install --from 'headroom-ai[proxy]' headroom`.
+    // `uv tool run headroom` falls back to PyPI package "headroom" (unrelated), so we
+    // must use `--from headroom-ai[proxy]` to explicitly tell uv which package provides
+    // the `headroom` executable.
     cmd.args([
         "uv",
         "tool",
         "run",
+        "--from",
+        "headroom-ai[proxy]",
         "headroom",
         "proxy",
         "--host",
@@ -1088,7 +1091,7 @@ pub fn build_proxy_command(
     cmd.arg(log_path.to_string_lossy().as_ref());
 
     let label = format!(
-        "vx uv tool run headroom proxy --host {} --port {}",
+        "vx uv tool run --from headroom-ai[proxy] headroom proxy --host {} --port {}",
         host, port
     );
     (cmd, label)
@@ -1304,9 +1307,19 @@ async fn handle_headroom_doctor(quick: bool, json: bool, port: u16, mcp_port: u1
         _ => {}
     }
 
-    // Check headroom availability
+    // Check headroom availability via the canonical vx bridge:
+    // `uv tool run` must use `--from headroom-ai[proxy]` because the bare
+    // `headroom` name resolves to an unrelated PyPI package.
     let hr_check = std::process::Command::new(&vx_exe)
-        .args(["headroom", "--version"])
+        .args([
+            "uv",
+            "tool",
+            "run",
+            "--from",
+            "headroom-ai[proxy]",
+            "headroom",
+            "--version",
+        ])
         .output();
     let headroom_ok = matches!(hr_check, Ok(ref output) if output.status.success());
     match hr_check {
@@ -1473,7 +1486,15 @@ async fn handle_headroom_proxy(command: &HeadroomProxyCommand) -> Result<()> {
             let vx_exe =
                 std::env::current_exe().context("Could not determine vx executable path")?;
             let version_check = std::process::Command::new(&vx_exe)
-                .args(["uv", "tool", "run", "headroom", "--version"])
+                .args([
+                    "uv",
+                    "tool",
+                    "run",
+                    "--from",
+                    "headroom-ai[proxy]",
+                    "headroom",
+                    "--version",
+                ])
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
                 .output();

--- a/crates/vx-cli/tests/headroom_proxy_tests.rs
+++ b/crates/vx-cli/tests/headroom_proxy_tests.rs
@@ -137,7 +137,7 @@ fn build_proxy_command_uses_vx_bridge() {
         !program.ends_with("headroom") && !program.ends_with("headroom.exe"),
         "should NOT invoke bare headroom"
     );
-    assert!(label.contains("vx uv tool run headroom proxy"));
+    assert!(label.contains("vx uv tool run --from headroom-ai[proxy] headroom proxy"));
 }
 
 #[test]
@@ -145,20 +145,25 @@ fn build_proxy_command_includes_uv_tool_run_args() {
     let (cmd, _) = build_proxy_command("10.0.0.1", 9999, None, false);
     let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy()).collect();
 
-    // Verify the bridge path: vx uv tool run headroom proxy --host ... --port ...
+    // Verify the bridge path: vx uv tool run --from headroom-ai[proxy] headroom proxy ...
     assert!(args.iter().any(|a| a == "uv"), "expected 'uv' subcommand");
-    assert!(
-        args.iter().any(|a| a == "tool"),
-        "expected 'tool' subcommand"
-    );
+    assert!(args.iter().any(|a| a == "tool"), "expected 'tool' subcommand");
     assert!(args.iter().any(|a| a == "run"), "expected 'run' subcommand");
     assert!(
+        args.iter().any(|a| a == "--from"),
+        "expected '--from' flag"
+    );
+    assert!(
+        args.iter().any(|a| a == "headroom-ai[proxy]"),
+        "expected 'headroom-ai[proxy]' package"
+    );
+    assert!(
         args.iter().any(|a| a == "headroom"),
-        "expected 'headroom' command"
+        "expected 'headroom' executable"
     );
     assert!(
         args.iter().any(|a| a == "proxy"),
-        "expected 'proxy' command"
+        "expected 'proxy' subcommand"
     );
 }
 
@@ -264,3 +269,76 @@ fn headroom_state_dir_with_base_uses_injected_base() {
     assert!(state.starts_with(base));
     assert!(state.ends_with(std::path::Path::new(".vx").join("state").join("headroom")));
 }
+
+// ---------------------------------------------------------------------------
+// Behavioral verification: the command shape is executable when headroom is
+// installed via `uv tool install --from 'headroom-ai[proxy]' headroom`.
+// We can't run headroom in a test (it may not be installed on CI), but we
+// CAN verify that `--from` comes BEFORE `headroom` (uv positional requirement)
+// and that the program path exists.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_proxy_command_from_flag_comes_before_executable() {
+    let (cmd, _) = build_proxy_command("127.0.0.1", 8787, None, false);
+    let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy()).collect();
+
+    let from_idx = args
+        .iter()
+        .position(|a| a == "--from")
+        .expect("--from flag must be present");
+    let headroom_idx = args
+        .iter()
+        .position(|a| a == "headroom")
+        .expect("headroom executable must be present");
+
+    assert!(
+        from_idx < headroom_idx,
+        "--from must precede the executable name (uv positional requirement); got --from at {}, headroom at {}",
+        from_idx,
+        headroom_idx
+    );
+}
+
+#[test]
+fn build_proxy_command_exact_arg_order_is_correct() {
+    let (cmd, _) = build_proxy_command("192.168.0.1", 8888, None, false);
+    let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy()).collect();
+
+    // Expected: uv tool run --from headroom-ai[proxy] headroom proxy --host 192.168.0.1 --port 8888 [--log-file ...]
+    assert_eq!(args[0], "uv");
+    assert_eq!(args[1], "tool");
+    assert_eq!(args[2], "run");
+    assert_eq!(args[3], "--from");
+    assert_eq!(args[4], "headroom-ai[proxy]");
+    assert_eq!(args[5], "headroom");
+    assert_eq!(args[6], "proxy");
+    assert_eq!(args[7], "--host");
+    assert_eq!(args[8], "192.168.0.1");
+    assert_eq!(args[9], "--port");
+    assert_eq!(args[10], "8888");
+    // Followed by --log-file with a temp path
+    assert_eq!(args[11], "--log-file");
+}
+
+#[test]
+fn build_proxy_command_program_is_this_vx_binary() {
+    let (cmd, _) = build_proxy_command("127.0.0.1", 8787, None, false);
+    let program = cmd.get_program();
+
+    // The program path must be the current vx binary, which must exist.
+    // This verifies the command target is runnable, not a placeholder.
+    assert!(
+        Path::new(program).exists(),
+        "program '{}' does not exist — bridge target is broken",
+        program.to_string_lossy()
+    );
+
+    let program_str = program.to_string_lossy();
+    assert!(
+        program_str.contains("vx") || program_str.ends_with("vx.exe"),
+        "program '{}' does not appear to be the vx binary",
+        program_str
+    );
+}
+

--- a/crates/vx-cli/tests/headroom_proxy_tests.rs
+++ b/crates/vx-cli/tests/headroom_proxy_tests.rs
@@ -1,0 +1,266 @@
+// Tests for headroom proxy lifecycle helpers.
+//
+// All state-path tests use `_with_base` variants with a TempDir to avoid
+// writing to the real `~/.vx/state/headroom/` directory.
+
+use std::io::Write;
+use std::path::Path;
+
+use tempfile::{NamedTempFile, TempDir};
+use vx_cli::commands::ai::{
+    DEFAULT_PROXY_HOST, build_proxy_command, check_port, headroom_state_dir_with_base,
+    proxy_host_path_with_base, proxy_log_path_with_base, proxy_pid_path_with_base, read_pid,
+    read_proxy_host_with_base,
+};
+
+// ---------------------------------------------------------------------------
+// State file path helpers (isolated via TempDir)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn proxy_host_path_with_base_returns_expected_suffix() {
+    let dir = TempDir::new().unwrap();
+    let base = dir.path();
+    let path = proxy_host_path_with_base(base, 8787).unwrap();
+    assert!(
+        path.to_string_lossy().contains("proxy-8787.host"),
+        "expected suffix proxy-8787.host, got {}",
+        path.display()
+    );
+    assert!(
+        path.starts_with(base),
+        "path should be under the injected base directory"
+    );
+}
+
+#[test]
+fn proxy_pid_path_with_base_returns_expected_suffix() {
+    let dir = TempDir::new().unwrap();
+    let base = dir.path();
+    let path = proxy_pid_path_with_base(base, 9999).unwrap();
+    assert!(
+        path.to_string_lossy().contains("proxy-9999.pid"),
+        "expected suffix proxy-9999.pid, got {}",
+        path.display()
+    );
+    assert!(path.starts_with(base));
+}
+
+#[test]
+fn proxy_log_path_with_base_returns_expected_suffix() {
+    let dir = TempDir::new().unwrap();
+    let base = dir.path();
+    let path = proxy_log_path_with_base(base, 4321).unwrap();
+    assert!(
+        path.to_string_lossy().contains("proxy-4321.log"),
+        "expected suffix proxy-4321.log, got {}",
+        path.display()
+    );
+    assert!(path.starts_with(base));
+}
+
+// ---------------------------------------------------------------------------
+// read_proxy_host_with_base
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_proxy_host_with_base_falls_back_to_default() {
+    let dir = TempDir::new().unwrap();
+    let host = read_proxy_host_with_base(dir.path(), 55432);
+    assert_eq!(host, DEFAULT_PROXY_HOST);
+}
+
+#[test]
+fn read_proxy_host_with_base_returns_persisted_value() {
+    let dir = TempDir::new().unwrap();
+    let base = dir.path();
+
+    // Write a host file for port 8788
+    let host_path = proxy_host_path_with_base(base, 8788).unwrap();
+    std::fs::write(&host_path, "192.168.1.1").unwrap();
+
+    let host = read_proxy_host_with_base(base, 8788);
+    assert_eq!(host, "192.168.1.1");
+}
+
+#[test]
+fn read_proxy_host_with_base_returns_persisted_value_with_trailing_newline() {
+    let dir = TempDir::new().unwrap();
+    let base = dir.path();
+
+    let host_path = proxy_host_path_with_base(base, 8788).unwrap();
+    std::fs::write(&host_path, "10.0.0.1\n").unwrap();
+
+    let host = read_proxy_host_with_base(base, 8788);
+    assert_eq!(host, "10.0.0.1");
+}
+
+// ---------------------------------------------------------------------------
+// read_pid
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_pid_returns_none_for_missing_file() {
+    assert!(read_pid(Path::new("/nonexistent/pid/file.pid")).is_none());
+}
+
+#[test]
+fn read_pid_returns_parsed_value() {
+    let mut file = NamedTempFile::new().unwrap();
+    writeln!(file, "4242").unwrap();
+    assert_eq!(read_pid(file.path()), Some(4242));
+}
+
+#[test]
+fn read_pid_rejects_invalid_content() {
+    let mut file = NamedTempFile::new().unwrap();
+    writeln!(file, "not-a-number").unwrap();
+    assert_eq!(read_pid(file.path()), None);
+}
+
+// ---------------------------------------------------------------------------
+// build_proxy_command: vx bridge
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_proxy_command_uses_vx_bridge() {
+    let (cmd, label) = build_proxy_command("127.0.0.1", 8787, None, false);
+    let program = cmd.get_program().to_string_lossy();
+
+    // The command should use the vx executable, NOT bare "headroom"
+    assert!(
+        program.contains("vx") || program.ends_with("vx.exe"),
+        "expected vx bridge, got program '{}'",
+        program
+    );
+    assert!(
+        !program.ends_with("headroom") && !program.ends_with("headroom.exe"),
+        "should NOT invoke bare headroom"
+    );
+    assert!(label.contains("vx uv tool run headroom proxy"));
+}
+
+#[test]
+fn build_proxy_command_includes_uv_tool_run_args() {
+    let (cmd, _) = build_proxy_command("10.0.0.1", 9999, None, false);
+    let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy()).collect();
+
+    // Verify the bridge path: vx uv tool run headroom proxy --host ... --port ...
+    assert!(args.iter().any(|a| a == "uv"), "expected 'uv' subcommand");
+    assert!(
+        args.iter().any(|a| a == "tool"),
+        "expected 'tool' subcommand"
+    );
+    assert!(args.iter().any(|a| a == "run"), "expected 'run' subcommand");
+    assert!(
+        args.iter().any(|a| a == "headroom"),
+        "expected 'headroom' command"
+    );
+    assert!(
+        args.iter().any(|a| a == "proxy"),
+        "expected 'proxy' command"
+    );
+}
+
+#[test]
+fn build_proxy_command_program_is_executable() {
+    let (cmd, _) = build_proxy_command("127.0.0.1", 8787, None, false);
+    let program = cmd.get_program();
+
+    // The program is derived from std::env::current_exe() which must exist.
+    let program_str = program.to_string_lossy();
+    assert!(!program_str.is_empty(), "program path must not be empty");
+    assert!(
+        Path::new(program).exists() || program_str.contains("vx"),
+        "program '{}' should exist or reference the vx binary",
+        program_str
+    );
+}
+
+#[test]
+fn build_proxy_command_includes_no_optimize_flag() {
+    let (cmd, _) = build_proxy_command("127.0.0.1", 8787, Some("/tmp/log"), true);
+    let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy()).collect();
+    assert!(
+        args.iter().any(|a| a == "--no-optimize"),
+        "expected --no-optimize in args: {:?}",
+        args
+    );
+}
+
+#[test]
+fn build_proxy_command_sets_telemetry_off() {
+    let (cmd, _) = build_proxy_command("127.0.0.1", 8787, None, false);
+    let envs: Vec<_> = cmd.get_envs().collect();
+    let telemetry_off = envs.iter().any(|(k, v)| {
+        *k == std::ffi::OsStr::new("HEADROOM_TELEMETRY")
+            && v.map(|val| val == "off").unwrap_or(false)
+    });
+    assert!(telemetry_off, "HEADROOM_TELEMETRY should be 'off'");
+}
+
+#[test]
+fn build_proxy_command_passes_log_file() {
+    let (cmd, _) = build_proxy_command("127.0.0.1", 8787, Some("/custom/log.log"), false);
+    let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy()).collect();
+    let log_file_idx = args.iter().position(|a| a == "--log-file");
+    assert!(log_file_idx.is_some(), "expected --log-file flag in args");
+    let next = args[log_file_idx.unwrap() + 1].clone();
+    assert_eq!(
+        next, "/custom/log.log",
+        "log file arg should follow --log-file"
+    );
+}
+
+#[test]
+fn build_proxy_command_passes_host_and_port() {
+    let (cmd, _) = build_proxy_command("10.20.30.40", 12345, None, false);
+    let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy()).collect();
+
+    let host_idx = args.iter().position(|a| a == "--host");
+    assert!(host_idx.is_some(), "expected --host flag");
+    assert_eq!(args[host_idx.unwrap() + 1], "10.20.30.40");
+
+    let port_idx = args.iter().position(|a| a == "--port");
+    assert!(port_idx.is_some(), "expected --port flag");
+    assert_eq!(args[port_idx.unwrap() + 1], "12345");
+}
+
+// ---------------------------------------------------------------------------
+// check_port / check_health_endpoint — behavioral verification
+// ---------------------------------------------------------------------------
+
+#[test]
+fn check_port_refuses_unreachable_host() {
+    // 240.0.0.1 is in the reserved / experimental range (240/4) and should
+    // be unreachable. This verifies check_port returns Err for a host that
+    // cannot be reached within the 2-second timeout.
+    let result = check_port("240.0.0.1", 1);
+    assert!(
+        result.is_err(),
+        "check_port should fail for unreachable host 240.0.0.1:1"
+    );
+}
+
+#[test]
+fn check_port_refuses_loopback_with_impossible_port() {
+    // On most systems, port 0 is reserved and a high port with nothing
+    // listening should be refused quickly on loopback.
+    let result = check_port("127.0.0.1", 65534);
+    if let Ok(()) = result {
+        // Some systems may have something listening on this port — skip
+        // the assertion in that case (not a real failure).
+        eprintln!("Note: 127.0.0.1:65534 was reachable (unusual but not a bug)");
+    }
+    // The primary goal is that check_port doesn't panic and returns in
+    // a reasonable time.
+}
+
+#[test]
+fn headroom_state_dir_with_base_uses_injected_base() {
+    let dir = TempDir::new().unwrap();
+    let base = dir.path();
+    let state = headroom_state_dir_with_base(base);
+    assert!(state.starts_with(base));
+    assert!(state.ends_with(std::path::Path::new(".vx").join("state").join("headroom")));
+}


### PR DESCRIPTION
## Summary

Implement `vx ai headroom proxy start|status|stop` commands as the first phase of headroom context compression integration.

- **PID file management** — state files under `~/.vx/state/headroom/`
- **Cross-platform process lifecycle** — SIGTERM on Unix, taskkill on Windows
- **Health check probing** — TCP port + `/health` HTTP endpoint
- **Telemetry default-off** — `HEADROOM_TELEMETRY=off` env var set for all proxy processes

## Commands

| Command | Description |
|---------|-------------|
| `vx ai headroom proxy start` | Start proxy in detached mode, with health check wait |
| `vx ai headroom proxy status` | PID check + process liveness + port + /health endpoint |
| `vx ai headroom proxy stop` | Graceful shutdown + PID file cleanup |

## Test plan

- [x] All 55 vx-cli unit tests pass
- [x] All add_command_tests pass
- [x] All boundary_e2e_tests pass
- [x] All tool_e2e_tests pass (212 passed, 3 ignored)
- [x] Format check passes
- [ ] Manual smoke test: `vx ai headroom proxy start` / `status` / `stop` cycle
