### PR TITLE
fix(release): add retry logic to cargo-dist install steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,14 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.3/cargo-dist-installer.sh | sh"
+        run: |
+          for i in 1 2 3; do
+            curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.3/cargo-dist-installer.sh | sh && exit 0
+            echo "cargo-dist install attempt $i/3 failed, retrying in 10s..."
+            sleep 10
+          done
+          echo "All 3 attempts failed"
+          exit 1
 
       - name: Cache dist
         uses: actions/upload-artifact@v7
@@ -163,8 +170,28 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
-      - name: Install dist
-        run: ${{ matrix.install_dist.run }}
+      - name: Install dist (Unix)
+        if: ${{ runner.os != 'Windows' }}
+        shell: bash
+        run: |
+          for i in 1 2 3; do
+            ${{ matrix.install_dist.run }} && exit 0
+            echo "cargo-dist install attempt $i/3 failed, retrying in 10s..."
+            sleep 10
+          done
+          echo "All 3 attempts failed"
+          exit 1
+      - name: Install dist (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          $retries = 3; $delay = 10
+          for ($i = 1; $i -le $retries; $i++) {
+            ${{ matrix.install_dist.run }}; if ($LASTEXITCODE -eq 0) { return }
+            Write-Host "cargo-dist install attempt $i/$retries failed, retrying in ${delay}s..."
+            Start-Sleep -Seconds $delay
+          }
+          exit 1
       # Get the dist-manifest
       - name: Fetch local artifacts
         uses: actions/download-artifact@v8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4570,7 +4570,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "indexmap",
  "regex",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4625,7 +4625,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4712,7 +4712,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4733,7 +4733,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "colored",
@@ -4773,7 +4773,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4829,7 +4829,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4847,7 +4847,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4892,14 +4892,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-output-filter"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "regex",
@@ -4913,7 +4913,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4932,7 +4932,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4957,7 +4957,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "flate2",
@@ -5040,7 +5040,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5090,7 +5090,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5107,7 +5107,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "serde",
@@ -5125,11 +5125,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.9.17"
+version = "0.9.18"
 
 [[package]]
 name = "vx-starlark"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5182,7 +5182,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5200,7 +5200,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## Summary

GitHub Actions runners experience persistent 504 errors when downloading
cargo-dist from axodotdev/cargo-dist releases. This adds 3-attempt retry
with 10s sleep to the Install dist step in both the `plan` and
`build-local-artifacts` jobs.

## Changes

- **plan job Install dist**: Wrapped curl-to-sh in a bash retry loop
- **build-local-artifacts Install dist**:
  - Unix runners: bash retry loop around `matrix.install_dist.run`
  - Windows runners: PowerShell retry loop around `matrix.install_dist.run`

## Reason

Without retry, a transient network blip kills the entire release pipeline.
With retry, the workflow self-heals from temporary CDN / GitHub release
asset download failures.

## Test plan

- [ ] Merge to main
- [ ] Trigger workflow_dispatch with `tag=v0.9.18`
- [ ] Verify all build jobs succeed
