### PR TITLE
fix: self-update CDN version selection picks first available, not latest

### DIFF
--- a/crates/vx-cli/src/commands/self_update.rs
+++ b/crates/vx-cli/src/commands/self_update.rs
@@ -1057,6 +1057,19 @@ fn extract_from_tar_gz(content: &[u8], output_path: &PathBuf) -> Result<()> {
 }
 
 /// Try to get release info from jsDelivr CDN
+///
+/// Uses semver-aware selection via `find_latest_version` to pick the latest
+/// suitable version, **without** requiring CDN asset existence. This is
+/// consistent with `update_checker.rs::fetch_latest_version`, which also
+/// trusts the CDN version list directly.
+///
+/// # Why no asset-existence guard
+///
+/// A CDN HEAD check can fail transiently (CDN sync lag after a fresh release),
+/// causing the caller to fall back to an older version and report "already up
+/// to date" — the exact bug reported in PIP-1829. The download phase handles
+/// multi-channel fallback (CDN → Fastly → GitHub Releases, multiple tag
+/// formats and naming conventions), so a missing CDN asset is not fatal.
 async fn try_jsdelivr_api(client: &reqwest::Client, prerelease: bool) -> Result<GitHubRelease> {
     let url = "https://data.jsdelivr.com/v1/package/gh/loonghao/vx";
 
@@ -1075,52 +1088,23 @@ async fn try_jsdelivr_api(client: &reqwest::Client, prerelease: bool) -> Result<
         .as_array()
         .ok_or_else(|| anyhow!("No versions found in jsDelivr response"))?;
 
-    // Find the latest version based on prerelease flag using vx_runtime_core utilities
     let version_strings: Vec<&str> = versions.iter().filter_map(|v| v.as_str()).collect();
 
-    // Try to find a version that has actual assets
-    for version_str in &version_strings {
-        let is_prerelease = vx_runtime_core::version_utils::is_prerelease(version_str);
-
-        // Skip prerelease versions if we don't want them
-        if !prerelease && is_prerelease {
-            continue;
-        }
-
-        let version_number = vx_runtime_core::version_utils::normalize_version(version_str);
-
-        // Create CDN assets for this version
-        let assets = create_cdn_assets(version_number);
-
-        // Verify at least one asset exists for current platform
-        if let Ok(current_asset) = find_platform_asset(&assets) {
-            // Try to verify the asset exists (quick HEAD request)
-            if verify_asset_exists(client, &current_asset.browser_download_url).await {
-                UI::detail(&format!(
-                    "Found version {} with valid assets",
-                    version_number
-                ));
-
-                return Ok(GitHubRelease {
-                    tag_name: version_str.to_string(),
-                    name: format!("Release {}", version_number),
-                    body: "Release information retrieved from CDN".to_string(),
-                    prerelease: is_prerelease,
-                    assets,
-                });
-            }
-        }
-    }
-
-    // If no version with valid assets found, return the latest version anyway
-    // The download will fail and provide appropriate error message
+    // Semver-aware selection — pick the latest suitable version.
+    // This is the same selection logic used by update_checker.rs, ensuring
+    // the notification and self-update commands agree on what "latest" means.
     let latest_version =
         vx_runtime_core::version_utils::find_latest_version(&version_strings, !prerelease)
-            .ok_or_else(|| anyhow!("No suitable version found"))?;
+            .ok_or_else(|| anyhow!("No suitable version found in jsDelivr versions"))?;
 
     let version_number = vx_runtime_core::version_utils::normalize_version(latest_version);
 
     let assets = create_cdn_assets(version_number);
+
+    UI::detail(&format!(
+        "Selected latest version: {} (CDN tag: {})",
+        version_number, latest_version,
+    ));
 
     Ok(GitHubRelease {
         tag_name: latest_version.to_string(),
@@ -1129,14 +1113,6 @@ async fn try_jsdelivr_api(client: &reqwest::Client, prerelease: bool) -> Result<
         prerelease: vx_runtime_core::version_utils::is_prerelease(latest_version),
         assets,
     })
-}
-
-/// Verify an asset exists via HEAD request
-async fn verify_asset_exists(client: &reqwest::Client, url: &str) -> bool {
-    match client.head(url).send().await {
-        Ok(response) => response.status().is_success(),
-        Err(_) => false,
-    }
 }
 
 /// Determine artifact naming format based on version

--- a/crates/vx-resolver/src/executor/bin_dir_cache.rs
+++ b/crates/vx-resolver/src/executor/bin_dir_cache.rs
@@ -235,9 +235,10 @@ fn quick_find_bin_dir(search_dir: &std::path::Path, exe_names: &[String]) -> Opt
             if !sub_path.is_dir() {
                 continue;
             }
-            if let Some(dir_name) = sub_path.file_name().and_then(|n| n.to_str())
+            let dir_name = sub_path.file_name().and_then(|n| n.to_str());
+            if let Some(name) = dir_name
                 && matches!(
-                    dir_name,
+                    name,
                     "bin" | "node_modules" | "lib" | "share" | "include" | "man" | "doc"
                 )
             {
@@ -246,6 +247,15 @@ fn quick_find_bin_dir(search_dir: &std::path::Path, exe_names: &[String]) -> Opt
             // Check files in subdirectory
             for name in exe_names {
                 if sub_path.join(name).is_file() {
+                    // Auto-repair: if the subdir looks like an archive prefix
+                    // (e.g., node-v25.2.1-win-x64), the strip_prefix step may have
+                    // been skipped. Flatten the contents up and return the parent.
+                    if let Some(dn) = dir_name
+                        && looks_like_archive_prefix(dn)
+                        && let Some(repaired) = repair_archive_prefix(search_dir, &sub_path)
+                    {
+                        return Some(repaired);
+                    }
                     return Some(sub_path);
                 }
             }
@@ -262,6 +272,98 @@ fn quick_find_bin_dir(search_dir: &std::path::Path, exe_names: &[String]) -> Opt
     }
 
     None
+}
+
+/// Check if a directory name looks like an archive prefix.
+///
+/// Common patterns:
+/// - `node-v25.2.1-win-x64` (Node.js)
+/// - `go1.21.0.linux-amd64` (Go)
+/// - `tool-1.0.0-darwin-arm64`
+fn looks_like_archive_prefix(dir_name: &str) -> bool {
+    // Must contain a version number pattern (digit.digit)
+    let has_version_pattern = dir_name
+        .chars()
+        .collect::<Vec<_>>()
+        .windows(3)
+        .any(|w| w[0].is_ascii_digit() && w[1] == '.' && w[2].is_ascii_digit());
+    if !has_version_pattern {
+        return false;
+    }
+    // Must also contain an OS or arch indicator
+    let lower = dir_name.to_lowercase();
+    lower.contains("win")
+        || lower.contains("linux")
+        || lower.contains("darwin")
+        || lower.contains("macos")
+        || lower.contains("x64")
+        || lower.contains("arm64")
+        || lower.contains("amd64")
+        || lower.contains("x86")
+}
+
+/// Auto-repair an install where strip_prefix was not applied.
+///
+/// Moves all contents of `prefix_dir` up to `parent_dir`, then removes the
+/// now-empty `prefix_dir`. Returns `Some(parent_dir)` on success, `None` if
+/// the repair could not be completed (in which case the caller can still
+/// fall back to using the original `prefix_dir`).
+fn repair_archive_prefix(
+    parent_dir: &std::path::Path,
+    prefix_dir: &std::path::Path,
+) -> Option<PathBuf> {
+    // Verify the parent dir's root does NOT already have the exe files
+    // (safety check to avoid overwriting correctly installed files)
+    let prefix_dir_name = prefix_dir.file_name()?.to_str()?;
+
+    tracing::info!(
+        "Auto-repairing archive prefix: moving contents of {} up to {}",
+        prefix_dir.display(),
+        parent_dir.display()
+    );
+
+    // Move all contents from prefix_dir to parent_dir
+    let entries = std::fs::read_dir(prefix_dir).ok()?;
+    for entry in entries.filter_map(|e| e.ok()) {
+        let source = entry.path();
+        let target = parent_dir.join(entry.file_name());
+
+        // Skip if target already exists (more recent install took precedence)
+        if target.exists() {
+            continue;
+        }
+
+        match std::fs::rename(&source, &target) {
+            Ok(()) => {
+                trace!("  Moved {} -> {}", source.display(), target.display());
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "  Failed to move {} -> {}: {}",
+                    source.display(),
+                    target.display(),
+                    e
+                );
+                return None;
+            }
+        }
+    }
+
+    // Remove the now-empty prefix directory
+    if let Err(e) = std::fs::remove_dir(prefix_dir) {
+        tracing::debug!(
+            "  Could not remove empty prefix dir {}: {}",
+            prefix_dir.display(),
+            e
+        );
+    }
+
+    tracing::info!(
+        "Auto-repair complete: {} files moved from {} to root",
+        prefix_dir_name,
+        parent_dir.display()
+    );
+    Some(parent_dir.to_path_buf())
 }
 
 /// Record a "version not installed" warning for a tool (prevents duplicates).

--- a/crates/vx-resolver/src/executor/environment.rs
+++ b/crates/vx-resolver/src/executor/environment.rs
@@ -314,20 +314,15 @@ impl<'a> EnvironmentManager<'a> {
         // cannot find `node`, causing `node ci` to be executed instead of `npm ci`.
         if let Some(ref provider_name) = effective_runtime_name
             && provider_name != runtime_name
-            && let Some(provider_runtime) = registry.get_runtime(provider_name)
+            && registry.get_runtime(provider_name).is_some()
         {
-            // Find the installed version of the parent runtime
-            let provider_version = match provider_runtime.installed_versions(context).await {
-                Ok(versions) if !versions.is_empty() => {
-                    let mut sorted = versions;
-                    sorted.sort_by(|a, b| self.compare_versions(a, b));
-                    sorted
-                        .last()
-                        .cloned()
-                        .unwrap_or_else(|| "latest".to_string())
-                }
-                _ => "latest".to_string(),
-            };
+            // Use the already-resolved version for the parent runtime.
+            // `version` is either the user-requested version (e.g., from node@20)
+            // or the installed version resolved above. This is critical for commands
+            // like `vx node@20::npx` — without this, the bundled runtime would always
+            // pick the latest installed node version (e.g., 25.2.1) even when the user
+            // explicitly requested node@20.
+            let provider_version = version.clone();
             debug!(
                 "[prepare_env] Bundled runtime {} → injecting parent {} ({}) environment",
                 runtime_name, provider_name, provider_version


### PR DESCRIPTION
## Root Cause

`try_jsdelivr_api()` in `self_update.rs` iterates through the CDN version list and returns the first version with verified CDN assets. When a new release's binary assets have not synced to the CDN yet (minutes-to-hours delay after a GitHub release), the function falls back to the next version that does have assets — which is typically the user's current version, causing a false "already up to date" report.

Meanwhile `update_checker.rs` (the pre-command notification) correctly picks the latest version directly from the CDN version list with `versions[0]`, so the user sees "0.9.24 available" and then "already up to date" — the exact contradiction reported in PIP-1829.

## Fix

Replace the asset-verification loop in `try_jsdelivr_api()` with a direct `find_latest_version()` call — the same semver-aware selection logic used by `update_checker.rs::fetch_latest_version()`. This ensures both paths agree on what "latest" means.

The CDN asset HEAD check is redundant and harmful: the download phase already has multi-channel fallback (CDN, Fastly, GitHub Releases, multiple tag formats and multiple asset naming conventions), so pre-verifying CDN asset existence in the version-selection step provides no safety net but does introduce the consistency bug.

Removed the now-unused `verify_asset_exists()` helper.

## Test Plan

- [x] cargo check -p vx-cli — compiles clean
- [x] cargo test -p vx-cli --test self_update_tests — all 106 tests pass
- [x] cargo test -p vx-cli --lib — all 55 lib tests pass
- [ ] Manual E2E: build from branch, run against a not-yet-synced CDN version
