### PR TITLE
fix: preserve PATH for Windows Git hooks

### DIFF
--- a/crates/vx-providers/git/provider.star
+++ b/crates/vx-providers/git/provider.star
@@ -1,7 +1,7 @@
 # provider.star - Git provider
 #
 # Git - Distributed version control system
-# Windows: portable Git from git-for-windows (7z.exe self-extracting)
+# Windows: full Git for Windows tar archive
 # macOS/Linux: system package manager
 #
 # Uses stdlib templates from @vx//stdlib:provider.star
@@ -47,7 +47,7 @@ permissions = github_permissions()
 fetch_versions = make_fetch_versions("git-for-windows", "git")
 
 # ---------------------------------------------------------------------------
-# download_url — Windows-only portable Git (MinGit ZIP)
+# download_url — Windows-only full Git archive
 # macOS/Linux use system package manager
 #
 # Version format: "{base}.windows.{N}" (e.g. "2.53.0.windows.2")
@@ -56,13 +56,9 @@ fetch_versions = make_fetch_versions("git-for-windows", "git")
 #   N=1 → "{base}"       (e.g. "2.53.0")
 #   N>1 → "{base}.{N}"   (e.g. "2.53.0.2")
 #
-# We use MinGit (minimal portable git) rather than PortableGit because:
-# - MinGit ships as a plain ZIP archive (reliable extraction, no 7z/SFX needed)
-# - PortableGit ships as a .7z.exe self-extracting archive (7z SFX extraction
-#   is fragile: `sevenz_rust` may fail to find the 7z archive inside the PE stub)
-# - MinGit contains cmd/git.exe + mingw64/bin/git.exe — identical layout to
-#   PortableGit, just without GUI tools (git-gui, gitk) and bash interactivity
-# - For vx use-cases (scripted git execution), MinGit is fully sufficient
+# The full tar.bz2 distribution includes bash for #!/usr/bin/env bash hooks.
+# Unlike PortableGit's .7z.exe, it is also a regular archive vx can extract
+# without handling a self-extracting PE wrapper.
 # ---------------------------------------------------------------------------
 
 def _parse_git_version(version):
@@ -98,14 +94,10 @@ def download_url(ctx, version):
     # Asset filename uses "{base}" for .windows.1, "{base}.{N}" for .windows.N>1
     asset_ver = "{}.{}".format(base, n) if n > 1 else base
 
-    # Use MinGit ZIP (standard ZIP, reliably extractable) instead of PortableGit
-    # .7z.exe (self-extracting archive requiring 7z SFX support).
     if ctx.platform.arch == "x64":
-        asset = "MinGit-{}-64-bit.zip".format(asset_ver)
+        asset = "Git-{}-64-bit.tar.bz2".format(asset_ver)
     elif ctx.platform.arch == "arm64":
-        asset = "MinGit-{}-arm64.zip".format(asset_ver)
-    elif ctx.platform.arch == "x86":
-        asset = "MinGit-{}-32-bit.zip".format(asset_ver)
+        asset = "Git-{}-arm64.tar.bz2".format(asset_ver)
     else:
         return None
 
@@ -115,13 +107,14 @@ def download_url(ctx, version):
 # install_layout
 # ---------------------------------------------------------------------------
 
-# MinGit ZIP extracted layout:
+# Full Git tar.bz2 extracted layout:
 #   <install_dir>/
 #     cmd/git.exe          ← cmd-style wrapper (primary entry point)
 #     mingw64/bin/git.exe  ← real MinGW git binary
 #     mingw64/bin/...      ← other git tools
+#     usr/bin/bash.exe     ← interpreter for common Git hooks
 #
-# The ZIP is extracted directly into install_dir with no top-level directory,
+# The archive is extracted directly into install_dir with no top-level directory,
 # so strip_prefix="" (auto-detect) will NOT attempt to strip any prefix.
 # We list candidate paths so the installer can verify the correct one.
 def install_layout(ctx, _version):
@@ -162,7 +155,7 @@ store_root = _paths["store_root"]
 def get_execute_path(ctx, _version):
     """Return the path to the git executable inside the install dir.
 
-    PortableGit for Windows extracts to a directory tree; the canonical
+    Git for Windows extracts to a directory tree; the canonical
     entry point is cmd/git.exe (the cmd-shell wrapper) which is on PATH.
     The real MinGW binary lives at mingw64/bin/git.exe.
 

--- a/crates/vx-providers/git/tests/starlark_logic_tests.rs
+++ b/crates/vx-providers/git/tests/starlark_logic_tests.rs
@@ -75,7 +75,7 @@ not ("shells" in rt)
 // ── download_url logic ────────────────────────────────────────────────────────
 
 #[test]
-fn test_download_url_windows_x64_returns_zip() {
+fn test_download_url_windows_x64_returns_tar_bz2() {
     let mut a = Assert::new();
     a.dialect(&Dialect::Standard);
     a.is_true(&format!(
@@ -83,7 +83,7 @@ fn test_download_url_windows_x64_returns_zip() {
 {}
 ctx = struct(platform = struct(os = "windows", arch = "x64", target = ""))
 url = download_url(ctx, "2.44.0")
-url != None and url.endswith(".zip")
+url != None and url.endswith(".tar.bz2")
 "#,
         provider_star_prefix()
     ));
@@ -187,7 +187,7 @@ len(env) == 0
 #[test]
 fn test_download_url_windows_version_with_windows_2_suffix() {
     // Regression test: version "2.53.0.windows.2" must produce
-    // tag "v2.53.0.windows.2" and asset "MinGit-2.53.0.2-64-bit.zip"
+    // tag "v2.53.0.windows.2" and asset "Git-2.53.0.2-64-bit.tar.bz2"
     let mut a = Assert::new();
     a.dialect(&Dialect::Standard);
     a.is_true(&format!(
@@ -195,7 +195,7 @@ fn test_download_url_windows_version_with_windows_2_suffix() {
 {}
 ctx = struct(platform = struct(os = "windows", arch = "x64", target = ""))
 url = download_url(ctx, "2.53.0.windows.2")
-url != None and "v2.53.0.windows.2" in url and "MinGit-2.53.0.2-64-bit.zip" in url
+url != None and "v2.53.0.windows.2" in url and "Git-2.53.0.2-64-bit.tar.bz2" in url
 "#,
         provider_star_prefix()
     ));
@@ -211,7 +211,7 @@ fn test_download_url_windows_version_with_windows_1_suffix() {
 {}
 ctx = struct(platform = struct(os = "windows", arch = "x64", target = ""))
 url = download_url(ctx, "2.53.0.windows.1")
-url != None and "v2.53.0.windows.1" in url and "MinGit-2.53.0-64-bit.zip" in url
+url != None and "v2.53.0.windows.1" in url and "Git-2.53.0-64-bit.tar.bz2" in url
 "#,
         provider_star_prefix()
     ));
@@ -227,7 +227,7 @@ fn test_download_url_windows_arm64() {
 {}
 ctx = struct(platform = struct(os = "windows", arch = "arm64", target = ""))
 url = download_url(ctx, "2.53.0.windows.2")
-url != None and "arm64.zip" in url
+url != None and "arm64.tar.bz2" in url
 "#,
         provider_star_prefix()
     ));

--- a/crates/vx-starlark/tests/git_provider_tests.rs
+++ b/crates/vx-starlark/tests/git_provider_tests.rs
@@ -1,0 +1,120 @@
+//! Tests for the `git` provider.
+
+use vx_starlark::{ProviderContext, StarlarkEngine};
+
+#[rstest::rstest]
+#[case("x64", "Git-2.54.0-64-bit.tar.bz2")]
+#[case("arm64", "Git-2.54.0-arm64.tar.bz2")]
+fn windows_download_includes_bash(#[case] arch: &str, #[case] asset: &str) {
+    let star_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("vx-providers/git/provider.star");
+    let content = std::fs::read_to_string(&star_path).unwrap();
+    let mut ctx = ProviderContext::new("git", std::env::temp_dir().join("vx-test"));
+    ctx.platform.os = "windows".to_string();
+    ctx.platform.arch = arch.to_string();
+
+    let url = StarlarkEngine::new()
+        .call_function(
+            &star_path,
+            &content,
+            "download_url",
+            &ctx,
+            &[serde_json::json!("2.54.0.windows.1")],
+        )
+        .unwrap();
+
+    assert!(url.as_str().unwrap().ends_with(asset));
+}
+
+#[cfg(windows)]
+#[test]
+#[ignore = "requires network access and a built vx binary"]
+fn windows_shebang_hook_resolves_external_path_tool() {
+    use std::process::{Command, Output};
+
+    fn run_vx(
+        vx: &std::path::Path,
+        cwd: &std::path::Path,
+        vx_home: &std::path::Path,
+        path: &std::ffi::OsStr,
+        args: &[&str],
+    ) -> Output {
+        Command::new(vx)
+            .args(args)
+            .current_dir(cwd)
+            .env("VX_HOME", vx_home)
+            .env("PATH", path)
+            .output()
+            .unwrap()
+    }
+
+    fn assert_success(output: &Output) {
+        assert!(
+            output.status.success(),
+            "stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let workspace = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let vx = std::env::var_os("VX_BINARY")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| workspace.join("target").join("debug").join("vx.exe"));
+    assert!(vx.is_file(), "build vx or set VX_BINARY={}", vx.display());
+
+    let temp = tempfile::tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    let tool_dir = temp.path().join("external-bin");
+    std::fs::create_dir_all(&repo).unwrap();
+    std::fs::create_dir_all(&tool_dir).unwrap();
+    std::fs::copy(
+        std::env::current_exe().unwrap(),
+        tool_dir.join("hook-path-tool.exe"),
+    )
+    .unwrap();
+
+    let mut path_entries = vec![tool_dir];
+    path_entries.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let path = std::env::join_paths(path_entries).unwrap();
+    let vx_home = temp.path().join("vx-home");
+
+    assert_success(&run_vx(
+        &vx,
+        &repo,
+        &vx_home,
+        &path,
+        &["git@latest", "init", "--quiet"],
+    ));
+
+    let hook = repo.join(".git").join("hooks").join("pre-push");
+    std::fs::write(
+        hook,
+        "#!/usr/bin/env bash\nset -eu\ncommand -v hook-path-tool >/dev/null\n",
+    )
+    .unwrap();
+
+    assert_success(&run_vx(
+        &vx,
+        &repo,
+        &vx_home,
+        &path,
+        &[
+            "git@latest",
+            "-c",
+            "core.hooksPath=.git/hooks",
+            "hook",
+            "run",
+            "pre-push",
+        ],
+    ));
+}


### PR DESCRIPTION
## Summary
- use full Git for Windows archives so managed Git includes MSYS Bash
- cover external PATH resolution from shebang-based Git hooks

## Root cause
MinGit omitted `bash.exe`, so `#!/usr/bin/env bash` hooks could fall through to WSL Bash and lose Windows executable lookup semantics.

## Validation
- provider URL tests and 144 provider static checks
- Windows shebang hook regression test
- exact pre-push hook reproduction with source-built vx