### PR TITLE
fix: stabilize remaining CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,6 +675,11 @@ jobs:
           shared-key: test
           install-nextest: "true"
 
+      - name: Preinstall Node.js on Windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: vx node --version
+
       - name: Run full workspace tests
         shell: bash
         run: cargo nextest run --workspace --no-fail-fast

--- a/crates/vx-runtime-http/src/installer.rs
+++ b/crates/vx-runtime-http/src/installer.rs
@@ -840,17 +840,17 @@ impl Installer for RealInstaller {
 
             // Helper: set 0o755 on all regular files under a directory.
             let chmod_dir = |dir: &std::path::Path| {
-                if dir.is_dir() {
-                    if let Ok(entries) = std::fs::read_dir(dir) {
-                        for entry in entries.filter_map(|e| e.ok()) {
-                            let path = entry.path();
-                            if path.is_file() {
-                                if let Ok(meta) = std::fs::metadata(&path) {
-                                    let mut perms = meta.permissions();
-                                    perms.set_mode(0o755);
-                                    let _ = std::fs::set_permissions(&path, perms);
-                                }
-                            }
+                if dir.is_dir()
+                    && let Ok(entries) = std::fs::read_dir(dir)
+                {
+                    for entry in entries.filter_map(|e| e.ok()) {
+                        let path = entry.path();
+                        if path.is_file()
+                            && let Ok(meta) = std::fs::metadata(&path)
+                        {
+                            let mut perms = meta.permissions();
+                            perms.set_mode(0o755);
+                            let _ = std::fs::set_permissions(&path, perms);
                         }
                     }
                 }

--- a/justfile
+++ b/justfile
@@ -181,7 +181,7 @@ security-audit-ci:
 
 # Coverage (CI)
 coverage-ci:
-    vx cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+    cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
 # Cross build (release) — installs cross via cargo, then builds with optimizations
 cross-build TARGET:


### PR DESCRIPTION
## Summary
- satisfy Unix-only Clippy checks
- run coverage with the CI-provided system Rust toolchain
- preinstall Node before parallel Windows E2E tests

## Validation
- full workspace Clippy
- scoped coverage smoke
- Windows Node E2E: 23/23
- actionlint
- exact Windows shebang hook reproduction