### PR TITLE
fix(release): use Get-Command instead of $LASTEXITCODE for Windows cargo-dist retry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,8 @@ jobs:
         run: |
           $retries = 3; $delay = 10
           for ($i = 1; $i -le $retries; $i++) {
-            ${{ matrix.install_dist.run }}; if ($LASTEXITCODE -eq 0) { return }
+            ${{ matrix.install_dist.run }}
+            if (Get-Command dist -ErrorAction SilentlyContinue) { return }
             Write-Host "cargo-dist install attempt $i/$retries failed, retrying in ${delay}s..."
             Start-Sleep -Seconds $delay
           }


### PR DESCRIPTION
## Summary

Bug fix for the Windows cargo-dist retry logic. Original PR #975 used `$LASTEXITCODE -eq 0` to check installation success, but the PowerShell installer (`irm ... | iex`) returns a non-zero exit code even on successful installation, causing the retry loop to incorrectly treat all installs as failures.

## Root Cause

From run #27125548985 logs: the cargo-dist installer prints "everything's installed!" every time (success), but `$LASTEXITCODE` remains non-zero. All 3 retries are falsely treated as failures, then the step exits with code 1.

## Fix

Replace `$LASTEXITCODE -eq 0` with `Get-Command dist -ErrorAction SilentlyContinue` to actually check whether the `dist` binary is available.

```diff
- ${{ matrix.install_dist.run }}; if ($LASTEXITCODE -eq 0) { return }
+ ${{ matrix.install_dist.run }}
+ if (Get-Command dist -ErrorAction SilentlyContinue) { return }
```

## Verification

In run #27125548985, 7/8 platforms succeeded (all Unix/Linux/macOS). Only Windows MSVC failed due to this bug. After this fix, all platforms should pass.

## Related

- PIP-1133
- PR #975 (original retry logic)