### PR TITLE
fix: repair Scoop publishing for vx releases

### DIFF
--- a/.github/workflows/package-managers.yml
+++ b/.github/workflows/package-managers.yml
@@ -3,95 +3,95 @@ name: Package Managers
 # Publish to various package managers using pre-built artifacts
 # Downloads binaries from GitHub Release
 # No building - only packaging and distribution
+#
+# Triggered by the "release published" event: fires whenever a GitHub Release is
+# published (including releases created by the cargo-dist Release workflow when
+# it is run via workflow_dispatch, which the workflow_run trigger misses).
+# A manual dispatch can publish an arbitrary version.
 
 on:
-  workflow_run:
-    workflows: ["Release"]
+  release:
     types:
-      - completed
+      - published
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to publish (e.g., v1.0.0)"
+        description: "Version to publish (e.g., v0.9.29)"
         required: true
         type: string
-      force_run:
-        description: "Force run even if Release workflow failed"
-        required: false
-        default: false
-        type: boolean
 
 permissions:
   contents: read
 
 jobs:
-  # Only run if the Release workflow was successful or forced
+  # Determine whether (and which version) to publish.
+  # Skips prereleases and the legacy "vx-vX.Y.Z" compatibility releases.
   check-release:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
     outputs:
       should-publish: ${{ steps.check.outputs.should-publish }}
       version: ${{ steps.version.outputs.version }}
+      version-num: ${{ steps.version.outputs.version-num }}
     steps:
       - name: Debug workflow event
-
         run: |
           echo "Event name: ${{ github.event_name }}"
-          echo "Workflow run conclusion: ${{ github.event.workflow_run.conclusion }}"
-          echo "Workflow run head branch: ${{ github.event.workflow_run.head_branch }}"
-          echo "Force run input: ${{ github.event.inputs.force_run }}"
+          echo "Release tag: ${{ github.event.release.tag_name }}"
+          echo "Release prerelease: ${{ github.event.release.prerelease }}"
+          echo "Dispatch version input: ${{ github.event.inputs.version }}"
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.version }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          # Strip leading v for the package-manager version number
+          VERSION_NUM="${TAG#v}"
+          if [[ ! "${VERSION_NUM}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::Invalid version: ${TAG}"
+            exit 1
+          fi
+          echo "version=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version-num=${VERSION_NUM}" >> "$GITHUB_OUTPUT"
+          echo "Using tag: ${TAG} (version ${VERSION_NUM})"
 
       - name: Check if should publish
         id: check
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "Manual dispatch - will publish"
-            echo "should-publish=true" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event.inputs.force_run }}" == "true" ]]; then
-            echo "Force run enabled - will publish"
-            echo "should-publish=true" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event.workflow_run.conclusion }}" == "success" ]]; then
-            echo "Release workflow successful - will publish"
-            echo "should-publish=true" >> $GITHUB_OUTPUT
+            echo "should-publish=true" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+            echo "Prerelease - will not publish to package managers"
+            echo "should-publish=false" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event.release.tag_name }}" == vx-* ]]; then
+            echo "Legacy compatibility release - will not publish"
+            echo "should-publish=false" >> "$GITHUB_OUTPUT"
           else
-            echo "Release workflow failed or conditions not met - will not publish"
-            echo "should-publish=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Download release tag artifact
-        if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v8
-        with:
-          name: release-tag
-          path: .
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-      - name: Get version
-        id: version
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
-          else
-            version=$(cat release-tag.txt)
-            echo "version=$version" >> $GITHUB_OUTPUT
+            echo "Stable release published - will publish"
+            echo "should-publish=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Verify GitHub Release exists
+        if: steps.check.outputs.should-publish == 'true'
         run: |
           version="${{ steps.version.outputs.version }}"
-          echo "Checking if GitHub Release exists for version: $version"
+          echo "Checking if GitHub Release exists for version: ${version}"
 
           # Check if release exists
-          release_url="https://api.github.com/repos/loonghao/vx/releases/tags/$version"
+          release_url="https://api.github.com/repos/loonghao/vx/releases/tags/${version}"
           if curl -s -f -H "Accept: application/vnd.github.v3+json" "$release_url" > /dev/null; then
-            echo "�?GitHub Release found for $version"
+            echo "OK GitHub Release found for ${version}"
 
             # List available assets
-            echo "📦 Available release assets:"
+            echo "Available release assets:"
             curl -s -H "Accept: application/vnd.github.v3+json" "$release_url" | \
               jq -r '.assets[] | "  - \(.name) (\(.size) bytes)"'
           else
-            echo "�?GitHub Release not found for $version"
+            echo "FAIL GitHub Release not found for ${version}"
             echo "Please ensure the Release workflow completed successfully"
             exit 1
           fi
@@ -104,20 +104,35 @@ jobs:
     runs-on: windows-latest
     if: needs.check-release.outputs.should-publish == 'true'
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
       - name: Download Windows binary from release
         run: |
-          # Download pre-built binary from GitHub Release (cargo-dist artifact naming)
-          $version = "${{ needs.check-release.outputs.version }}"
+          $versionTag = "${{ needs.check-release.outputs.version }}"
+          $versionNum = "${{ needs.check-release.outputs.version-num }}"
 
-          $downloadUrl = "https://github.com/loonghao/vx/releases/download/$version/vx-x86_64-pc-windows-msvc.zip"
-          Write-Host "Downloading from: $downloadUrl"
-          Invoke-WebRequest -Uri $downloadUrl -OutFile "vx-windows.zip" -ErrorAction Stop
+          # Prefer the unversioned cargo-dist asset name, fall back to the
+          # versioned compatibility copy if the unversioned one is missing.
+          $urls = @(
+            "https://github.com/loonghao/vx/releases/download/$versionTag/vx-x86_64-pc-windows-msvc.zip",
+            "https://github.com/loonghao/vx/releases/download/$versionTag/vx-$versionNum-x86_64-pc-windows-msvc.zip"
+          )
+          $downloaded = $false
+          foreach ($url in $urls) {
+            try {
+              Write-Host "Downloading from: $url"
+              Invoke-WebRequest -Uri $url -OutFile "vx-windows.zip" -ErrorAction Stop
+              $downloaded = $true
+              break
+            } catch {
+              Write-Host "Download failed: $url - $($_.Exception.Message)"
+            }
+          }
+          if (-not $downloaded) {
+            Write-Host "::error::Could not download vx Windows binary from any release URL"
+            exit 1
+          }
           Write-Host "Downloaded zip size: $((Get-Item vx-windows.zip).Length) bytes"
 
-          # Extract the exe from zip (cargo-dist archives contain a top-level directory)
+          # Extract the exe from zip (archives contain the exe at the top level)
           Expand-Archive -Path "vx-windows.zip" -DestinationPath "." -Force
 
           # Find the vx.exe file (it will be in a subdirectory)
@@ -134,17 +149,34 @@ jobs:
 
       - name: Create Chocolatey package
         run: |
-          $version = "${{ needs.check-release.outputs.version }}"
+          $version = "${{ needs.check-release.outputs.version-num }}"
 
-          # Create chocolatey package structure
-          New-Item -ItemType Directory -Force -Path "chocolatey/tools"
+          # Create chocolatey package structure (the nuspec is generated here
+          # so this job never depends on files outside the workflow)
+          New-Item -ItemType Directory -Force -Path "chocolatey/tools" | Out-Null
           Copy-Item "vx.exe" "chocolatey/tools/"
 
-          # Update nuspec file with current version
-          $nuspecContent = Get-Content "chocolatey/vx.nuspec" -Raw
-          $nuspecContent = $nuspecContent -replace "{{VERSION}}", $version.TrimStart('v')
-          $nuspecContent = $nuspecContent -replace "{{RELEASE_NOTES}}", "See https://github.com/loonghao/vx/releases/tag/$version"
-          Set-Content "chocolatey/vx.nuspec" $nuspecContent
+          $nuspec = @"
+          <?xml version="1.0" encoding="utf-8"?>
+          <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+            <metadata>
+              <id>vx</id>
+              <version>$version</version>
+              <title>vx</title>
+              <authors>loonghao</authors>
+              <projectUrl>https://github.com/loonghao/vx</projectUrl>
+              <license type="expression">MIT</license>
+              <requireLicenseAcceptance>false</requireLicenseAcceptance>
+              <description>Universal development tool manager - run any dev tool with automatic runtime management</description>
+              <releaseNotes>See https://github.com/loonghao/vx/releases/tag/v$version</releaseNotes>
+              <tags>vx devtools package-manager</tags>
+            </metadata>
+            <files>
+              <file src="tools\**" target="tools" />
+            </files>
+          </package>
+          "@
+          Set-Content -Path "chocolatey/vx.nuspec" -Value $nuspec -Encoding UTF8
 
           # Build package
           choco pack chocolatey/vx.nuspec --outputdirectory .
@@ -167,6 +199,10 @@ jobs:
   # in release.yml. No custom Homebrew job needed here.
 
   # Publish to Scoop (Custom implementation)
+  #
+  # Generates a manifest from the published GitHub Release and pushes it to
+  # loonghao/scoop-vx. The Windows ARM64 block is only emitted when the
+  # release actually ships an ARM64 Windows asset.
   publish-scoop:
     needs: check-release
     runs-on: ubuntu-latest
@@ -174,84 +210,98 @@ jobs:
     steps:
       - name: Generate and push Scoop manifest
         env:
-          GITHUB_TOKEN: ${{ secrets.SCOOP_BUCKET_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_GITHUB_TOKEN }}
         run: |
-          VERSION="${{ needs.check-release.outputs.version }}"
-          # Remove 'v' prefix for version number
-          VERSION_NUM="${VERSION#v}"
+          set -euo pipefail
+          TAG="${{ needs.check-release.outputs.version }}"
+          VERSION_NUM="${{ needs.check-release.outputs.version-num }}"
+          BASE_URL="https://github.com/loonghao/vx/releases/download/${TAG}"
 
-          echo "Generating Scoop manifest for version: $VERSION_NUM"
+          echo "Generating Scoop manifest for version: ${VERSION_NUM}"
 
-          # Download SHA256 checksums from release
-          BASE_URL="https://github.com/loonghao/vx/releases/download/${VERSION}"
-
-          # Get SHA256 for Windows x64
-          WIN_X64_SHA256=$(curl -sL "${BASE_URL}/vx-x86_64-pc-windows-msvc.zip.sha256" | awk '{print $1}')
-          # Get SHA256 for Windows ARM64
-          WIN_ARM64_SHA256=$(curl -sL "${BASE_URL}/vx-aarch64-pc-windows-msvc.zip.sha256" | awk '{print $1}')
-
-          echo "Windows x64 SHA256: $WIN_X64_SHA256"
-          echo "Windows ARM64 SHA256: $WIN_ARM64_SHA256"
-
-          # Validate checksums
-          if [[ -z "$WIN_X64_SHA256" || "$WIN_X64_SHA256" == "null" ]]; then
-            echo "Failed to get Windows x64 SHA256"
+          # --- Windows x64 checksum (required) ---
+          WIN_X64_SHA256="$(curl -fsSL "${BASE_URL}/vx-x86_64-pc-windows-msvc.zip.sha256" | awk '{print $1}' || true)"
+          if [[ ! "${WIN_X64_SHA256}" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::warning::.sha256 asset missing for Windows x64 - computing from the archive"
+            curl -fsSL "${BASE_URL}/vx-x86_64-pc-windows-msvc.zip" -o /tmp/vx-x64.zip
+            WIN_X64_SHA256="$(sha256sum /tmp/vx-x64.zip | awk '{print $1}')"
+          fi
+          if [[ ! "${WIN_X64_SHA256}" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::Failed to resolve Windows x64 SHA256"
             exit 1
           fi
+          echo "Windows x64 SHA256: ${WIN_X64_SHA256}"
 
-          # Create Scoop manifest
-          cat > vx.json << EOF
-          {
-              "version": "${VERSION_NUM}",
-              "description": "Universal development tool manager - run any dev tool with automatic runtime management",
-              "homepage": "https://github.com/loonghao/vx",
-              "license": "MIT",
-              "architecture": {
-                  "64bit": {
-                      "url": "${BASE_URL}/vx-x86_64-pc-windows-msvc.zip",
-                      "hash": "${WIN_X64_SHA256}"
-                  },
-                  "arm64": {
-                      "url": "${BASE_URL}/vx-aarch64-pc-windows-msvc.zip",
-                      "hash": "${WIN_ARM64_SHA256}"
-                  }
-              },
-              "bin": "vx.exe",
-              "checkver": "github",
-              "autoupdate": {
-                  "architecture": {
-                      "64bit": {
-                          "url": "https://github.com/loonghao/vx/releases/download/v\$version/vx-x86_64-pc-windows-msvc.zip"
-                      },
-                      "arm64": {
-                          "url": "https://github.com/loonghao/vx/releases/download/v\$version/vx-aarch64-pc-windows-msvc.zip"
-                      }
-                  }
-              }
-          }
-          EOF
+          # --- Windows ARM64 checksum (optional) ---
+          WIN_ARM64_SHA256=""
+          ASSET_NAMES="$(curl -fsSL -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/repos/loonghao/vx/releases/tags/${TAG}" | jq -r '.assets[].name' 2>/dev/null || true)"
+          if echo "${ASSET_NAMES}" | grep -qx 'vx-aarch64-pc-windows-msvc.zip'; then
+            WIN_ARM64_SHA256="$(curl -fsSL "${BASE_URL}/vx-aarch64-pc-windows-msvc.zip.sha256" | awk '{print $1}' || true)"
+            if [[ ! "${WIN_ARM64_SHA256}" =~ ^[0-9a-f]{64}$ ]]; then
+              curl -fsSL "${BASE_URL}/vx-aarch64-pc-windows-msvc.zip" -o /tmp/vx-arm64.zip
+              WIN_ARM64_SHA256="$(sha256sum /tmp/vx-arm64.zip | awk '{print $1}')"
+            fi
+            if [[ ! "${WIN_ARM64_SHA256}" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "::error::Failed to resolve Windows ARM64 SHA256"
+              exit 1
+            fi
+            echo "Windows ARM64 SHA256: ${WIN_ARM64_SHA256}"
+          else
+            echo "No Windows ARM64 asset in this release - manifest will be 64-bit only"
+          fi
 
+          # --- Build the manifest with jq (no heredoc quoting pitfalls) ---
+          MANIFEST="$(jq -n \
+            --arg version "${VERSION_NUM}" \
+            --arg url "${BASE_URL}/vx-x86_64-pc-windows-msvc.zip" \
+            --arg hash "${WIN_X64_SHA256}" \
+            '{
+               version: $version,
+               description: "Universal development tool manager - run any dev tool with automatic runtime management",
+               homepage: "https://github.com/loonghao/vx",
+               license: "MIT",
+               architecture: {"64bit": {url: $url, hash: $hash}},
+               bin: "vx.exe",
+               checkver: "github",
+               autoupdate: {architecture: {"64bit": {url: ("https://github.com/loonghao/vx/releases/download/v" + "$" + "version/vx-x86_64-pc-windows-msvc.zip")}}}
+             }')"
+
+          if [[ -n "${WIN_ARM64_SHA256}" ]]; then
+            MANIFEST="$(jq -n \
+              --argjson manifest "${MANIFEST}" \
+              --arg url "${BASE_URL}/vx-aarch64-pc-windows-msvc.zip" \
+              --arg hash "${WIN_ARM64_SHA256}" \
+              '$manifest | .architecture.arm64 = {url: $url, hash: $hash} | .autoupdate.architecture.arm64 = {url: ("https://github.com/loonghao/vx/releases/download/v" + "$" + "version/vx-aarch64-pc-windows-msvc.zip")}')"
+          fi
+
+          echo "${MANIFEST}" | jq . > vx.json
+          jq -e . vx.json > /dev/null  # validate JSON
           echo "Generated manifest:"
           cat vx.json
 
-          # Clone the scoop bucket repo and update
+          # --- Push to the Scoop bucket repo ---
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
           # Clean token to remove any newlines
-          CLEAN_TOKEN=$(echo "$GITHUB_TOKEN" | tr -d '\n\r')
-          git clone "https://x-access-token:${CLEAN_TOKEN}@github.com/loonghao/scoop-vx.git" scoop-bucket
+          CLEAN_TOKEN="$(echo "${BUCKET_TOKEN}" | tr -d '\n\r')"
+          if [[ -z "${CLEAN_TOKEN}" ]]; then
+            echo "::error::SCOOP_BUCKET_GITHUB_TOKEN secret is empty - cannot push to the Scoop bucket"
+            exit 1
+          fi
+          git clone --depth 1 "https://x-access-token:${CLEAN_TOKEN}@github.com/loonghao/scoop-vx.git" scoop-bucket
           cd scoop-bucket
 
           # Create bucket directory if not exists
           mkdir -p bucket
 
-          # Copy manifest to bucket
+          # Copy manifest to bucket (scope the commit to the manifest only)
           cp ../vx.json bucket/vx.json
 
-          # Commit and push
-          git add .
-          if git diff --staged --quiet; then
+          git add bucket/vx.json
+          if git diff --cached --quiet; then
             echo "No changes to commit"
           else
             git commit -m "Update vx to ${VERSION_NUM}"
@@ -269,20 +319,20 @@ jobs:
         run: |
           VERSION="${{ needs.check-release.outputs.version }}"
 
-          echo "## 📦 Package Manager Publishing Summary" >> $GITHUB_STEP_SUMMARY
+          echo "## Package Manager Publishing Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** ${VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Package Manager | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-----------------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| 🪟 WinGet | (handled by release workflow) |" >> $GITHUB_STEP_SUMMARY
-          echo "| 🍫 Chocolatey | ${{ needs.publish-chocolatey.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| 🍺 Homebrew | (handled by cargo-dist) |" >> $GITHUB_STEP_SUMMARY
-          echo "| 🥄 Scoop | ${{ needs.publish-scoop.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| WinGet | (handled by release workflow) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Chocolatey | ${{ needs.publish-chocolatey.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Homebrew | (handled by cargo-dist) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Scoop | ${{ needs.publish-scoop.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Installation Commands" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "```bash" >> $GITHUB_STEP_SUMMARY
           echo "# Windows (WinGet)" >> $GITHUB_STEP_SUMMARY
           echo "winget install loonghao.vx" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -298,4 +348,4 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "# Rust (Cargo)" >> $GITHUB_STEP_SUMMARY
           echo "cargo install vx" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "```" >> $GITHUB_STEP_SUMMARY

--- a/docs/advanced/release-process.md
+++ b/docs/advanced/release-process.md
@@ -102,7 +102,7 @@ installers-regex: 'vx-(x86_64|aarch64)-pc-windows-msvc\.zip$'
 
 ### Package Managers Workflow (`.github/workflows/package-managers.yml`)
 
-This workflow runs after the Release workflow completes and publishes to package managers.
+This workflow runs whenever a GitHub Release is published (`release: published` event) and publishes to package managers.
 It serves as a **backup** for WinGet publishing (in case the `release.yml` publish-winget
 job fails) and as the **primary** publisher for Chocolatey and Scoop.
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -58,7 +58,7 @@ brew install loonghao/vx/vx
 ### Scoop (Windows)
 
 ```powershell
-scoop bucket add loonghao https://github.com/loonghao/scoop-bucket
+scoop bucket add vx https://github.com/loonghao/scoop-vx
 scoop install vx
 ```
 

--- a/docs/zh/guide/installation.md
+++ b/docs/zh/guide/installation.md
@@ -58,7 +58,7 @@ brew install loonghao/vx/vx
 ### Scoop (Windows)
 
 ```powershell
-scoop bucket add loonghao https://github.com/loonghao/scoop-bucket
+scoop bucket add vx https://github.com/loonghao/scoop-vx
 scoop install vx
 ```
 


### PR DESCRIPTION
## Problem

Scoop publishing for vx is broken:

1. The [scoop-vx bucket](https://github.com/loonghao/scoop-vx/blob/main/bucket/vx.json) is stuck at **0.9.12** while the latest release is **0.9.29** — 17 releases were never published.
2. The published manifest contains an invalid ARM64 hash (`"hash": "Not"`) because the release has no Windows ARM64 asset and `curl -sL` on the missing `.sha256` file returned the 404 body ("404: Not Found"), of which `awk` kept "Not".
3. Root cause of the stall: `package-managers.yml` was triggered by `workflow_run` on the Release workflow, but every release since 0.9.12 has been created via `workflow_dispatch`, for which the trigger stopped firing — no Package Managers runs have happened since 2026-06-08.

## Fix

- Trigger on `release: published` instead of `workflow_run` (fires for every published release regardless of how the Release workflow was started). `workflow_dispatch` kept for manual runs.
- Skip prereleases and the legacy `vx-v*` compatibility releases (both publish their own GitHub Release events).
- Rewrite the Scoop manifest generation with `jq`:
  - Fetch checksums with `curl -f` and validate `^[0-9a-f]{64}$`, with a download-and-hash fallback.
  - Emit the ARM64 block **only when** `vx-aarch64-pc-windows-msvc.zip` actually exists in the release.
  - Correct `$version` autoupdate placeholder (built via string concat — `\$` is not a valid jq escape).
  - Scope the bucket commit to `bucket/vx.json` and validate the JSON before pushing.
- Chocolatey: retry download with versioned-name fallback, and generate the nuspec inline (the referenced `chocolatey/vx.nuspec` never existed in the repo, so the job was doomed even when the download worked).
- Docs: fix scoop bucket install command in `docs/guide/installation.md` + `docs/zh/guide/installation.md` (`loonghao/scoop-bucket` → `loonghao/scoop-vx`).

## Already applied

The bucket itself is fixed and live: [loonghao/scoop-vx](https://github.com/loonghao/scoop-vx) now carries v0.9.29 with a verified SHA256 (`6c3192a35e9299358f09b2665a4ef05e4bbf9146ba0a7f4a5a1a720aa1518808`).

## Testing

- `actionlint` clean.
- The scoop job's exact `run` block was extracted from the workflow and executed end-to-end against the real v0.9.29 release: checksum resolved, ARM64 correctly omitted, JSON valid, autoupdate URL contains the literal `$version` placeholder.
