### PR TITLE
feat: migrate hugo provider to github_smart_provider (PIP-558)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4570,7 +4570,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "indexmap",
  "regex",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4625,7 +4625,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4689,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4732,7 +4732,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "colored",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4828,7 +4828,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4846,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4869,7 +4869,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4891,14 +4891,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-output-filter"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "regex",
@@ -4912,7 +4912,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4931,7 +4931,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "flate2",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5089,7 +5089,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5106,7 +5106,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "serde",
@@ -5124,11 +5124,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.9.15"
+version = "0.9.16"
 
 [[package]]
 name = "vx-starlark"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5158,7 +5158,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/vx-providers/hugo/provider.star
+++ b/crates/vx-providers/hugo/provider.star
@@ -1,26 +1,13 @@
-# provider.star - hugo provider
+# provider.star - hugo provider (github_smart_provider)
 #
 # Hugo is a fast and flexible static site generator (written in Go).
-#
-# Release assets (GitHub releases):
-#   hugo_{version}_Linux-64bit.tar.gz
-#   hugo_{version}_Linux-ARM64.tar.gz
-#   hugo_{version}_darwin-universal.pkg
-#   hugo_{version}_Windows-64bit.zip
-#   hugo_{version}_Windows-ARM64.zip
-#
-# Version source: gohugoio/hugo releases on GitHub (tag prefix "v")
+# Smart detection auto-selects the best GitHub release asset per platform.
+# macOS: .pkg is hard-excluded by smart_detect → falls through to brew.
 
-load("@vx//stdlib:provider.star",
-     "runtime_def", "github_permissions",
-     "path_fns", "path_env_fns",
-     "fetch_versions_with_tag_prefix",
+load("@vx//stdlib:provider_templates.star", "github_smart_provider")
+load("@vx//stdlib:provider.star", "runtime_def", "github_permissions",
      "system_install_strategies", "winget_install", "brew_install", "apt_install")
-load("@vx//stdlib:layout.star", "archive_layout")
 
-# ---------------------------------------------------------------------------
-# Provider metadata
-# ---------------------------------------------------------------------------
 name        = "hugo"
 description = "Hugo - Fast and flexible static site generator"
 homepage    = "https://gohugo.io"
@@ -28,90 +15,22 @@ repository  = "https://github.com/gohugoio/hugo"
 license     = "Apache-2.0"
 ecosystem   = "devtools"
 
-# ---------------------------------------------------------------------------
-# Runtime definitions
-# ---------------------------------------------------------------------------
-
-runtimes = [
-    runtime_def("hugo",
-        version_cmd     = "{executable} version",
-        version_pattern = "hugo v\\d+\\.\\d+\\.\\d+",
-    ),
-]
-
-# ---------------------------------------------------------------------------
-# Permissions
-# ---------------------------------------------------------------------------
+runtimes = [runtime_def("hugo",
+    version_cmd     = "{executable} version",
+    version_pattern = "hugo v\\d+\\.\\d+\\.\\d+")]
 
 permissions = github_permissions()
 
-# ---------------------------------------------------------------------------
-# fetch_versions - from gohugoio/hugo releases
-# ---------------------------------------------------------------------------
+_p = github_smart_provider("gohugoio", "hugo")
+fetch_versions   = _p["fetch_versions"]
+download_url     = _p["download_url"]
+install_layout   = _p["install_layout"]
+store_root       = _p["store_root"]
+get_execute_path = _p["get_execute_path"]
+post_install     = _p["post_install"]
+environment      = _p["environment"]
+deps             = _p["deps"]
 
-fetch_versions = fetch_versions_with_tag_prefix("gohugoio", "hugo", tag_prefix = "v")
-
-# ---------------------------------------------------------------------------
-# Platform helpers
-# ---------------------------------------------------------------------------
-
-_PLATFORMS = {
-    "windows/x64":  ("windows", "amd64"),
-    "windows/arm64": ("windows", "arm64"),
-    "macos/x64":     ("darwin",  "universal"),
-    "macos/arm64":   ("darwin",  "universal"),
-    "linux/x64":     ("linux",   "amd64"),
-    "linux/arm64":   ("linux",   "arm64"),
-}
-
-def _hugo_platform(ctx):
-    key = "{}/{}".format(ctx.platform.os, ctx.platform.arch)
-    return _PLATFORMS.get(key)
-
-# ---------------------------------------------------------------------------
-# download_url
-#
-# Hugo uses custom naming: hugo_{version}_{OS}-{Arch}.{ext}
-# Archives: .tar.gz (Linux/macOS), .zip (Windows)
-# ---------------------------------------------------------------------------
-
-def download_url(ctx, version):
-    platform = _hugo_platform(ctx)
-    if not platform:
-        return None
-    os_str, arch_str = platform
-    if ctx.platform.os == "macos":
-        # Recent Hugo releases publish macOS as .pkg installers, not tarballs.
-        return None
-    if ctx.platform.os == "windows":
-        ext = "zip"
-    else:
-        ext = "tar.gz"
-    return "https://github.com/gohugoio/hugo/releases/download/v{}/hugo_{}_{}-{}.{}".format(
-        version, version, os_str, arch_str, ext)
-
-# ---------------------------------------------------------------------------
-# install_layout — hugo archives have no top-level dir; binary sits at root
-# ---------------------------------------------------------------------------
-
-install_layout = archive_layout("hugo")
-
-# ---------------------------------------------------------------------------
-# Path queries + environment
-# ---------------------------------------------------------------------------
-
-paths            = path_fns("hugo")
-store_root       = paths["store_root"]
-get_execute_path = paths["get_execute_path"]
-env_fns          = path_env_fns()
-environment      = env_fns["environment"]
-post_install     = env_fns["post_install"]
-
-def deps(_ctx, _version):
-    return []
-
-# system_install fallback when GitHub download is unavailable
-# (use static form — more reliable than callable system_install)
 system_install = system_install_strategies([
     winget_install("Hugo.Hugo.Extended", priority = 90),
     brew_install("hugo",                 priority = 90),

--- a/crates/vx-starlark/stdlib/smart_detect.star
+++ b/crates/vx-starlark/stdlib/smart_detect.star
@@ -273,7 +273,7 @@ def score_asset(name, ctx, version, linux_libc = "musl", extra_excludes = None):
 
 def _tie_break_key(item):
     """Sort key for tie-breaking: (score desc, size asc, name_length asc, name asc)."""
-    score = item.get("total", 0)
+    score = item.get("score", 0)
     size  = item.get("size", 0)
     name  = item.get("name", "")
     # Higher score first, smaller size first, shorter name first, alphabetical

--- a/crates/vx-starlark/tests/hugo_tests.rs
+++ b/crates/vx-starlark/tests/hugo_tests.rs
@@ -48,11 +48,27 @@ async fn test_hugo_download_url() {
     match result {
         Ok(json) => {
             if let Some(s) = json.as_str() {
+                // Legacy URL string format (for providers not using smart_detect)
                 assert!(s.contains("hugo"), "URL should contain 'hugo': {}", s);
                 assert!(
                     s.starts_with("https://"),
                     "URL should start with https://: {}",
                     s
+                );
+            } else if let Some(obj) = json.as_object() {
+                // github_smart_detect descriptor format
+                assert_eq!(
+                    obj.get("__type").and_then(|v| v.as_str()).unwrap_or(""),
+                    "github_smart_detect",
+                    "smart provider descriptor should have __type=github_smart_detect"
+                );
+                assert_eq!(
+                    obj.get("owner").and_then(|v| v.as_str()).unwrap_or(""),
+                    "gohugoio"
+                );
+                assert_eq!(
+                    obj.get("repo").and_then(|v| v.as_str()).unwrap_or(""),
+                    "hugo"
                 );
             } else if json.is_null() {
                 // None = platform not supported
@@ -107,8 +123,8 @@ async fn test_hugo_install_layout() {
         Ok(json) => {
             if let Some(obj) = json.as_object() {
                 assert!(
-                    obj.contains_key("type"),
-                    "install_layout should return dict with 'type' key"
+                    obj.contains_key("__type"),
+                    "install_layout should return dict with '__type' key"
                 );
             } else if json.is_null() {
                 // None = platform not supported


### PR DESCRIPTION
## Summary

Migrate the Hugo provider from a hand-written platform map to `github_smart_provider()`, validating the end-to-end ROI of the smart provider template (RFC 0041).

## Changes

| File | Change |
|------|--------|
| `crates/vx-providers/hugo/provider.star` | 120 → 38 lines (-68%) |
| `crates/vx-starlark/stdlib/smart_detect.star` | Fix `_tie_break_key` bug (score vs total key mismatch) |
| `crates/vx-starlark/tests/hugo_tests.rs` | Adapt test expectations for smart_detect descriptor format |

## Migration Highlights

- Remove custom `_PLATFORMS` map (~60 lines)
- Remove hand-written `download_url` function (~20 lines)
- Replace with `github_smart_provider("gohugoio", "hugo")` (1 line)
- `system_install` fallback retained (brew/apt/winget)

## Bug Fix

Discovered and fixed a critical bug in `smart_detect.star`: `_tie_break_key` reads `item.get("total", 0)` but `detect_best_asset` stores the score under the `"score"` key. This caused all candidate asset scores to be read as 0, making the tie-break sort effectively by file size — ARM64 assets were incorrectly preferred because they are smaller.

## Verification

- [x] `vx hugo version` succeeds on Windows x64
- [x] Smart detect correctly selects `hugo_0.162.1_windows-amd64.zip` (score 95)
- [x] Version parsing correct: `hugo v0.162.1-bba860e3 windows/amd64`
- [x] Full test suite passing (200+ tests, 0 failures)

## Known Gaps

- **macOS `.pkg` excluded**: smart_detect hard-excludes `.pkg` files; Hugo macOS releases only provide `darwin-universal.pkg`. macOS users fall back to `brew install hugo` via existing `system_install`.
- **`64bit` arch alias missing**: Hugo's legacy naming (`Linux-64bit.tar.gz`) uses `64bit` which is not in the arch alias map. However, Hugo also provides `linux-amd64.tar.gz` standard naming, and smart detect correctly prefers it (score 88).

Follow-up RFC 0041 items: add `64bit` to x86_64 aliases, evaluate `.pkg` exception for macOS.

Closes PIP-558