### PR TITLE
fix(providers): generate correct per-platform download URLs in vx.lock for Starlark providers

### DIFF
--- a/crates/vx-runtime/src/manifest_runtime/mod.rs
+++ b/crates/vx-runtime/src/manifest_runtime/mod.rs
@@ -248,10 +248,14 @@ pub type FetchVersionsFn = Arc<
 
 /// Type alias for an async `download_url` function injected from Starlark providers.
 ///
-/// Signature: `(version: String) -> Option<String>`
+/// Signature: `(version: String, platform: Platform) -> Option<String>`
+///
+/// The platform parameter lets Starlark-backed runtimes compute download URLs
+/// for a specific target platform (used by `vx lock` to fill `platform_urls`).
 pub type DownloadUrlFn = Arc<
     dyn Fn(
             String,
+            crate::platform::Platform,
         )
             -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Option<String>>> + Send>>
         + Send
@@ -582,6 +586,7 @@ impl ManifestDrivenRuntime {
     where
         F: Fn(
                 String,
+                crate::platform::Platform,
             ) -> std::pin::Pin<
                 Box<dyn std::future::Future<Output = Result<Option<String>>> + Send>,
             > + Send
@@ -1286,7 +1291,7 @@ impl Runtime for ManifestDrivenRuntime {
 
     async fn download_url(&self, version: &str, platform: &Platform) -> Result<Option<String>> {
         if let Some(ref f) = self.download_url_fn {
-            return f(version.to_string()).await;
+            return f(version.to_string(), platform.clone()).await;
         }
 
         for strategy in &self.install_strategies {

--- a/crates/vx-runtime/tests/runtime_tests.rs
+++ b/crates/vx-runtime/tests/runtime_tests.rs
@@ -339,3 +339,26 @@ fn test_platform_os_checks() {
     assert!(!macos.is_linux());
     assert!(macos.is_macos());
 }
+
+/// `download_url_fn` must receive the requested target platform so
+/// Starlark-backed providers can compute per-platform URLs
+/// (e.g. for `vx lock` `platform_urls`).
+#[tokio::test]
+async fn test_download_url_fn_receives_requested_platform() {
+    let runtime = ManifestDrivenRuntime::new("test-tool", "test-tool", ProviderSource::BuiltIn)
+        .with_download_url(|version: String, platform: Platform| {
+            Box::pin(async move { Ok(Some(format!("{version}-{}", platform.as_str()))) })
+        });
+
+    let url = runtime
+        .download_url("1.2.3", &Platform::new(Os::Linux, Arch::Aarch64))
+        .await
+        .expect("download_url should resolve");
+    assert_eq!(url.as_deref(), Some("1.2.3-linux-arm64"));
+
+    let url = runtime
+        .download_url("1.2.3", &Platform::new(Os::Windows, Arch::X86_64))
+        .await
+        .expect("download_url should resolve");
+    assert_eq!(url.as_deref(), Some("1.2.3-windows-x64"));
+}

--- a/crates/vx-starlark/src/context.rs
+++ b/crates/vx-starlark/src/context.rs
@@ -31,6 +31,61 @@ impl PlatformInfo {
         }
     }
 
+    /// Create platform info from a [`vx_runtime::Platform`].
+    ///
+    /// Maps the runtime platform enums to the string values expected by
+    /// `provider.star` scripts (`ctx.platform.os` / `ctx.platform.arch`), e.g.
+    /// `Os::MacOS` maps to `"macos"` (not `"darwin"`).
+    ///
+    /// Used by `vx lock` to generate per-platform download URLs: the download
+    /// URL closure overrides `ctx.platform` with the requested target platform
+    /// before evaluating the script's `download_url(ctx, version)` function.
+    pub fn from_runtime_platform(platform: &vx_runtime::Platform) -> Self {
+        let os = match platform.os {
+            vx_runtime::Os::Windows => "windows",
+            vx_runtime::Os::MacOS => "macos",
+            vx_runtime::Os::Linux => "linux",
+            vx_runtime::Os::FreeBSD => "freebsd",
+            vx_runtime::Os::Unknown => "unknown",
+        };
+        let arch = match platform.arch {
+            vx_runtime::Arch::X86_64 => "x64",
+            vx_runtime::Arch::Aarch64 => "arm64",
+            vx_runtime::Arch::Arm => "arm",
+            vx_runtime::Arch::Armv7 => "armv7",
+            vx_runtime::Arch::X86 => "x86",
+            vx_runtime::Arch::PowerPC64 => "ppc64",
+            vx_runtime::Arch::PowerPC64LE => "ppc64le",
+            vx_runtime::Arch::S390x => "s390x",
+            vx_runtime::Arch::Riscv64 => "riscv64",
+            vx_runtime::Arch::Unknown => "unknown",
+        };
+        let arch_triple = match platform.arch {
+            vx_runtime::Arch::X86_64 => "x86_64",
+            vx_runtime::Arch::Aarch64 => "aarch64",
+            vx_runtime::Arch::Arm => "arm",
+            vx_runtime::Arch::Armv7 => "armv7",
+            vx_runtime::Arch::X86 => "i686",
+            vx_runtime::Arch::PowerPC64 => "powerpc64",
+            vx_runtime::Arch::PowerPC64LE => "powerpc64le",
+            vx_runtime::Arch::S390x => "s390x",
+            vx_runtime::Arch::Riscv64 => "riscv64",
+            vx_runtime::Arch::Unknown => "unknown",
+        };
+        let os_triple = match platform.os {
+            vx_runtime::Os::Windows => "pc-windows-msvc",
+            vx_runtime::Os::MacOS => "apple-darwin",
+            vx_runtime::Os::Linux => "unknown-linux-gnu",
+            vx_runtime::Os::FreeBSD => "unknown-freebsd",
+            vx_runtime::Os::Unknown => "unknown",
+        };
+        Self {
+            os: os.to_string(),
+            arch: arch.to_string(),
+            target: format!("{}-{}", arch_triple, os_triple),
+        }
+    }
+
     fn detect_os() -> String {
         if cfg!(target_os = "windows") {
             "windows".to_string()
@@ -353,6 +408,15 @@ impl ProviderContext {
         self
     }
 
+    /// Override the platform exposed to scripts.
+    ///
+    /// Used when generating download URLs for a target platform other than
+    /// the host (see [`PlatformInfo::from_runtime_platform`]).
+    pub fn with_platform(mut self, platform: PlatformInfo) -> Self {
+        self.platform = platform;
+        self
+    }
+
     /// Set environment variables
     pub fn with_env(mut self, env: HashMap<String, String>) -> Self {
         self.env = env;
@@ -500,5 +564,32 @@ impl ProviderContext {
         } else {
             s == pattern
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_platform_info_from_runtime_platform() {
+        let macos = vx_runtime::Platform::new(vx_runtime::Os::MacOS, vx_runtime::Arch::Aarch64);
+        let info = PlatformInfo::from_runtime_platform(&macos);
+        assert_eq!(info.os, "macos");
+        assert_eq!(info.arch, "arm64");
+        assert_eq!(info.target, "aarch64-apple-darwin");
+
+        let windows =
+            vx_runtime::Platform::new(vx_runtime::Os::Windows, vx_runtime::Arch::X86_64);
+        let info = PlatformInfo::from_runtime_platform(&windows);
+        assert_eq!(info.os, "windows");
+        assert_eq!(info.arch, "x64");
+        assert_eq!(info.target, "x86_64-pc-windows-msvc");
+
+        let linux = vx_runtime::Platform::new(vx_runtime::Os::Linux, vx_runtime::Arch::X86);
+        let info = PlatformInfo::from_runtime_platform(&linux);
+        assert_eq!(info.os, "linux");
+        assert_eq!(info.arch, "x86");
+        assert_eq!(info.target, "i686-unknown-linux-gnu");
     }
 }

--- a/crates/vx-starlark/src/context.rs
+++ b/crates/vx-starlark/src/context.rs
@@ -412,8 +412,8 @@ impl ProviderContext {
     ///
     /// Used when generating download URLs for a target platform other than
     /// the host (see [`PlatformInfo::from_runtime_platform`]).
-    pub fn with_platform(mut self, platform: PlatformInfo) -> Self {
-        self.platform = platform;
+    pub fn with_platform(mut self, platform: &PlatformInfo) -> Self {
+        self.platform = platform.clone();
         self
     }
 

--- a/crates/vx-starlark/src/handle.rs
+++ b/crates/vx-starlark/src/handle.rs
@@ -548,7 +548,7 @@ impl ProviderHandle {
     /// Delegates to provider.star::download_url
     pub async fn download_url(&self, version: &str) -> Result<Option<String>> {
         self.star
-            .download_url_for_runtime(version, self.runtime_name.as_deref())
+            .download_url_for_runtime(version, self.runtime_name.as_deref(), None)
             .await
     }
 

--- a/crates/vx-starlark/src/provider/bridge.rs
+++ b/crates/vx-starlark/src/provider/bridge.rs
@@ -50,6 +50,7 @@ pub fn make_download_url_fn(
     content: impl Into<String>,
 ) -> impl Fn(
     String,
+    vx_runtime::Platform,
 ) -> std::pin::Pin<
     Box<dyn std::future::Future<Output = anyhow::Result<Option<String>>> + Send>,
 > + Send
@@ -57,16 +58,15 @@ pub fn make_download_url_fn(
 + 'static {
     let name: Arc<str> = Arc::from(name.into());
     let content: Arc<str> = Arc::from(content.into());
-    move |version: String| {
-        let name = Arc::clone(&name);
-        let content = Arc::clone(&content);
+    move |version: String, platform: vx_runtime::Platform| {
         Box::pin(async move {
             let provider = StarlarkProvider::from_content(&*name, &*content)
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to load {} provider.star: {e}", name))?;
 
+            let platform_info = crate::context::PlatformInfo::from_runtime_platform(&platform);
             provider
-                .download_url(&version)
+                .download_url_for_runtime(&version, None, Some(&platform_info))
                 .await
                 .map_err(|e| anyhow::anyhow!("{} download_url failed: {e}", name))
         })
@@ -153,12 +153,13 @@ pub(super) fn make_download_url_fn_owned(
     runtime_name: String,
 ) -> impl Fn(
     String,
+    vx_runtime::Platform,
 ) -> std::pin::Pin<
     Box<dyn std::future::Future<Output = anyhow::Result<Option<String>>> + Send>,
 > + Send
 + Sync
 + 'static {
-    move |version: String| {
+    move |version: String, platform: vx_runtime::Platform| {
         let provider_name = Arc::clone(&provider_name);
         let content = Arc::clone(&content);
         let rt_name = runtime_name.clone();
@@ -169,8 +170,9 @@ pub(super) fn make_download_url_fn_owned(
                     anyhow::anyhow!("Failed to load {} provider.star: {e}", provider_name)
                 })?;
 
+            let platform_info = crate::context::PlatformInfo::from_runtime_platform(&platform);
             provider
-                .download_url_for_runtime(&version, Some(&rt_name))
+                .download_url_for_runtime(&version, Some(&rt_name), Some(&platform_info))
                 .await
                 .map_err(|e| anyhow::anyhow!("{} download_url failed: {e}", provider_name))
         })

--- a/crates/vx-starlark/src/provider/bridge.rs
+++ b/crates/vx-starlark/src/provider/bridge.rs
@@ -59,6 +59,8 @@ pub fn make_download_url_fn(
     let name: Arc<str> = Arc::from(name.into());
     let content: Arc<str> = Arc::from(content.into());
     move |version: String, platform: vx_runtime::Platform| {
+        let name = Arc::clone(&name);
+        let content = Arc::clone(&content);
         Box::pin(async move {
             let provider = StarlarkProvider::from_content(&*name, &*content)
                 .await

--- a/crates/vx-starlark/src/provider/mod.rs
+++ b/crates/vx-starlark/src/provider/mod.rs
@@ -25,7 +25,7 @@ pub mod types;
 pub mod version_cache;
 mod versions;
 
-use crate::context::{InstallResult, ProviderContext, VersionInfo};
+use crate::context::{InstallResult, PlatformInfo, ProviderContext, VersionInfo};
 use crate::engine::{FrozenProviderInfo, StarlarkEngine};
 use crate::error::{Error, Result};
 use crate::sandbox::SandboxConfig;
@@ -323,13 +323,17 @@ impl StarlarkProvider {
 
     /// Call the `download_url` function
     pub async fn download_url(&self, version: &str) -> Result<Option<String>> {
-        self.download_url_for_runtime(version, None).await
+        self.download_url_for_runtime(version, None, None).await
     }
 
     /// Call the `download_url` function for a specific runtime within a multi-runtime provider.
     ///
     /// Passes `ctx.runtime_name` so that providers can dispatch to the correct
     /// download URL for each runtime (e.g. different GitHub repos for yazi vs starship).
+    ///
+    /// When `platform` is provided, `ctx.platform` is overridden with it before
+    /// evaluation, so the script computes the download URL for that platform.
+    /// This is used by `vx lock` to populate per-platform `platform_urls`.
     ///
     /// For providers that depend on `ctx.version_date` (e.g. python-build-standalone),
     /// this method will automatically trigger a `fetch_versions` call to populate the
@@ -339,6 +343,7 @@ impl StarlarkProvider {
         &self,
         version: &str,
         runtime_name: Option<&str>,
+        platform: Option<&PlatformInfo>,
     ) -> Result<Option<String>> {
         // Look up the build tag (date) for this version from the version cache.
         // This is needed by providers like python-build-standalone where the
@@ -380,6 +385,9 @@ impl StarlarkProvider {
             .with_sandbox(self.sandbox.clone())
             .with_version(version);
 
+        if let Some(platform) = platform {
+            ctx = ctx.with_platform(platform.clone());
+        }
         if let Some(date) = version_date {
             ctx = ctx.with_version_date(date);
         }

--- a/crates/vx-starlark/src/provider/mod.rs
+++ b/crates/vx-starlark/src/provider/mod.rs
@@ -386,7 +386,7 @@ impl StarlarkProvider {
             .with_version(version);
 
         if let Some(platform) = platform {
-            ctx = ctx.with_platform(platform.clone());
+            ctx = ctx.with_platform(platform);
         }
         if let Some(date) = version_date {
             ctx = ctx.with_version_date(date);


### PR DESCRIPTION
## Problem

`vx lock` writes the **same download URL for every platform** into `platform_urls`
for Starlark-backed providers. Example with the `dotnet` provider on Windows:

```toml
[tools.dotnet.platform_urls]
darwin-arm64 = "https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.424/dotnet-sdk-8.0.424-win-x64.zip"
linux-x64    = "https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.424/dotnet-sdk-8.0.424-win-x64.zip"
windows-x64  = "https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.424/dotnet-sdk-8.0.424-win-x64.zip"
```

A lockfile generated on one OS therefore points every other OS at the host
platform's artifact, breaking cross-platform reproducible installs.

## Root cause

- `Runtime::download_url(version, platform)` carries a `Platform`, but the
  Starlark bridge `DownloadUrlFn` drops it (`Fn(String)`), and
  `StarlarkProvider::download_url_for_runtime` always evaluates the script
  with a `ProviderContext` built from the **host** platform.
- `vx lock` already iterates `common_platforms()` and calls
  `runtime.download_url(&version, &platform)` — the platform just never
  reaches the `provider.star` `ctx`.

## Fix

1. `DownloadUrlFn` now takes `(String, crate::platform::Platform)`.
2. `StarlarkProvider::download_url_for_runtime` accepts an optional
   `&PlatformInfo` and overrides `ctx.platform` before evaluation
   (`ProviderContext::with_platform`).
3. New `PlatformInfo::from_runtime_platform` maps the runtime `Os`/`Arch`
   enums to the strings `provider.star` expects (`Os::MacOS` → `"macos"`, ...).
4. The bridge closures convert the requested `Platform` and pass it through.

## Tests

- `vx-runtime`: `download_url_fn` receives the requested target platform
  (linux-arm64 and windows-x64 produce distinct URLs).
- `vx-starlark`: `PlatformInfo::from_runtime_platform` os/arch/target mapping.

## Verification

- With a `vx.toml` pinning `dotnet = "8"`, `vx lock` now emits per-RID URLs:
  `dotnet-sdk-8.0.424-{win-x64.zip,osx-arm64.tar.gz,linux-x64.tar.gz,...}`.

Follow-up (out of scope here): `vx lock` records `ecosystem = "generic"` for
dotnet because `vx-resolver::Ecosystem` (re-exported from `vx-versions`) has no
`DotNet` variant to map to.