### PR TITLE
fix: isolate action cache by runner architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4544,7 +4544,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vx"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "vx-args"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "indexmap",
  "regex",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "vx-bridge"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "tempfile",
  "tracing",
@@ -4584,7 +4584,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cache"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4599,7 +4599,7 @@ dependencies = [
 
 [[package]]
 name = "vx-cli"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4664,7 +4664,7 @@ dependencies = [
 
 [[package]]
 name = "vx-config"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4686,7 +4686,7 @@ dependencies = [
 
 [[package]]
 name = "vx-console"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4707,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "vx-ecosystem-pm"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4725,7 +4725,7 @@ dependencies = [
 
 [[package]]
 name = "vx-env"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "colored",
@@ -4747,7 +4747,7 @@ dependencies = [
 
 [[package]]
 name = "vx-extension"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4769,7 +4769,7 @@ dependencies = [
 
 [[package]]
 name = "vx-installer"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4803,7 +4803,7 @@ dependencies = [
 
 [[package]]
 name = "vx-manifest"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "pretty_assertions",
  "rstest",
@@ -4821,7 +4821,7 @@ dependencies = [
 
 [[package]]
 name = "vx-metrics"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4844,7 +4844,7 @@ dependencies = [
 
 [[package]]
 name = "vx-migration"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4866,14 +4866,14 @@ dependencies = [
 
 [[package]]
 name = "vx-msbuild-bridge"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "workspace-hack",
 ]
 
 [[package]]
 name = "vx-output-filter"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "regex",
@@ -4887,7 +4887,7 @@ dependencies = [
 
 [[package]]
 name = "vx-paths"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "vx-project-analyzer"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4931,7 +4931,7 @@ dependencies = [
 
 [[package]]
 name = "vx-resolver"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4995,7 +4995,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-archive"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "flate2",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-core"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "vx-runtime-http"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "vx-setup"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5081,7 +5081,7 @@ dependencies = [
 
 [[package]]
 name = "vx-shim"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "serde",
@@ -5099,11 +5099,11 @@ dependencies = [
 
 [[package]]
 name = "vx-star-metadata"
-version = "0.9.26"
+version = "0.9.27"
 
 [[package]]
 name = "vx-starlark"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5133,7 +5133,7 @@ dependencies = [
 
 [[package]]
 name = "vx-system-pm"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "vx-version-fetcher"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "vx-versions"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/action.yml
+++ b/action.yml
@@ -52,10 +52,10 @@ runs:
           ~/.vx
           ~/.local/bin/vx
           ~/.local/bin/vx.exe
-        key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ inputs.version }}-${{ inputs.tools }}-${{ hashFiles('vx.toml', '.vx.toml', 'vx.lock') }}
+        key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}-${{ inputs.tools }}-${{ hashFiles('vx.toml', '.vx.toml', 'vx.lock') }}
         restore-keys: |
-          ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ inputs.version }}-
-          ${{ inputs.cache-key-prefix }}-${{ runner.os }}-
+          ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}-
+          ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ runner.arch }}-
 
     # Install vx on Linux/macOS using install.sh
     - name: Install vx (Unix)

--- a/tests/action_cache_key_tests.rs
+++ b/tests/action_cache_key_tests.rs
@@ -1,0 +1,50 @@
+//! Regression tests for the setup Action cache key contract.
+
+use std::{fs, path::PathBuf};
+
+use rstest::{fixture, rstest};
+
+#[fixture]
+fn action_yaml() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("action.yml");
+    fs::read_to_string(path).expect("action.yml should be readable")
+}
+
+#[rstest]
+fn cache_keys_are_arch_scoped_and_keep_the_custom_prefix(action_yaml: String) {
+    let cache_step = action_yaml
+        .split_once("    - name: Cache vx tools")
+        .expect("cache step should exist")
+        .1
+        .split_once("\n    # Install vx")
+        .expect("cache step should end before installation")
+        .0;
+    let key_templates: Vec<_> = cache_step
+        .lines()
+        .map(str::trim)
+        .filter_map(|line| {
+            line.strip_prefix("key: ").or_else(|| {
+                line.starts_with("${{ inputs.cache-key-prefix }}-")
+                    .then_some(line)
+            })
+        })
+        .collect();
+
+    assert_eq!(
+        key_templates,
+        [
+            "${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}-${{ inputs.tools }}-${{ hashFiles('vx.toml', '.vx.toml', 'vx.lock') }}",
+            "${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}-",
+            "${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ runner.arch }}-",
+        ]
+    );
+
+    let prefix_input = action_yaml
+        .split_once("  cache-key-prefix:")
+        .expect("cache-key-prefix input should exist")
+        .1
+        .split_once("  setup:")
+        .expect("cache-key-prefix input should precede setup")
+        .0;
+    assert!(prefix_input.contains("    default: \"vx-tools\""));
+}


### PR DESCRIPTION
## Summary
- scope Action cache and restore keys by runner architecture
- preserve custom cache key prefixes with regression coverage
- sync release lock metadata required by the pre-push gate

## Tests
- `vx actionlint`
- `vx cargo clippy --test action_cache_key_tests -- -D warnings`
- `vx cargo test --test action_cache_key_tests`