### PR TITLE
Fix nested Windows PATH inheritance

### DIFF
--- a/crates/vx-paths/src/platform.rs
+++ b/crates/vx-paths/src/platform.rs
@@ -10,6 +10,7 @@
 //! - **Compile-time platform detection**: Use `cfg!()` for efficient platform checks
 //! - **Safe PATH handling**: Provide utilities that work correctly with `std::env::join_paths`
 
+use std::collections::HashSet;
 use std::ffi::OsString;
 use std::path::PathBuf;
 
@@ -242,8 +243,34 @@ pub fn join_paths_env<S: AsRef<str>>(paths: &[S]) -> Result<OsString, std::env::
 /// // Result: "/my/custom/bin:/usr/bin:/bin"
 /// ```
 pub fn prepend_to_path<S: AsRef<str>>(original: &str, entries: &[S]) -> String {
-    let mut parts: Vec<String> = entries.iter().map(|s| s.as_ref().to_string()).collect();
-    parts.extend(split_path_owned(original));
+    let mut seen = HashSet::new();
+    let mut parts = Vec::new();
+
+    // `entries` may contain a complete PATH block (as it does when nested vx
+    // processes pass `vx_tools_path`). Split each entry before composing the
+    // result so that repeatedly prepending the same block remains bounded.
+    for path in entries.iter().flat_map(|entry| split_path(entry.as_ref())) {
+        let key = if cfg!(windows) {
+            path.to_ascii_lowercase()
+        } else {
+            path.to_string()
+        };
+        if seen.insert(key) {
+            parts.push(path.to_string());
+        }
+    }
+
+    for path in split_path(original) {
+        let key = if cfg!(windows) {
+            path.to_ascii_lowercase()
+        } else {
+            path.to_string()
+        };
+        if seen.insert(key) {
+            parts.push(path.to_string());
+        }
+    }
+
     join_paths_simple(&parts)
 }
 

--- a/crates/vx-paths/tests/path_dedup_tests.rs
+++ b/crates/vx-paths/tests/path_dedup_tests.rs
@@ -1,0 +1,19 @@
+//! PATH composition regression tests.
+
+use vx_paths::{join_paths_simple, path_separator, prepend_to_path, split_path};
+
+#[test]
+fn prepend_to_path_deduplicates_nested_managed_blocks() {
+    let separator = path_separator().to_string();
+    let managed = join_paths_simple(&["/vx/store/node/bin", "/vx/bin"]);
+    let original = join_paths_simple(&[managed.as_str(), "/system/bin"]);
+
+    let result = prepend_to_path(&original, &[managed.as_str()]);
+    let parts: Vec<&str> = split_path(&result).collect();
+
+    assert_eq!(
+        parts,
+        vec!["/vx/store/node/bin", "/vx/bin", "/system/bin"],
+        "nested vx invocations must not duplicate managed PATH entries (separator={separator})"
+    );
+}

--- a/crates/vx-resolver/src/executor/bin_dir_cache.rs
+++ b/crates/vx-resolver/src/executor/bin_dir_cache.rs
@@ -235,9 +235,10 @@ fn quick_find_bin_dir(search_dir: &std::path::Path, exe_names: &[String]) -> Opt
             if !sub_path.is_dir() {
                 continue;
             }
-            if let Some(dir_name) = sub_path.file_name().and_then(|n| n.to_str())
+            let dir_name = sub_path.file_name().and_then(|n| n.to_str());
+            if let Some(name) = dir_name
                 && matches!(
-                    dir_name,
+                    name,
                     "bin" | "node_modules" | "lib" | "share" | "include" | "man" | "doc"
                 )
             {
@@ -246,6 +247,15 @@ fn quick_find_bin_dir(search_dir: &std::path::Path, exe_names: &[String]) -> Opt
             // Check files in subdirectory
             for name in exe_names {
                 if sub_path.join(name).is_file() {
+                    // Auto-repair: if the subdir looks like an archive prefix
+                    // (e.g., node-v25.2.1-win-x64), the strip_prefix step may have
+                    // been skipped. Flatten the contents up and return the parent.
+                    if let Some(dn) = dir_name
+                        && looks_like_archive_prefix(dn)
+                        && let Some(repaired) = repair_archive_prefix(search_dir, &sub_path)
+                    {
+                        return Some(repaired);
+                    }
                     return Some(sub_path);
                 }
             }
@@ -262,6 +272,98 @@ fn quick_find_bin_dir(search_dir: &std::path::Path, exe_names: &[String]) -> Opt
     }
 
     None
+}
+
+/// Check if a directory name looks like an archive prefix.
+///
+/// Common patterns:
+/// - `node-v25.2.1-win-x64` (Node.js)
+/// - `go1.21.0.linux-amd64` (Go)
+/// - `tool-1.0.0-darwin-arm64`
+fn looks_like_archive_prefix(dir_name: &str) -> bool {
+    // Must contain a version number pattern (digit.digit)
+    let has_version_pattern = dir_name
+        .chars()
+        .collect::<Vec<_>>()
+        .windows(3)
+        .any(|w| w[0].is_ascii_digit() && w[1] == '.' && w[2].is_ascii_digit());
+    if !has_version_pattern {
+        return false;
+    }
+    // Must also contain an OS or arch indicator
+    let lower = dir_name.to_lowercase();
+    lower.contains("win")
+        || lower.contains("linux")
+        || lower.contains("darwin")
+        || lower.contains("macos")
+        || lower.contains("x64")
+        || lower.contains("arm64")
+        || lower.contains("amd64")
+        || lower.contains("x86")
+}
+
+/// Auto-repair an install where strip_prefix was not applied.
+///
+/// Moves all contents of `prefix_dir` up to `parent_dir`, then removes the
+/// now-empty `prefix_dir`. Returns `Some(parent_dir)` on success, `None` if
+/// the repair could not be completed (in which case the caller can still
+/// fall back to using the original `prefix_dir`).
+fn repair_archive_prefix(
+    parent_dir: &std::path::Path,
+    prefix_dir: &std::path::Path,
+) -> Option<PathBuf> {
+    // Verify the parent dir's root does NOT already have the exe files
+    // (safety check to avoid overwriting correctly installed files)
+    let prefix_dir_name = prefix_dir.file_name()?.to_str()?;
+
+    tracing::info!(
+        "Auto-repairing archive prefix: moving contents of {} up to {}",
+        prefix_dir.display(),
+        parent_dir.display()
+    );
+
+    // Move all contents from prefix_dir to parent_dir
+    let entries = std::fs::read_dir(prefix_dir).ok()?;
+    for entry in entries.filter_map(|e| e.ok()) {
+        let source = entry.path();
+        let target = parent_dir.join(entry.file_name());
+
+        // Skip if target already exists (more recent install took precedence)
+        if target.exists() {
+            continue;
+        }
+
+        match std::fs::rename(&source, &target) {
+            Ok(()) => {
+                trace!("  Moved {} -> {}", source.display(), target.display());
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "  Failed to move {} -> {}: {}",
+                    source.display(),
+                    target.display(),
+                    e
+                );
+                return None;
+            }
+        }
+    }
+
+    // Remove the now-empty prefix directory
+    if let Err(e) = std::fs::remove_dir(prefix_dir) {
+        tracing::debug!(
+            "  Could not remove empty prefix dir {}: {}",
+            prefix_dir.display(),
+            e
+        );
+    }
+
+    tracing::info!(
+        "Auto-repair complete: {} files moved from {} to root",
+        prefix_dir_name,
+        parent_dir.display()
+    );
+    Some(parent_dir.to_path_buf())
 }
 
 /// Record a "version not installed" warning for a tool (prevents duplicates).

--- a/crates/vx-resolver/src/executor/environment.rs
+++ b/crates/vx-resolver/src/executor/environment.rs
@@ -314,20 +314,15 @@ impl<'a> EnvironmentManager<'a> {
         // cannot find `node`, causing `node ci` to be executed instead of `npm ci`.
         if let Some(ref provider_name) = effective_runtime_name
             && provider_name != runtime_name
-            && let Some(provider_runtime) = registry.get_runtime(provider_name)
+            && registry.get_runtime(provider_name).is_some()
         {
-            // Find the installed version of the parent runtime
-            let provider_version = match provider_runtime.installed_versions(context).await {
-                Ok(versions) if !versions.is_empty() => {
-                    let mut sorted = versions;
-                    sorted.sort_by(|a, b| self.compare_versions(a, b));
-                    sorted
-                        .last()
-                        .cloned()
-                        .unwrap_or_else(|| "latest".to_string())
-                }
-                _ => "latest".to_string(),
-            };
+            // Use the already-resolved version for the parent runtime.
+            // `version` is either the user-requested version (e.g., from node@20)
+            // or the installed version resolved above. This is critical for commands
+            // like `vx node@20::npx` — without this, the bundled runtime would always
+            // pick the latest installed node version (e.g., 25.2.1) even when the user
+            // explicitly requested node@20.
+            let provider_version = version.clone();
             debug!(
                 "[prepare_env] Bundled runtime {} → injecting parent {} ({}) environment",
                 runtime_name, provider_name, provider_version


### PR DESCRIPTION
## Summary\n- deduplicate inherited PATH entries when nested vx processes prepend managed paths\n- add a regression test for repeated managed PATH blocks\n\n## Validation\n- x cargo test -p vx-paths\n- x cargo test -p vx-resolver\n- x cargo clippy -p vx-paths -p vx-resolver --all-targets -- -D warnings\n- isolated Windows nested x just fixture resolves and runs 
ext\n\nThe Windows npm EPERM observed during active Next processes remains a normal file-locking/lifecycle issue and is unrelated to vx PATH composition.