### PR TITLE
fix(ci): work around npm EOVERRIDE in aionui example

### DIFF
--- a/examples/msvc/aionui.build.ps1
+++ b/examples/msvc/aionui.build.ps1
@@ -14,6 +14,11 @@ if (-not (Test-Path $repoDir)) {
 
 Push-Location $repoDir
 try {
+  # Workaround: npm EOVERRIDE — @codemirror/language is both a direct dependency
+  # and in overrides/resolutions. npm 10+ rejects overrides on direct deps when
+  # the version specs differ. Remove the redundant override/resolution entries.
+  vx npm pkg delete overrides.@codemirror/language resolutions.@codemirror/language 2>$null
+
   "== AionUi build test ==" | Tee-Object -FilePath $logFile
   "Working directory: $repoDir" | Tee-Object -FilePath $logFile -Append
 

--- a/examples/msvc/aionui.build.ps1
+++ b/examples/msvc/aionui.build.ps1
@@ -14,7 +14,19 @@ if (-not (Test-Path $repoDir)) {
 
 Push-Location $repoDir
 try {
-  # Workaround: npm EOVERRIDE — @codemirror/language is both a direct dependency
+  # Workaround 1: npm doesn't support pnpm/yarn "workspace:*" protocol.
+  # AionUi is a monorepo with internal deps like "@aionui/web-host": "workspace:*".
+  # Replace with "*" so npm can resolve workspace packages.
+  Get-ChildItem -Path . -Recurse -Filter "package.json" -Depth 3 | ForEach-Object {
+    $c = Get-Content $_.FullName -Raw -Encoding UTF8
+    if ($c -match 'workspace:') {
+      Write-Host "Replacing workspace:* in $($_.FullName)"
+      $c = $c -replace '"workspace:\*"', '"*"'
+      [System.IO.File]::WriteAllText($_.FullName, $c, [System.Text.Encoding]::UTF8)
+    }
+  }
+
+  # Workaround 2: npm EOVERRIDE — @codemirror/language is both a direct dependency
   # and in overrides/resolutions. npm 10+ rejects overrides on direct deps when
   # the version specs differ. Remove the redundant override/resolution entries.
   vx npm pkg delete overrides.@codemirror/language resolutions.@codemirror/language 2>$null


### PR DESCRIPTION
## Summary
- The aionui MSVC example CI has been failing since 2026-05-25 due to npm `EOVERRIDE`
- Root cause: aionui's `package.json` lists `@codemirror/language` as both a direct dependency and in `overrides`/`resolutions`. npm 10+ rejects overrides on direct dependencies when the version specs differ
- Fix: add a `vx npm pkg delete` step after git clone to remove the redundant override/resolution entries before running `npm install`

## Test plan
- [ ] MSVC Examples CI passes on this branch
- [ ] The aionui step specifically passes (run at https://github.com/loonghao/vx/actions/workflows/examples-msvc.yml)