### PR TITLE
fix: prepare MSVC Spectre toolchains

### DIFF
--- a/crates/vx-resolver/src/executor/environment.rs
+++ b/crates/vx-resolver/src/executor/environment.rs
@@ -565,8 +565,13 @@ impl<'a> EnvironmentManager<'a> {
 
                 // Call prepare_environment() (NOT execution_environment())
                 // This gives us marker/discovery variables without full compilation env
+                let companion_context = self
+                    .project_config
+                    .and_then(|config| config.get_install_options(companion_name))
+                    .map(|options| context.clone().with_install_options(options.clone()))
+                    .unwrap_or_else(|| context.clone());
                 match companion_runtime
-                    .prepare_environment(&companion_installed_version, context)
+                    .prepare_environment(&companion_installed_version, &companion_context)
                     .await
                 {
                     Ok(companion_env) => {

--- a/crates/vx-resolver/tests/prepare_stage_tests.rs
+++ b/crates/vx-resolver/tests/prepare_stage_tests.rs
@@ -93,13 +93,18 @@ impl Runtime for CountingRuntime {
     async fn prepare_environment(
         &self,
         version: &str,
-        _ctx: &RuntimeContext,
+        ctx: &RuntimeContext,
     ) -> Result<HashMap<String, String>> {
         self.prepare_count.fetch_add(1, Ordering::SeqCst);
-        Ok(HashMap::from([(
-            "VX_COMPANION_MARKER".to_string(),
-            version.to_string(),
-        )]))
+        let mut environment =
+            HashMap::from([("VX_COMPANION_MARKER".to_string(), version.to_string())]);
+        if let Some(components) = ctx.get_install_option("VX_MSVC_COMPONENTS") {
+            environment.insert(
+                "VX_COMPANION_COMPONENTS".to_string(),
+                components.to_string(),
+            );
+        }
+        Ok(environment)
     }
 }
 
@@ -223,8 +228,13 @@ async fn prepare_stage_skips_missing_companion_without_auto_installing() {
         ],
     }));
 
-    let project_config =
-        ProjectToolsConfig::from_tools(HashMap::from([("msvc".to_string(), "14.42".to_string())]));
+    let project_config = ProjectToolsConfig::from_tools_with_install_options(
+        HashMap::from([("msvc".to_string(), "14.42".to_string())]),
+        HashMap::from([(
+            "msvc".to_string(),
+            HashMap::from([("VX_MSVC_COMPONENTS".to_string(), "spectre".to_string())]),
+        )]),
+    );
     let stage = PrepareStage::new(&resolver, &config, Some(&registry), Some(&context))
         .with_project_config(&project_config);
     let plan = ExecutionPlan::new(
@@ -269,8 +279,13 @@ async fn prepare_stage_injects_already_installed_companion_environment() {
         ],
     }));
 
-    let project_config =
-        ProjectToolsConfig::from_tools(HashMap::from([("msvc".to_string(), "14.42".to_string())]));
+    let project_config = ProjectToolsConfig::from_tools_with_install_options(
+        HashMap::from([("msvc".to_string(), "14.42".to_string())]),
+        HashMap::from([(
+            "msvc".to_string(),
+            HashMap::from([("VX_MSVC_COMPONENTS".to_string(), "spectre".to_string())]),
+        )]),
+    );
     let stage = PrepareStage::new(&resolver, &config, Some(&registry), Some(&context))
         .with_project_config(&project_config);
     let plan = ExecutionPlan::new(
@@ -288,6 +303,13 @@ async fn prepare_stage_injects_already_installed_companion_environment() {
     assert_eq!(
         prepared.env.get("VX_COMPANION_MARKER").map(String::as_str),
         Some("system")
+    );
+    assert_eq!(
+        prepared
+            .env
+            .get("VX_COMPANION_COMPONENTS")
+            .map(String::as_str),
+        Some("spectre")
     );
 }
 

--- a/crates/vx-runtime/src/manifest_runtime/mod.rs
+++ b/crates/vx-runtime/src/manifest_runtime/mod.rs
@@ -27,6 +27,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+#[cfg(windows)]
+use anyhow::Context;
 use anyhow::Result;
 use async_trait::async_trait;
 use tracing::{debug, warn};
@@ -92,6 +94,141 @@ pub fn find_first_glob_match(patterns: &[String]) -> Option<PathBuf> {
         }
     }
     None
+}
+
+#[cfg(windows)]
+fn msvc_toolset_dir(cl_path: &Path) -> Option<&Path> {
+    cl_path.ancestors().nth(4)
+}
+
+#[cfg(windows)]
+fn has_spectre_libs(cl_path: &Path) -> bool {
+    let Some(toolset_dir) = msvc_toolset_dir(cl_path) else {
+        return false;
+    };
+    let Some(arch) = cl_path.parent().and_then(Path::file_name) else {
+        return false;
+    };
+    toolset_dir.join("lib").join("spectre").join(arch).is_dir()
+}
+
+#[cfg(windows)]
+fn find_msvc_cl(patterns: &[String], require_spectre: bool) -> Option<PathBuf> {
+    patterns.iter().find_map(|pattern| {
+        glob::glob(pattern)
+            .ok()?
+            .filter_map(Result::ok)
+            .find(|path| path.is_file() && (!require_spectre || has_spectre_libs(path)))
+    })
+}
+
+#[cfg(windows)]
+fn read_msvc_environment(cl_path: &Path) -> Result<HashMap<String, String>> {
+    let toolset_dir = msvc_toolset_dir(cl_path)
+        .with_context(|| format!("unexpected MSVC compiler path: {}", cl_path.display()))?;
+    let vc_dir = toolset_dir
+        .ancestors()
+        .nth(3)
+        .with_context(|| format!("cannot locate VC root from {}", cl_path.display()))?;
+    let arch = cl_path
+        .parent()
+        .and_then(Path::file_name)
+        .with_context(|| {
+            format!(
+                "cannot determine MSVC architecture from {}",
+                cl_path.display()
+            )
+        })?;
+    let sdk_root = [
+        Path::new(r"C:\Program Files (x86)\Windows Kits\10"),
+        Path::new(r"C:\Program Files\Windows Kits\10"),
+    ]
+    .into_iter()
+    .find(|root| root.join("Include").is_dir())
+    .context("Windows 10 SDK was not found")?;
+    let mut sdk_versions = std::fs::read_dir(sdk_root.join("Include"))?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().join("ucrt").is_dir())
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .collect::<Vec<_>>();
+    sdk_versions.sort();
+    let sdk_version = sdk_versions
+        .last()
+        .context("Windows 10 SDK has no usable version")?;
+    let sdk_include = sdk_root.join("Include").join(sdk_version);
+    let sdk_lib = sdk_root.join("Lib").join(sdk_version);
+    let sdk_bin = sdk_root.join("bin").join(sdk_version).join(arch);
+
+    let join = |paths: Vec<PathBuf>| -> Result<String> {
+        Ok(std::env::join_paths(paths)?.to_string_lossy().into_owned())
+    };
+    let mut path = vec![
+        cl_path
+            .parent()
+            .expect("compiler has a parent")
+            .to_path_buf(),
+        sdk_bin,
+    ];
+    path.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+
+    Ok(HashMap::from([
+        ("PATH".to_string(), join(path)?),
+        (
+            "INCLUDE".to_string(),
+            join(
+                [
+                    toolset_dir.join("include"),
+                    sdk_include.join("ucrt"),
+                    sdk_include.join("shared"),
+                    sdk_include.join("um"),
+                    sdk_include.join("winrt"),
+                    sdk_include.join("cppwinrt"),
+                ]
+                .into_iter()
+                .filter(|path| path.is_dir())
+                .collect(),
+            )?,
+        ),
+        (
+            "LIB".to_string(),
+            join(vec![
+                toolset_dir.join("lib").join(arch),
+                sdk_lib.join("ucrt").join(arch),
+                sdk_lib.join("um").join(arch),
+            ])?,
+        ),
+        (
+            "VCINSTALLDIR".to_string(),
+            vc_dir.to_string_lossy().into_owned(),
+        ),
+        (
+            "VCToolsInstallDir".to_string(),
+            toolset_dir.to_string_lossy().into_owned(),
+        ),
+        (
+            "VCToolsVersion".to_string(),
+            toolset_dir
+                .file_name()
+                .expect("toolset has a version")
+                .to_string_lossy()
+                .into_owned(),
+        ),
+        (
+            "VSINSTALLDIR".to_string(),
+            vc_dir
+                .parent()
+                .expect("VC root has a parent")
+                .to_string_lossy()
+                .into_owned(),
+        ),
+        (
+            "WindowsSdkDir".to_string(),
+            sdk_root.to_string_lossy().into_owned(),
+        ),
+        ("WindowsSDKVersion".to_string(), format!("{sdk_version}\\")),
+    ]))
 }
 
 use crate::{Ecosystem, InstallResult, Platform, Runtime, RuntimeContext, VersionInfo};
@@ -671,6 +808,34 @@ impl Runtime for ManifestDrivenRuntime {
         meta
     }
 
+    async fn prepare_environment(
+        &self,
+        _version: &str,
+        ctx: &RuntimeContext,
+    ) -> Result<HashMap<String, String>> {
+        #[cfg(windows)]
+        if self.name == "msvc" {
+            let require_spectre = ctx
+                .get_install_option("VX_MSVC_COMPONENTS")
+                .map(|components| {
+                    components
+                        .split(',')
+                        .any(|component| component.trim().eq_ignore_ascii_case("spectre"))
+                })
+                .unwrap_or(false);
+            let cl_path = find_msvc_cl(&self.system_paths, require_spectre).with_context(|| {
+                if require_spectre {
+                    "no MSVC toolchain with Spectre-mitigated libraries was found".to_string()
+                } else {
+                    "no MSVC toolchain was found".to_string()
+                }
+            })?;
+            return read_msvc_environment(&cl_path);
+        }
+
+        Ok(HashMap::new())
+    }
+
     async fn versioned_dependencies(
         &self,
         version: &str,
@@ -988,7 +1153,13 @@ impl Runtime for ManifestDrivenRuntime {
             }
         }
 
-        // 2. Fall back to system PATH detection.
+        // 2. Honor provider-declared system paths for tools such as MSVC that
+        // are intentionally not added to the global PATH.
+        if !self.system_paths.is_empty() && find_first_glob_match(&self.system_paths).is_some() {
+            return Ok(vec!["system".to_string()]);
+        }
+
+        // 3. Fall back to system PATH detection.
         if which::which(&self.executable).is_ok() {
             if let Ok(Some(version)) = detection::detect_version(
                 &self.executable,

--- a/crates/vx-runtime/tests/runtime_tests.rs
+++ b/crates/vx-runtime/tests/runtime_tests.rs
@@ -8,8 +8,8 @@ use async_trait::async_trait;
 use rstest::rstest;
 use tempfile::TempDir;
 use vx_runtime::{
-    Arch, Ecosystem, HttpClient, Installer, Os, Platform, RealFileSystem, RealPathProvider,
-    Runtime, RuntimeContext, VersionInfo,
+    Arch, Ecosystem, HttpClient, Installer, ManifestDrivenRuntime, Os, Platform, ProviderSource,
+    RealFileSystem, RealPathProvider, Runtime, RuntimeContext, VersionInfo,
 };
 
 #[derive(Debug)]
@@ -63,6 +63,23 @@ fn test_context() -> (TempDir, RuntimeContext) {
     );
 
     (temp_dir, ctx)
+}
+
+#[tokio::test]
+async fn manifest_runtime_reports_provider_declared_system_installation() {
+    let (temp_dir, ctx) = test_context();
+    let executable = temp_dir.path().join("cl.exe");
+    std::fs::write(&executable, b"").expect("mock compiler should be created");
+    let runtime = ManifestDrivenRuntime::new("msvc", "cl", ProviderSource::BuiltIn)
+        .with_system_paths(vec![executable.to_string_lossy().to_string()]);
+
+    assert_eq!(
+        runtime
+            .installed_versions(&ctx)
+            .await
+            .expect("system path detection should succeed"),
+        vec!["system"]
+    );
 }
 
 /// Test runtime implementation


### PR DESCRIPTION
## Summary
- detect provider-declared system MSVC installations
- propagate companion install options and select a Spectre-capable toolchain
- prepare MSVC and Windows SDK environment variables for commands

## Validation
- `vx cargo test -p vx-runtime --test runtime_tests`
- `vx cargo test -p vx-resolver --test prepare_stage_tests`
- `vx cargo clippy -p vx-runtime -p vx-resolver --all-targets -- -D warnings`
- `vx cargo fmt --all -- --check`