### PR TITLE
fix: stabilize cross-platform CI

### DIFF
--- a/crates/vx-installer/src/formats/tar.rs
+++ b/crates/vx-installer/src/formats/tar.rs
@@ -280,6 +280,7 @@ mod tests {
             let mut header = tar::Header::new_gnu();
             header.set_path("sample.txt").unwrap();
             header.set_size(data.len() as u64);
+            header.set_mode(0o644);
             header.set_cksum();
             builder.append(&header, &data[..]).unwrap();
             let encoder = builder.into_inner().unwrap();

--- a/crates/vx-runtime/src/manifest_runtime/mod.rs
+++ b/crates/vx-runtime/src/manifest_runtime/mod.rs
@@ -866,11 +866,11 @@ impl Runtime for ManifestDrivenRuntime {
     async fn prepare_environment(
         &self,
         _version: &str,
-        ctx: &RuntimeContext,
+        _ctx: &RuntimeContext,
     ) -> Result<HashMap<String, String>> {
         #[cfg(windows)]
         if self.name == "msvc" {
-            let require_spectre = ctx
+            let require_spectre = _ctx
                 .get_install_option("VX_MSVC_COMPONENTS")
                 .map(|components| {
                     components


### PR DESCRIPTION
Fix the Linux Clippy warning and make the tar.bz2 fixture portable across Unix runners.

Validation: full workspace Clippy, focused tar.bz2 test, and the exact Windows shebang-hook reproduction.