### PR TITLE
docs(zh/tools/ai): fix dead link to Headroom guide

### DIFF
--- a/docs/zh/tools/ai.md
+++ b/docs/zh/tools/ai.md
@@ -133,7 +133,7 @@ headroom-test = "vx ai headroom mcp test"
 }
 ```
 
-详细指南请参见 [Headroom 指南](../zh/guides/headroom)。
+详细指南请参见 [Headroom 指南](../guides/headroom)。
 
 ## AI 驱动的开发工作流
 


### PR DESCRIPTION
## Summary

Fix a dead link in `docs/zh/tools/ai.md` that caused Vitepress build to fail.

The link `../zh/guides/headroom` contained an extra `zh/` segment. Since the
file is already under `docs/zh/`, the path resolved to
`docs/zh/zh/guides/headroom` (nonexistent). Changed to `../guides/headroom`
which correctly resolves to `docs/zh/guides/headroom`.

## Test plan

- [x] `vitepress build` passes with no dead link errors