### PR TITLE
fix: use vx-managed Go runtime for go install global workflow (PIP-1156)

### DIFF
--- a/crates/vx-cli/src/commands/global/handler.rs
+++ b/crates/vx-cli/src/commands/global/handler.rs
@@ -227,6 +227,37 @@ async fn handle_install(ctx: &CommandContext, args: &InstallGlobalArgs) -> Resul
                 Box::new(vx_ecosystem_pm::installers::NpmInstaller::new())
             }
         }
+        "go" | "golang" => {
+            let go_path = if runtime_version.is_some() {
+                match vx_paths::get_bundled_tool_path("go", "go") {
+                    Ok(Some(path)) => Some(path),
+                    Ok(None) => {
+                        tracing::warn!("go not found in installed go runtime");
+                        None
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed to get go path from RuntimeRoot: {}", e);
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+
+            if let Some(path) = go_path {
+                if path.exists() {
+                    if args.verbose {
+                        UI::detail(&format!("Using go from: {}", path.display()));
+                    }
+                    Box::new(vx_ecosystem_pm::installers::GoInstaller::with_go_path(path))
+                } else {
+                    tracing::warn!("go path does not exist: {}", path.display());
+                    Box::new(vx_ecosystem_pm::installers::GoInstaller::new())
+                }
+            } else {
+                Box::new(vx_ecosystem_pm::installers::GoInstaller::new())
+            }
+        }
         _ => get_installer(&spec.ecosystem)
             .with_context(|| format!("Unsupported ecosystem: {}", spec.ecosystem))?,
     };


### PR DESCRIPTION
## Summary
- `vx go install <pkg>` auto-downloads Go via `ensure_runtime_installed("go")` but `GoInstaller` only checked PATH, ignoring the freshly installed runtime
- Added `"go" | "golang"` arm to the installer match block, following the existing npm pattern
- After runtime install, locates the Go binary in vx store via `get_bundled_tool_path("go", "go")` and injects it via `GoInstaller::with_go_path()`

## Test plan
- [x] `vx cargo check -p vx-cli` passes
- [x] `vx cargo fmt -- --check` passes
- [x] `vx cargo test -p vx-cli` (pre-existing headroom_proxy_tests failure, unrelated)
- [ ] Manual: `vx go install github.com/studyzy/tapd-ai-cli/cmd/tapd@latest` without system Go