### PR TITLE
ci: prefer PERSONAL_ACCESS_TOKEN over GITHUB_TOKEN for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -101,7 +101,7 @@ jobs:
         if: ${{ steps.release-state.outputs.release_exists != 'true' }}
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           skip-github-pull-request: true
@@ -192,7 +192,7 @@ jobs:
         if: steps.current-main.outputs.is_current == 'true'
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

Change both `release` and `update-pr` jobs in `release-please.yml` to prefer `PERSONAL_ACCESS_TOKEN` (PAT) with `GITHUB_TOKEN` fallback.

### Problem
When release-please uses `GITHUB_TOKEN`, created PRs do not trigger `pull_request` CI workflows (GitHub security limitation). The existing `ci-release-pr.yml` provides CI gate coverage, but full CI only runs with PAT-created PRs.

### Change
`${{ secrets.GITHUB_TOKEN }}` → `${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}`

When `PERSONAL_ACCESS_TOKEN` is set, release PRs trigger full CI normally. The existing `ci-release-pr.yml` continues to provide CI gate coverage as a fallback.