### PR TITLE
fix: chmod +x after archive extraction and fix ffmpeg strip_prefix

### DIFF
--- a/crates/vx-providers/ffmpeg/provider.star
+++ b/crates/vx-providers/ffmpeg/provider.star
@@ -70,9 +70,10 @@ permissions = github_permissions()
 
 _ASSET_MAP = {
     # (os, arch): (asset_name, archive_subdir)
-    "windows/x64":  ("ffmpeg-{v}-win64-lgpl.zip",          "ffmpeg-{v}-win64-lgpl"),
-    "linux/x64":    ("ffmpeg-{v}-linux64-lgpl.tar.xz",     "ffmpeg-{v}-linux64-lgpl"),
-    "linux/arm64":  ("ffmpeg-{v}-linuxarm64-lgpl.tar.xz",  "ffmpeg-{v}-linuxarm64-lgpl"),
+    # BtbN archive internal dir naming: ffmpeg-n{version}-latest-{platform}-{version}
+    "windows/x64":  ("ffmpeg-{v}-win64-lgpl.zip",          "ffmpeg-n{v}-latest-win64-lgpl-{v}"),
+    "linux/x64":    ("ffmpeg-{v}-linux64-lgpl.tar.xz",     "ffmpeg-n{v}-latest-linux64-lgpl-{v}"),
+    "linux/arm64":  ("ffmpeg-{v}-linuxarm64-lgpl.tar.xz",  "ffmpeg-n{v}-latest-linuxarm64-lgpl-{v}"),
 }
 
 # ---------------------------------------------------------------------------

--- a/crates/vx-runtime-http/src/installer.rs
+++ b/crates/vx-runtime-http/src/installer.rs
@@ -829,6 +829,29 @@ impl Installer for RealInstaller {
             }
         }
 
+        // Ensure extracted binaries have executable permissions on Unix.
+        // Archive extraction (tar/zip/7z) does not guarantee execute bits,
+        // unlike the single-file path which explicitly chmods 0o755.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let bin_dir = dest.join("bin");
+            if bin_dir.is_dir() {
+                if let Ok(entries) = std::fs::read_dir(&bin_dir) {
+                    for entry in entries.filter_map(|e| e.ok()) {
+                        let path = entry.path();
+                        if path.is_file() {
+                            if let Ok(meta) = std::fs::metadata(&path) {
+                                let mut perms = meta.permissions();
+                                perms.set_mode(0o755);
+                                let _ = std::fs::set_permissions(&path, perms);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Two fixes for CI failures in the Test Providers workflow:

### 1. Archive extraction `chmod +x` (19 provider failures)
`crates/vx-runtime-http/src/installer.rs` — After archive extraction (tar/zip/7z), all files in `dest/bin/` now get `0o755` permissions on Unix. Previously only the single-file download path set executable bits; archive-provided binaries lacked execute permission, causing `Permission denied (os error 13)`.

**Affected providers**: protoc, duckdb, ninja, bun, terraform, vault, deno, yazi, gh, buildcache (Linux + macOS)

### 2. ffmpeg `strip_prefix` mismatch (2 provider failures)
`crates/vx-providers/ffmpeg/provider.star` — Fixed `strip_prefix` to match the actual BtbN archive internal directory naming: `ffmpeg-n{version}-latest-{platform}-{version}`. The old prefix `ffmpeg-{v}-{platform}` did not exist inside the mirrored archives from vx-org/mirrors.

**Verified** against actual archive contents for ffmpeg 7.1 and 8.1.

## Test plan
- [x] `cargo check -p vx-runtime-http` passes
- [x] `cargo test -p vx-runtime-http` passes
- [ ] CI: Test Providers workflow on this branch