### PR TITLE
feat(headroom): implement MCP config setup for AI agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4639,6 +4639,7 @@ dependencies = [
  "futures-util",
  "glob",
  "indicatif",
+ "libc",
  "pretty_assertions",
  "regex",
  "reqwest",

--- a/crates/vx-cli/Cargo.toml
+++ b/crates/vx-cli/Cargo.toml
@@ -94,6 +94,9 @@ toon-format = { version = "0.5", default-features = false }
 axoupdater = { workspace = true, optional = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true }
 

--- a/crates/vx-cli/src/cli.rs
+++ b/crates/vx-cli/src/cli.rs
@@ -1542,6 +1542,153 @@ pub enum AiCommand {
     /// Commands to manage persistent state for AI agents.
     #[command(subcommand)]
     Session(SessionCommand),
+
+    /// Headroom context compression integration
+    ///
+    /// Install, configure, and manage headroom-ai for LLM context compression.
+    /// Headroom provides proxy, MCP server, and context optimization for AI agents.
+    #[command(subcommand)]
+    Headroom(HeadroomCommand),
+}
+
+/// Headroom context compression commands
+#[derive(Subcommand, Clone)]
+pub enum HeadroomCommand {
+    /// Install headroom-ai with proxy support
+    ///
+    /// Installs headroom via uv tool install.
+    /// Uses Python-first bridge: delegates to `vx uv tool install --from 'headroom-ai[proxy]==<version>' headroom`.
+    Install {
+        /// Headroom version to install (default: latest)
+        #[arg(long, default_value = "latest")]
+        version: String,
+        /// Python version to use (default: 3.11)
+        #[arg(long, default_value = "3.11")]
+        python: String,
+        /// Mcpcall version (default: 0.4.0)
+        #[arg(long, default_value = "0.4.0")]
+        mcpcall_version: String,
+        /// Force reinstall even if already installed
+        #[arg(short, long)]
+        force: bool,
+    },
+
+    /// Check headroom environment and connectivity
+    ///
+    /// Validates the local headroom installation, proxy health, and MCP availability.
+    /// Performs three-layer checks: environment, proxy, and MCP.
+    Doctor {
+        /// Quick check (skip proxy startup and MCP probe)
+        #[arg(long)]
+        quick: bool,
+        /// Output results as JSON
+        #[arg(long)]
+        json: bool,
+        /// Proxy port (default: 8787)
+        #[arg(long, default_value = "8787")]
+        port: u16,
+        /// MCP port (default: 8765)
+        #[arg(long, default_value = "8765")]
+        mcp_port: u16,
+    },
+
+    /// Generate AI agent MCP configuration templates
+    ///
+    /// Produces MCP config snippets for Codex, Claude Code, and Cursor.
+    /// Defaults to dry-run; use --apply to write config files.
+    Setup {
+        /// Target agents (codex, claude-code, cursor; default: all)
+        #[arg(short, long, action = clap::ArgAction::Append)]
+        agent: Vec<String>,
+        /// Preview changes without writing (default)
+        #[arg(long)]
+        dry_run: bool,
+        /// Write MCP configuration to agent config files
+        #[arg(long, conflicts_with = "dry_run")]
+        apply: bool,
+        /// Proxy port (default: 8787)
+        #[arg(long, default_value = "8787")]
+        port: u16,
+        /// MCP port (default: 8765)
+        #[arg(long, default_value = "8765")]
+        mcp_port: u16,
+        /// Headroom version (default: latest)
+        #[arg(long, default_value = "latest")]
+        headroom_version: String,
+    },
+
+    /// Manage headroom proxy lifecycle
+    #[command(subcommand)]
+    Proxy(HeadroomProxyCommand),
+
+    /// Headroom MCP operations
+    #[command(subcommand)]
+    Mcp(HeadroomMcpCommand),
+}
+
+/// Headroom proxy lifecycle commands
+#[derive(Subcommand, Clone)]
+pub enum HeadroomProxyCommand {
+    /// Start headroom proxy (detached by default)
+    Start {
+        /// Proxy host (default: 127.0.0.1)
+        #[arg(long, default_value = "127.0.0.1")]
+        host: String,
+        /// Proxy port (default: 8787)
+        #[arg(long, default_value = "8787")]
+        port: u16,
+        /// Run in foreground (do not detach)
+        #[arg(long)]
+        foreground: bool,
+        /// Log file path
+        #[arg(long)]
+        log_file: Option<String>,
+        /// Disable headroom optimization passthrough
+        #[arg(long)]
+        no_optimize: bool,
+    },
+
+    /// Show proxy status
+    Status {
+        /// Proxy port (default: 8787)
+        #[arg(long, default_value = "8787")]
+        port: u16,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Stop headroom proxy
+    Stop {
+        /// Proxy port (default: 8787)
+        #[arg(long, default_value = "8787")]
+        port: u16,
+    },
+}
+
+/// Headroom MCP subcommands
+#[derive(Subcommand, Clone)]
+pub enum HeadroomMcpCommand {
+    /// Run headroom MCP server in stdio mode
+    ///
+    /// Internal bridge entry point for agent MCP configurations.
+    /// Agents point to: vx ai headroom mcp stdio
+    Stdio,
+
+    /// Smoke-test headroom MCP tools via mcpcall
+    ///
+    /// Validates headroom_compress, headroom_retrieve, and headroom_stats.
+    Test {
+        /// MCP server URL (default: http://127.0.0.1:8765/mcp)
+        #[arg(long, default_value = "http://127.0.0.1:8765/mcp")]
+        url: String,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+        /// Sample file to use for compress test
+        #[arg(long)]
+        sample_file: Option<String>,
+    },
 }
 
 /// AI session management commands
@@ -2260,6 +2407,7 @@ impl CommandHandler for Commands {
                     commands::ai::handle_context(ctx, *minimal, ctx.output_format()).await
                 }
                 AiCommand::Session(session) => commands::ai::handle_session(ctx, session).await,
+                AiCommand::Headroom(headroom) => commands::ai::handle_headroom(ctx, headroom).await,
             },
 
             Commands::Schema {

--- a/crates/vx-cli/src/commands/ai.rs
+++ b/crates/vx-cli/src/commands/ai.rs
@@ -1331,7 +1331,12 @@ fn apply_mcp_config(path: &std::path::Path, entry: &HeadroomMcpEntry) -> Result<
     let mut root: serde_json::Value = if path.exists() {
         let content = std::fs::read_to_string(path)
             .with_context(|| format!("Failed to read {}", path.display()))?;
-        serde_json::from_str(&content).unwrap_or(serde_json::Value::Object(Default::default()))
+        serde_json::from_str(&content).with_context(|| {
+            format!(
+                "{} is not valid JSON — refusing to overwrite. Fix or remove the file before retrying.",
+                path.display()
+            )
+        })?
     } else {
         serde_json::Value::Object(Default::default())
     };
@@ -1357,7 +1362,7 @@ fn apply_mcp_config(path: &std::path::Path, entry: &HeadroomMcpEntry) -> Result<
     Ok(())
 }
 
-async fn handle_headroom_setup(
+pub async fn handle_headroom_setup(
     agents: &[String],
     _dry_run: bool,
     apply: bool,
@@ -1402,6 +1407,7 @@ async fn handle_headroom_setup(
         UI::info("Applying MCP configuration...");
         println!();
 
+        let mut errors: Vec<String> = Vec::new();
         for target in &targets {
             let config_path = cwd.join(target.config_path);
             match apply_mcp_config(&config_path, &entry) {
@@ -1413,14 +1419,23 @@ async fn handle_headroom_setup(
                     ));
                 }
                 Err(e) => {
-                    UI::error(&format!(
-                        "{}: failed to update {} - {}",
+                    let msg = format!(
+                        "{}: failed to update {} — {}",
                         target.name,
                         config_path.display(),
                         e
-                    ));
+                    );
+                    UI::error(&msg);
+                    errors.push(msg);
                 }
             }
+        }
+        if !errors.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Failed to write {} agent config(s):\n{}",
+                errors.len(),
+                errors.join("\n")
+            ));
         }
     } else {
         // dry-run (default)

--- a/crates/vx-cli/src/commands/ai.rs
+++ b/crates/vx-cli/src/commands/ai.rs
@@ -1270,9 +1270,96 @@ async fn handle_headroom_doctor(quick: bool, json: bool, port: u16, mcp_port: u1
 /// Handle `vx ai headroom setup` — generate MCP config templates.
 ///
 /// Stub in PIP-601; full implementation in PIP-604.
+// ---------------------------------------------------------------------------
+// Headroom setup: MCP config templates for AI agents
+// ---------------------------------------------------------------------------
+
+/// MCP server entry for headroom — what gets written into agent configs.
+#[derive(Debug, serde::Serialize)]
+struct HeadroomMcpEntry {
+    command: &'static str,
+    args: Vec<&'static str>,
+    env: std::collections::BTreeMap<&'static str, &'static str>,
+}
+
+fn headroom_mcp_entry() -> HeadroomMcpEntry {
+    let mut env = std::collections::BTreeMap::new();
+    env.insert("HEADROOM_TELEMETRY", "off");
+    HeadroomMcpEntry {
+        command: "vx",
+        args: vec!["ai", "headroom", "mcp", "stdio"],
+        env,
+    }
+}
+
+/// Agent MCP config target — maps agent name to config file path (relative to CWD).
+struct McpAgentTarget {
+    name: &'static str,
+    config_path: &'static str,
+}
+
+const MCP_AGENT_TARGETS: &[McpAgentTarget] = &[
+    McpAgentTarget {
+        name: "codex",
+        config_path: ".codex/mcp.json",
+    },
+    McpAgentTarget {
+        name: "claude-code",
+        config_path: ".claude/settings.json",
+    },
+    McpAgentTarget {
+        name: "cursor",
+        config_path: ".cursor/mcp.json",
+    },
+];
+
+/// Format a single MCP server entry as a pretty-printed JSON snippet.
+fn format_mcp_snippet(entry: &HeadroomMcpEntry) -> Result<String> {
+    let mut servers = serde_json::Map::new();
+    servers.insert("headroom".to_string(), serde_json::to_value(entry)?);
+    let mut root = serde_json::Map::new();
+    root.insert("mcpServers".to_string(), serde_json::Value::Object(servers));
+    serde_json::to_string_pretty(&serde_json::Value::Object(root))
+        .context("Failed to serialize MCP config")
+}
+
+/// Merge the headroom MCP entry into an existing config file.
+///
+/// Reads the file (JSON object), sets `mcpServers.headroom`, writes back.
+/// If the file doesn't exist, creates it fresh.
+fn apply_mcp_config(path: &std::path::Path, entry: &HeadroomMcpEntry) -> Result<()> {
+    let mut root: serde_json::Value = if path.exists() {
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        serde_json::from_str(&content).unwrap_or(serde_json::Value::Object(Default::default()))
+    } else {
+        serde_json::Value::Object(Default::default())
+    };
+
+    // Ensure mcpServers exists
+    let mcp_servers = root
+        .as_object_mut()
+        .context("Config file is not a JSON object")?
+        .entry("mcpServers")
+        .or_insert_with(|| serde_json::Value::Object(Default::default()));
+
+    mcp_servers["headroom"] = serde_json::to_value(entry)?;
+
+    // Create parent directory if needed
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+
+    std::fs::write(path, serde_json::to_string_pretty(&root)? + "\n")
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+
+    Ok(())
+}
+
 async fn handle_headroom_setup(
     agents: &[String],
-    dry_run: bool,
+    _dry_run: bool,
     apply: bool,
     port: u16,
     mcp_port: u16,
@@ -1280,30 +1367,87 @@ async fn handle_headroom_setup(
 ) -> Result<()> {
     UI::header("headroom setup");
     println!();
-    UI::info("setup: not yet implemented (PIP-604)");
-    UI::info(&format!(
-        "Would configure MCP for agents: {}",
-        if agents.is_empty() {
-            "codex, claude-code, cursor (default)"
-        } else {
-            ""
-        }
-    ));
-    if !agents.is_empty() {
-        UI::info(&format!("  requested agents: {}", agents.join(", ")));
+
+    // Resolve target agents
+    let targets: Vec<&McpAgentTarget> = if agents.is_empty() {
+        // Default: all three
+        MCP_AGENT_TARGETS.iter().collect()
+    } else {
+        agents
+            .iter()
+            .filter_map(|name| MCP_AGENT_TARGETS.iter().find(|t| t.name == name.as_str()))
+            .collect()
+    };
+
+    if targets.is_empty() {
+        UI::warn("No matching agents found. Supported: codex, claude-code, cursor.");
+        return Ok(());
     }
+
+    let entry = headroom_mcp_entry();
+    let snippet = format_mcp_snippet(&entry)?;
+    let cwd = std::env::current_dir().context("Failed to get current directory")?;
+
+    UI::info(&format!(
+        "MCP command: {} {}",
+        entry.command,
+        entry.args.join(" ")
+    ));
     UI::info(&format!("  proxy port: {}", port));
     UI::info(&format!("  MCP port: {}", mcp_port));
     UI::info(&format!("  headroom version: {}", headroom_version));
-    UI::info(&format!(
-        "  mode: {}",
-        if apply {
-            "--apply"
-        } else {
-            "--dry-run (default)"
+    println!();
+
+    if apply {
+        UI::info("Applying MCP configuration...");
+        println!();
+
+        for target in &targets {
+            let config_path = cwd.join(target.config_path);
+            match apply_mcp_config(&config_path, &entry) {
+                Ok(()) => {
+                    UI::success(&format!(
+                        "{}: updated {}",
+                        target.name,
+                        config_path.display()
+                    ));
+                }
+                Err(e) => {
+                    UI::error(&format!(
+                        "{}: failed to update {} - {}",
+                        target.name,
+                        config_path.display(),
+                        e
+                    ));
+                }
+            }
         }
-    ));
-    UI::hint("This command will be fully implemented in PIP-604.");
+    } else {
+        // dry-run (default)
+        UI::info("Dry-run mode. Use --apply to write config files.");
+        println!();
+
+        for target in &targets {
+            let config_path = cwd.join(target.config_path);
+            let status = if config_path.exists() {
+                "(exists — would merge)"
+            } else {
+                "(new file)"
+            };
+            UI::info(&format!(
+                "{}: {} {}",
+                target.name,
+                config_path.display(),
+                status
+            ));
+        }
+
+        println!();
+        UI::header("Configuration to be written");
+        println!();
+        println!("{}", snippet);
+    }
+
     Ok(())
 }
 

--- a/crates/vx-cli/src/commands/ai.rs
+++ b/crates/vx-cli/src/commands/ai.rs
@@ -10,6 +10,7 @@
 //! - `vx ai context` - Generate AI-friendly project context (RFC 0035)
 //! - `vx ai session` - Manage AI session state (RFC 0035)
 
+use crate::cli::{HeadroomCommand, HeadroomMcpCommand, HeadroomProxyCommand};
 use crate::cli::{OutputFormat, SessionCommand};
 use crate::commands::CommandContext;
 use crate::output::{
@@ -881,4 +882,718 @@ async fn handle_session_cleanup(_ctx: &CommandContext) -> Result<()> {
     UI::success("AI session cleaned up");
 
     Ok(())
+}
+
+// ============================================================================
+// vx ai headroom (PIP-584 Phase 1)
+// ============================================================================
+
+/// Default headroom version
+const DEFAULT_HEADROOM_VERSION: &str = "0.22.3";
+/// Default Python version for headroom runtime
+#[allow(dead_code)]
+const DEFAULT_PYTHON_VERSION: &str = "3.11";
+/// Default mcpcall version
+#[allow(dead_code)]
+const DEFAULT_MCPCALL_VERSION: &str = "0.4.0";
+/// Default proxy host
+const DEFAULT_PROXY_HOST: &str = "127.0.0.1";
+/// Default proxy port
+#[allow(dead_code)]
+const DEFAULT_PROXY_PORT: u16 = 8787;
+
+// ---------------------------------------------------------------------------
+// Proxy state management helpers
+// ---------------------------------------------------------------------------
+
+/// Returns the headroom state directory: `~/.vx/state/headroom/`
+fn headroom_state_dir() -> Result<std::path::PathBuf> {
+    let home = dirs::home_dir().context("Could not determine home directory")?;
+    Ok(home.join(".vx").join("state").join("headroom"))
+}
+
+/// Returns the PID file path for a given proxy port
+fn proxy_pid_path(port: u16) -> Result<std::path::PathBuf> {
+    let dir = headroom_state_dir()?;
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("Failed to create state directory: {}", dir.display()))?;
+    Ok(dir.join(format!("proxy-{}.pid", port)))
+}
+
+/// Returns the default log file path for a given proxy port
+fn proxy_log_path(port: u16) -> Result<std::path::PathBuf> {
+    let dir = headroom_state_dir()?;
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("Failed to create state directory: {}", dir.display()))?;
+    Ok(dir.join(format!("proxy-{}.log", port)))
+}
+
+/// Reads a PID from a PID file. Returns `None` if the file does not exist or is unreadable.
+fn read_pid(path: &std::path::Path) -> Option<u32> {
+    let content = std::fs::read_to_string(path).ok()?;
+    content.trim().parse::<u32>().ok()
+}
+
+/// Checks whether a process with the given PID is running on this platform.
+#[cfg(unix)]
+fn is_process_running(pid: u32) -> bool {
+    unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+#[cfg(windows)]
+fn is_process_running(pid: u32) -> bool {
+    let output = std::process::Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {}", pid)])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output();
+    match output {
+        Ok(out) => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            stdout.contains(&format!("{}", pid))
+        }
+        Err(_) => false,
+    }
+}
+
+/// Tries to connect to the proxy's TCP port. Returns `Ok` if the port is reachable.
+fn check_port(host: &str, port: u16) -> Result<()> {
+    use std::net::TcpStream;
+    use std::time::Duration;
+    let addr = format!("{}:{}", host, port);
+    TcpStream::connect_timeout(&addr.parse()?, Duration::from_secs(2))
+        .with_context(|| format!("Port {}:{} is not reachable", host, port))?;
+    Ok(())
+}
+
+/// Performs a minimal HTTP health check: `GET /health`. Returns `true` if status is 200 OK.
+fn check_health_endpoint(host: &str, port: u16) -> bool {
+    use std::io::{Read, Write};
+    use std::net::TcpStream;
+    use std::time::Duration;
+
+    let addr = format!("{}:{}", host, port);
+    let mut stream =
+        match TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(2)) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+    stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+    stream.set_write_timeout(Some(Duration::from_secs(2))).ok();
+
+    let request = format!(
+        "GET /health HTTP/1.0\r\nHost: {}:{}\r\nConnection: close\r\n\r\n",
+        host, port
+    );
+    if stream.write_all(request.as_bytes()).is_err() {
+        return false;
+    }
+    let mut response = String::new();
+    if stream.read_to_string(&mut response).is_err() {
+        return false;
+    }
+    response.contains("200 OK")
+}
+
+/// Build the `headroom proxy` command with the given arguments.
+/// Returns the command and a human-readable label.
+fn build_proxy_command(
+    host: &str,
+    port: u16,
+    log_file: Option<&str>,
+    no_optimize: bool,
+) -> (std::process::Command, String) {
+    let mut cmd = std::process::Command::new("headroom");
+    cmd.args(["proxy", "--host", host, "--port", &port.to_string()]);
+
+    if no_optimize {
+        cmd.arg("--no-optimize");
+    }
+
+    // Headroom telemetry is disabled by default per PIP-584 product decision
+    cmd.env("HEADROOM_TELEMETRY", "off");
+
+    let log_path = if let Some(lf) = log_file {
+        std::path::PathBuf::from(lf)
+    } else {
+        proxy_log_path(port).unwrap_or_else(|_| std::path::PathBuf::from("headroom-proxy.log"))
+    };
+
+    cmd.arg("--log-file");
+    cmd.arg(log_path.to_string_lossy().as_ref());
+
+    let label = format!("headroom proxy --host {} --port {}", host, port);
+    (cmd, label)
+}
+
+/// Handle `vx ai headroom` command — dispatches to subcommands.
+pub async fn handle_headroom(ctx: &CommandContext, command: &HeadroomCommand) -> Result<()> {
+    match command {
+        HeadroomCommand::Install {
+            version,
+            python,
+            mcpcall_version,
+            force,
+        } => handle_headroom_install(version, python, mcpcall_version, *force).await,
+        HeadroomCommand::Doctor {
+            quick,
+            json,
+            port,
+            mcp_port,
+        } => handle_headroom_doctor(*quick, *json, *port, *mcp_port).await,
+        HeadroomCommand::Setup {
+            agent,
+            dry_run,
+            apply,
+            port,
+            mcp_port,
+            headroom_version,
+        } => {
+            handle_headroom_setup(agent, *dry_run, *apply, *port, *mcp_port, headroom_version).await
+        }
+        HeadroomCommand::Proxy(proxy) => handle_headroom_proxy(proxy).await,
+        HeadroomCommand::Mcp(mcp) => handle_headroom_mcp(ctx, mcp).await,
+    }
+}
+
+/// Resolve the actual version string (replaces "latest" with the default)
+fn resolve_version(version: &str) -> &str {
+    if version == "latest" {
+        DEFAULT_HEADROOM_VERSION
+    } else {
+        version
+    }
+}
+
+/// Handle `vx ai headroom install` — installs headroom-ai[proxy] via uv tool install.
+///
+/// Bridge runner: delegates to `vx uv tool install --python <version>
+/// --from 'headroom-ai[proxy]==<version>' headroom`.
+/// Also ensures mcpcall is available.
+async fn handle_headroom_install(
+    version: &str,
+    python: &str,
+    mcpcall_version: &str,
+    force: bool,
+) -> Result<()> {
+    let vx_exe = std::env::current_exe().context("Could not determine vx executable path")?;
+    let resolved_version = resolve_version(version);
+
+    UI::header("Installing headroom-ai");
+    println!();
+
+    // Step 1: Install headroom via uv tool install
+    // Equivalent to: vx uv tool install --python <python> --from 'headroom-ai[proxy]==<version>' headroom
+    let headroom_spec = format!("headroom-ai[proxy]=={}", resolved_version);
+
+    let mut install_args = vec![
+        "uv".to_string(),
+        "tool".to_string(),
+        "install".to_string(),
+        "--python".to_string(),
+        python.to_string(),
+        "--from".to_string(),
+        headroom_spec.clone(),
+        "headroom".to_string(),
+    ];
+
+    if force {
+        install_args.push("--force".to_string());
+    }
+
+    UI::info(&format!(
+        "Installing {} with Python {}...",
+        headroom_spec, python
+    ));
+
+    let install_status = std::process::Command::new(&vx_exe)
+        .args(&install_args)
+        .status()
+        .context("Failed to execute 'vx uv tool install' for headroom-ai")?;
+
+    if !install_status.success() {
+        let code = install_status.code().unwrap_or(1);
+        UI::error(&format!("headroom install failed with exit code {}", code));
+        UI::hint(
+            "Try running manually: vx uv tool install --python <version> --from 'headroom-ai[proxy]==<version>' headroom",
+        );
+        std::process::exit(code);
+    }
+
+    UI::success(&format!(
+        "headroom-ai[proxy] {} installed successfully",
+        resolved_version
+    ));
+
+    // Step 2: Ensure mcpcall is available
+    UI::info(&format!(
+        "Ensuring mcpcall {} is available...",
+        mcpcall_version
+    ));
+
+    let mcpcall_status = std::process::Command::new(&vx_exe)
+        .args(["install", "mcpcall", mcpcall_version])
+        .status()
+        .context("Failed to install mcpcall")?;
+
+    if mcpcall_status.success() {
+        UI::success(&format!("mcpcall {} ready", mcpcall_version));
+    } else {
+        UI::warn(&format!(
+            "mcpcall {} may not be installed — MCP smoke tests may fail",
+            mcpcall_version
+        ));
+    }
+
+    // Step 3: Run quick doctor check
+    UI::info("Running quick health check...");
+    handle_headroom_doctor(true, false, 8787, 8765).await?;
+
+    println!();
+    UI::success("headroom-ai installation complete");
+    UI::hint("Run 'vx ai headroom doctor' to verify the environment");
+    UI::hint("Run 'vx ai headroom proxy start' to start the proxy");
+    UI::hint("Run 'vx ai headroom mcp test' to validate MCP tools");
+
+    Ok(())
+}
+
+/// Handle `vx ai headroom doctor` — environment diagnostic checks.
+///
+/// Three-layer check: environment, proxy, MCP.
+/// This is a stub in PIP-601; full implementation in PIP-603.
+async fn handle_headroom_doctor(quick: bool, json: bool, port: u16, mcp_port: u16) -> Result<()> {
+    let vx_exe = std::env::current_exe().context("Could not determine vx executable path")?;
+
+    UI::header("headroom doctor");
+
+    // Layer 1: Environment checks
+    println!();
+    UI::info("--- Environment ---");
+
+    // Check uv availability
+    let uv_check = std::process::Command::new(&vx_exe)
+        .args(["uv", "--version"])
+        .output();
+    match uv_check {
+        Ok(output) if output.status.success() => {
+            let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            UI::success(&format!("uv: {}", ver));
+        }
+        _ => UI::error("uv: not available"),
+    }
+
+    // Check python availability
+    let py_check = std::process::Command::new(&vx_exe)
+        .args(["python", "--version"])
+        .output();
+    match py_check {
+        Ok(output) if output.status.success() => {
+            let ver = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let ver = if ver.is_empty() {
+                String::from_utf8_lossy(&output.stdout).trim().to_string()
+            } else {
+                ver
+            };
+            UI::success(&format!("python: {}", ver));
+        }
+        _ => UI::warn("python: check skipped (may not be installed via vx)"),
+    }
+
+    // Check headroom availability
+    let hr_check = std::process::Command::new(&vx_exe)
+        .args([
+            "uv",
+            "tool",
+            "run",
+            "--from",
+            &format!("headroom-ai[proxy]=={}", DEFAULT_HEADROOM_VERSION),
+            "headroom",
+            "--version",
+        ])
+        .output();
+    match hr_check {
+        Ok(output) if output.status.success() => {
+            let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            UI::success(&format!("headroom-ai: {}", ver));
+        }
+        _ => UI::error(&format!(
+            "headroom-ai[proxy] {}: not installed",
+            DEFAULT_HEADROOM_VERSION
+        )),
+    }
+
+    // Check mcpcall availability
+    let mcpcall_check = std::process::Command::new(&vx_exe)
+        .args(["mcpcall", "--version"])
+        .output();
+    match mcpcall_check {
+        Ok(output) if output.status.success() => {
+            let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            UI::success(&format!("mcpcall: {}", ver));
+        }
+        _ => UI::warn("mcpcall: not installed (run 'vx ai headroom install' to set up)"),
+    }
+
+    if quick {
+        UI::hint("Quick check complete. Run without --quick for proxy and MCP checks.");
+        return Ok(());
+    }
+
+    // Layer 2: Proxy checks
+    println!();
+    UI::info(&format!("--- Proxy (port {}) ---", port));
+    UI::info("proxy check: not yet implemented (PIP-602)");
+    UI::hint("Run 'vx ai headroom proxy start' to start the proxy service.");
+
+    // Layer 3: MCP checks
+    println!();
+    UI::info(&format!("--- MCP (port {}) ---", mcp_port));
+    UI::info("MCP check: not yet implemented (PIP-603)");
+    UI::hint("Run 'vx ai headroom mcp test' to validate MCP tools.");
+
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "status": "ok",
+                "headroom_version": DEFAULT_HEADROOM_VERSION,
+                "proxy_port": port,
+                "mcp_port": mcp_port,
+            })
+        );
+    }
+
+    Ok(())
+}
+
+/// Handle `vx ai headroom setup` — generate MCP config templates.
+///
+/// Stub in PIP-601; full implementation in PIP-604.
+async fn handle_headroom_setup(
+    agents: &[String],
+    dry_run: bool,
+    apply: bool,
+    port: u16,
+    mcp_port: u16,
+    headroom_version: &str,
+) -> Result<()> {
+    UI::header("headroom setup");
+    println!();
+    UI::info("setup: not yet implemented (PIP-604)");
+    UI::info(&format!(
+        "Would configure MCP for agents: {}",
+        if agents.is_empty() {
+            "codex, claude-code, cursor (default)"
+        } else {
+            ""
+        }
+    ));
+    if !agents.is_empty() {
+        UI::info(&format!("  requested agents: {}", agents.join(", ")));
+    }
+    UI::info(&format!("  proxy port: {}", port));
+    UI::info(&format!("  MCP port: {}", mcp_port));
+    UI::info(&format!("  headroom version: {}", headroom_version));
+    UI::info(&format!(
+        "  mode: {}",
+        if apply {
+            "--apply"
+        } else {
+            "--dry-run (default)"
+        }
+    ));
+    UI::hint("This command will be fully implemented in PIP-604.");
+    Ok(())
+}
+
+/// Handle `vx ai headroom proxy` — dispatch to proxy subcommands.
+///
+/// Manages the headroom proxy lifecycle: start (detached or foreground),
+/// status (process + health probe), and stop.
+async fn handle_headroom_proxy(command: &HeadroomProxyCommand) -> Result<()> {
+    match command {
+        HeadroomProxyCommand::Start {
+            host,
+            port,
+            foreground,
+            log_file,
+            no_optimize,
+        } => {
+            UI::header("headroom proxy start");
+            println!();
+
+            // Check if already running
+            let pid_path = proxy_pid_path(*port)?;
+            if let Some(pid) = read_pid(&pid_path) {
+                if is_process_running(pid) {
+                    UI::warn(&format!(
+                        "A headroom proxy appears to be running on port {} (PID {})",
+                        port, pid
+                    ));
+                    UI::hint("Run 'vx ai headroom proxy stop' to stop it first.");
+                    return Ok(());
+                }
+            }
+
+            // Verify headroom is installed
+            UI::step("Checking headroom availability...");
+            let version_check = std::process::Command::new("headroom")
+                .arg("--version")
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .output();
+
+            match version_check {
+                Ok(out) if out.status.success() => {
+                    let v = String::from_utf8_lossy(&out.stdout);
+                    UI::success(&format!("headroom: {}", v.trim()));
+                }
+                _ => {
+                    UI::error("headroom is not installed or not in PATH");
+                    UI::hint("Run 'vx ai headroom install' to install headroom-ai[proxy].");
+                    return Ok(());
+                }
+            }
+
+            let (mut cmd, _label) =
+                build_proxy_command(host, *port, log_file.as_deref(), *no_optimize);
+
+            if *foreground {
+                UI::info(&format!(
+                    "Starting headroom proxy in foreground on {}:{}...",
+                    host, port
+                ));
+                let status = cmd
+                    .stdin(std::process::Stdio::inherit())
+                    .stdout(std::process::Stdio::inherit())
+                    .stderr(std::process::Stdio::inherit())
+                    .status()
+                    .context("Failed to start headroom proxy in foreground")?;
+
+                if !status.success() {
+                    UI::error(&format!(
+                        "headroom proxy exited with code: {:?}",
+                        status.code()
+                    ));
+                }
+            } else {
+                UI::info(&format!(
+                    "Starting headroom proxy (detached) on {}:{}...",
+                    host, port
+                ));
+
+                let child = cmd
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn()
+                    .context("Failed to spawn headroom proxy process")?;
+
+                let pid = child.id();
+                std::fs::write(&pid_path, pid.to_string())
+                    .with_context(|| format!("Failed to write PID file: {}", pid_path.display()))?;
+
+                UI::success(&format!(
+                    "headroom proxy started (PID {}) on {}:{}",
+                    pid, host, port
+                ));
+                UI::item(&format!("PID file: {}", pid_path.display()));
+
+                let log = log_file
+                    .as_deref()
+                    .map(std::path::PathBuf::from)
+                    .unwrap_or_else(|| {
+                        proxy_log_path(*port)
+                            .unwrap_or_else(|_| std::path::PathBuf::from("headroom-proxy.log"))
+                    });
+                UI::item(&format!("Log file: {}", log.display()));
+
+                // Verify the proxy responds
+                UI::step("Waiting for proxy to become ready...");
+                for i in 1..=10 {
+                    if check_port(host, *port).is_ok() && check_health_endpoint(host, *port) {
+                        UI::success("headroom proxy is healthy and accepting connections");
+                        break;
+                    }
+                    if i == 10 {
+                        UI::warn("headroom proxy started but health check timed out");
+                        UI::hint("Check logs and run 'vx ai headroom proxy status' to diagnose.");
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                }
+            }
+        }
+
+        HeadroomProxyCommand::Status { port, json } => {
+            let pid_path = proxy_pid_path(*port)?;
+            let pid = read_pid(&pid_path);
+            let running = pid.map_or(false, is_process_running);
+            let port_open = check_port(DEFAULT_PROXY_HOST, *port).is_ok();
+            let healthy = port_open && check_health_endpoint(DEFAULT_PROXY_HOST, *port);
+
+            if *json {
+                let status = if healthy {
+                    "healthy"
+                } else if running && port_open {
+                    "unhealthy"
+                } else if running {
+                    "not_listening"
+                } else if pid.is_some() {
+                    "stale_pid"
+                } else {
+                    "not_running"
+                };
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "status": status,
+                        "port": port,
+                        "pid": pid,
+                        "process_running": running,
+                        "port_open": port_open,
+                        "health_check": healthy,
+                        "pid_file": pid_path.display().to_string(),
+                    })
+                );
+            } else {
+                UI::header("headroom proxy status");
+                println!();
+
+                match (running, port_open, healthy) {
+                    (true, true, true) => {
+                        UI::success(&format!(
+                            "headroom proxy is running on port {} (PID {}) — healthy",
+                            port,
+                            pid.unwrap()
+                        ));
+                    }
+                    (true, true, false) => {
+                        UI::warn("headroom proxy is running but health check failed");
+                        UI::item(&format!("Port {} is open, PID {}", port, pid.unwrap()));
+                        UI::hint("Check the proxy logs for errors.");
+                    }
+                    (true, false, _) => {
+                        UI::warn("headroom proxy process exists but port is not open");
+                        UI::item(&format!("PID: {} (found in pid file)", pid.unwrap()));
+                    }
+                    (false, _, _) if pid.is_some() => {
+                        UI::warn(&format!(
+                            "headroom proxy is not running (stale PID file for {})",
+                            pid.unwrap()
+                        ));
+                        UI::hint(&format!("Remove stale PID file: {}", pid_path.display()));
+                    }
+                    _ => {
+                        UI::info("headroom proxy is not running");
+                    }
+                }
+
+                UI::item(&format!("Port: {}", port));
+                UI::item(&format!("PID file: {}", pid_path.display()));
+            }
+        }
+
+        HeadroomProxyCommand::Stop { port } => {
+            UI::header("headroom proxy stop");
+            println!();
+
+            let pid_path = proxy_pid_path(*port)?;
+            let pid = read_pid(&pid_path);
+
+            match pid {
+                Some(p) if is_process_running(p) => {
+                    UI::info(&format!(
+                        "Stopping headroom proxy on port {} (PID {})...",
+                        port, p
+                    ));
+                    kill_process(p)?;
+                    let _ = std::fs::remove_file(&pid_path);
+                    UI::success(&format!("headroom proxy (PID {}) stopped", p));
+                }
+                Some(p) => {
+                    UI::warn(&format!(
+                        "PID {} found in PID file but process is not running (stale PID)",
+                        p
+                    ));
+                    let _ = std::fs::remove_file(&pid_path);
+                    UI::info("Cleaned up stale PID file.");
+                }
+                None => {
+                    // Try to find by port in use
+                    if check_port(DEFAULT_PROXY_HOST, *port).is_ok() {
+                        UI::warn(&format!("Port {} is in use but no PID file found", port));
+                        UI::hint(
+                            "The proxy may have been started outside of vx. Stop it manually.",
+                        );
+                    } else {
+                        UI::info("headroom proxy is not running.");
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Kill a process by PID. Platform-specific implementation.
+#[cfg(unix)]
+fn kill_process(pid: u32) -> Result<()> {
+    unsafe {
+        if libc::kill(pid as i32, libc::SIGTERM) != 0 {
+            let err = std::io::Error::last_os_error();
+            anyhow::bail!("Failed to send SIGTERM to PID {}: {}", pid, err);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn kill_process(pid: u32) -> Result<()> {
+    let status = std::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/F"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .with_context(|| format!("Failed to run taskkill for PID {}", pid))?;
+
+    if !status.success() {
+        anyhow::bail!("taskkill failed for PID {}", pid);
+    }
+    Ok(())
+}
+
+/// Handle `vx ai headroom mcp` — dispatch to MCP subcommands.
+///
+/// Stubs in PIP-601; full implementation in PIP-603.
+async fn handle_headroom_mcp(_ctx: &CommandContext, command: &HeadroomMcpCommand) -> Result<()> {
+    match command {
+        HeadroomMcpCommand::Stdio => {
+            // Internal bridge entry point for agent MCP configurations.
+            // In Phase 1, this is a stub. Eventually delegates to headroom MCP server.
+            UI::error("headroom mcp stdio: not yet implemented (PIP-603)");
+            UI::hint(
+                "Run 'vx ai headroom install' first, then 'vx ai headroom mcp test' to verify.",
+            );
+            Ok(())
+        }
+        HeadroomMcpCommand::Test {
+            url,
+            json,
+            sample_file,
+        } => {
+            UI::header("headroom mcp test");
+            println!();
+            UI::info("mcp test: not yet implemented (PIP-603)");
+            UI::info(&format!("  MCP URL: {}", url));
+            if *json {
+                UI::info("  output: json");
+            }
+            if let Some(sample) = sample_file {
+                UI::info(&format!("  sample file: {}", sample));
+            }
+            UI::hint("This command will be fully implemented in PIP-603.");
+            Ok(())
+        }
+    }
 }

--- a/crates/vx-cli/tests/headroom_setup_tests.rs
+++ b/crates/vx-cli/tests/headroom_setup_tests.rs
@@ -1,0 +1,243 @@
+//! Behavioral tests for `vx ai headroom setup` — dry-run, apply, error handling.
+
+use std::fs;
+use std::path::PathBuf;
+
+use serial_test::serial;
+use tempfile::TempDir;
+
+use vx_cli::commands::ai::handle_headroom_setup;
+
+struct CwdGuard {
+    original: PathBuf,
+}
+
+impl CwdGuard {
+    fn enter(path: &std::path::Path) -> Self {
+        let original = std::env::current_dir().expect("Failed to read current dir");
+        std::env::set_current_dir(path).expect("Failed to enter temp dir");
+        Self { original }
+    }
+}
+
+impl Drop for CwdGuard {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.original);
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_headroom_setup_dry_run_does_not_touch_disk() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let _cwd = CwdGuard::enter(temp_dir.path());
+
+    let agents: Vec<String> = vec![];
+    handle_headroom_setup(
+        &agents, true, /* dry_run */
+        false, 8787, 8765, "latest",
+    )
+    .await
+    .expect("dry-run should succeed");
+
+    // Verify no config files were created
+    assert!(!temp_dir.path().join(".codex/mcp.json").exists());
+    assert!(!temp_dir.path().join(".claude/settings.json").exists());
+    assert!(!temp_dir.path().join(".cursor/mcp.json").exists());
+    assert!(!temp_dir.path().join(".codex").exists());
+    assert!(!temp_dir.path().join(".claude").exists());
+    assert!(!temp_dir.path().join(".cursor").exists());
+}
+
+#[tokio::test]
+#[serial]
+async fn test_headroom_setup_apply_creates_new_config() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let _cwd = CwdGuard::enter(temp_dir.path());
+
+    let agents: Vec<String> = vec!["codex".to_string()];
+    let result = handle_headroom_setup(&agents, false, true, 8787, 8765, "latest").await;
+    assert!(result.is_ok(), "apply should succeed: {:?}", result.err());
+
+    let config_path = temp_dir.path().join(".codex/mcp.json");
+    assert!(config_path.exists());
+
+    let content = fs::read_to_string(&config_path).expect("should read config");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&content).expect("config should be valid JSON");
+
+    assert_eq!(parsed["mcpServers"]["headroom"]["command"], "vx");
+    assert_eq!(parsed["mcpServers"]["headroom"]["args"][0], "ai");
+    assert_eq!(parsed["mcpServers"]["headroom"]["args"][1], "headroom");
+    assert_eq!(parsed["mcpServers"]["headroom"]["args"][2], "mcp");
+    assert_eq!(parsed["mcpServers"]["headroom"]["args"][3], "stdio");
+    // HEADROOM_TELEMETRY=off must be present
+    let env = &parsed["mcpServers"]["headroom"]["env"];
+    assert_eq!(env["HEADROOM_TELEMETRY"], "off");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_headroom_setup_apply_preserves_existing_config() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let _cwd = CwdGuard::enter(temp_dir.path());
+
+    // Pre-create a valid config with another MCP server
+    let codex_dir = temp_dir.path().join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create .codex dir");
+    let pre_existing = serde_json::json!({
+        "mcpServers": {
+            "other-server": {
+                "command": "python",
+                "args": ["-m", "other_server"]
+            }
+        }
+    });
+    fs::write(
+        codex_dir.join("mcp.json"),
+        serde_json::to_string_pretty(&pre_existing).unwrap() + "\n",
+    )
+    .expect("write pre-existing config");
+
+    let agents: Vec<String> = vec!["codex".to_string()];
+    let result = handle_headroom_setup(&agents, false, true, 8787, 8765, "latest").await;
+    assert!(result.is_ok(), "apply should succeed: {:?}", result.err());
+
+    let content = fs::read_to_string(codex_dir.join("mcp.json")).expect("should read config");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&content).expect("config should be valid JSON");
+
+    // Original server preserved
+    assert_eq!(parsed["mcpServers"]["other-server"]["command"], "python");
+    // Headroom entry added
+    assert_eq!(parsed["mcpServers"]["headroom"]["command"], "vx");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_headroom_setup_apply_invalid_json_returns_error() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let _cwd = CwdGuard::enter(temp_dir.path());
+
+    // Pre-create an invalid JSON file
+    let codex_dir = temp_dir.path().join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create .codex dir");
+    fs::write(codex_dir.join("mcp.json"), "not valid json {{{").expect("write invalid config");
+
+    let agents: Vec<String> = vec!["codex".to_string()];
+    let result = handle_headroom_setup(&agents, false, true, 8787, 8765, "latest").await;
+    assert!(result.is_err(), "should fail on invalid JSON");
+
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("not valid JSON"),
+        "error should mention invalid JSON, got: {}",
+        err_msg
+    );
+
+    // Original content must NOT be overwritten
+    let content = fs::read_to_string(codex_dir.join("mcp.json")).expect("should read config");
+    assert_eq!(
+        content, "not valid json {{{",
+        "original content must be preserved"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_headroom_setup_apply_write_failure_returns_error() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let _cwd = CwdGuard::enter(temp_dir.path());
+
+    // Create .codex as a file (not directory) to cause a write failure
+    let codex_path = temp_dir.path().join(".codex");
+    fs::write(&codex_path, "not a directory").expect("write blocking file");
+
+    let agents: Vec<String> = vec!["codex".to_string()];
+    let result = handle_headroom_setup(&agents, false, true, 8787, 8765, "latest").await;
+    assert!(result.is_err(), "should fail when write is impossible");
+
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("Failed to write") || err_msg.contains("Failed to create"),
+        "error should mention the failure, got: {}",
+        err_msg
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_headroom_setup_apply_multiple_agents() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let _cwd = CwdGuard::enter(temp_dir.path());
+
+    let agents: Vec<String> = vec!["codex".to_string(), "claude-code".to_string()];
+    let result = handle_headroom_setup(&agents, false, true, 8787, 8765, "latest").await;
+    assert!(
+        result.is_ok(),
+        "multi-agent apply should succeed: {:?}",
+        result.err()
+    );
+
+    // Both config files should exist
+    assert!(temp_dir.path().join(".codex/mcp.json").exists());
+    assert!(temp_dir.path().join(".claude/settings.json").exists());
+
+    // Untargeted agent should NOT exist
+    assert!(!temp_dir.path().join(".cursor/mcp.json").exists());
+}
+
+#[tokio::test]
+#[serial]
+async fn test_headroom_setup_default_targets_all_agents() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let _cwd = CwdGuard::enter(temp_dir.path());
+
+    // Empty agents list = all three
+    let agents: Vec<String> = vec![];
+    let result = handle_headroom_setup(&agents, false, true, 8787, 8765, "latest").await;
+    assert!(
+        result.is_ok(),
+        "default apply should succeed: {:?}",
+        result.err()
+    );
+
+    assert!(temp_dir.path().join(".codex/mcp.json").exists());
+    assert!(temp_dir.path().join(".claude/settings.json").exists());
+    assert!(temp_dir.path().join(".cursor/mcp.json").exists());
+}
+
+#[tokio::test]
+#[serial]
+async fn test_headroom_setup_unsupported_agent_is_ignored() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let _cwd = CwdGuard::enter(temp_dir.path());
+
+    let agents: Vec<String> = vec!["unknown-agent".to_string()];
+    let result = handle_headroom_setup(&agents, false, true, 8787, 8765, "latest").await;
+    // No matching targets means nothing to do — should succeed with no files written
+    assert!(result.is_ok());
+
+    assert!(!temp_dir.path().join(".codex/mcp.json").exists());
+    assert!(!temp_dir.path().join(".claude/settings.json").exists());
+    assert!(!temp_dir.path().join(".cursor/mcp.json").exists());
+}
+
+#[tokio::test]
+#[serial]
+async fn test_headroom_setup_custom_ports_in_config() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let _cwd = CwdGuard::enter(temp_dir.path());
+
+    let agents: Vec<String> = vec!["codex".to_string()];
+    let result = handle_headroom_setup(&agents, false, true, 9999, 7777, "0.5.0").await;
+    assert!(result.is_ok(), "apply with custom ports should succeed");
+
+    let content =
+        fs::read_to_string(temp_dir.path().join(".codex/mcp.json")).expect("should read config");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&content).expect("config should be valid JSON");
+
+    // The MCP command always points to "vx ai headroom mcp stdio"
+    assert_eq!(parsed["mcpServers"]["headroom"]["command"], "vx");
+}


### PR DESCRIPTION
## Summary

Implement `vx ai headroom setup` command — generates MCP server configuration snippets for Codex, Claude Code, and Cursor.

- **--dry-run** (default): prints config snippet to stdout, never touches disk
- **--apply**: merges headroom MCP entry into existing agent config files, preserves other content
- Target files: `.codex/mcp.json`, `.claude/settings.json`, `.cursor/mcp.json`
- All generated configs point to: `vx ai headroom mcp stdio`
- `HEADROOM_TELEMETRY=off` enforced in all generated MCP entries

## Contract

- Only the `mcpServers.headroom` key is written; existing config entries are preserved
- Invalid JSON files are NOT overwritten — the command errors out with a clear message
- Configs are written relative to CWD (project-local setup)
- Missing parent directories are created automatically
- If agent config file doesn't exist, it's created fresh with only the MCP entry
- Setup failures return non-zero exit code (script/CI safe)

## Test plan

- [x] 9 headroom setup behavioral tests (dry-run, apply, preserve existing config, invalid JSON, write failure, multi-agent, custom ports)
- [x] Full vx-cli test suite passes
- [x] Clean compile, no warnings