### PR TITLE
fix: validate bot-created release pull requests

### DIFF
--- a/.github/workflows/ci-release-pr.yml
+++ b/.github/workflows/ci-release-pr.yml
@@ -1,26 +1,12 @@
-# CI gate for Release Please PRs
+# Event-driven CI gate for Release Please PRs.
 #
-# Problem:
-# Release Please creates PRs using GITHUB_TOKEN. Due to GitHub's security model,
-# PRs created by github-actions[bot] via GITHUB_TOKEN do NOT trigger `pull_request`
-# workflow events. This means the main CI workflow never runs on release PRs, so
-# the required "CI / CI Success" status check is never reported, blocking the merge.
+# A PR created with GITHUB_TOKEN does not emit another workflow event, so the
+# Release Please push workflow validates and reports its exact head directly.
+# This pull_request_target workflow is the equivalent fallback when a PAT or
+# GitHub App token creates/updates the PR and GitHub does emit the event.
 #
-# Solution:
-# Use `pull_request_target` which IS triggered for bot-created PRs. This workflow
-# validates the release PR metadata and then creates a successful "CI / CI Success"
-# commit status via the GitHub API, satisfying the branch protection requirement.
-#
-# Branch Protection Setup:
-# Only ONE required check is needed: "CI / CI Success"
-# - Normal PRs: ci.yml provides this check via the ci-success job
-# - Release PRs: this workflow provides it via the GitHub Status API
-#
-# Security:
-# - `pull_request_target` runs in the context of the base branch (main)
-# - We do NOT checkout or execute any code from the PR branch
-# - We only validate PR metadata (branch name, author) and changed file names
-# - This is safe per GitHub's security guidelines for `pull_request_target`
+# Security: only trusted base-branch code is checked out and executed. The PR
+# branch is inspected exclusively through metadata and changed-file API calls.
 
 name: CI (Release PR)
 
@@ -38,93 +24,60 @@ jobs:
   release-pr-gate:
     name: Release PR Gate
     runs-on: ubuntu-latest
-    # Only run for release-please PRs
+    timeout-minutes: 5
     if: startsWith(github.head_ref, 'release-please--')
     steps:
-      - name: Validate release PR
-        env:
-          RELEASE_HEAD_REF: ${{ github.head_ref }}
-          RELEASE_AUTHOR: ${{ github.event.pull_request.user.login }}
-        run: |
-          echo "## Release PR CI Gate" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** ${RELEASE_HEAD_REF}" >> $GITHUB_STEP_SUMMARY
-          echo "**Author:** ${RELEASE_AUTHOR}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+      - name: Checkout trusted base commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
 
-          # Verify this is from the expected bot
-          AUTHOR="${RELEASE_AUTHOR}"
-          if [[ "$AUTHOR" != "github-actions[bot]" && "$AUTHOR" != "release-please[bot]" ]]; then
-            echo "::error::Unexpected PR author: $AUTHOR (expected github-actions[bot] or release-please[bot])"
-            echo "❌ **Unexpected author** - this workflow only gates release-please PRs." >> $GITHUB_STEP_SUMMARY
-            exit 1
+      - name: Validate release pull request
+        id: policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          RELEASE_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          RELEASE_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          RELEASE_AUTHOR: ${{ github.event.pull_request.user.login }}
+        shell: bash
+        run: |
+          mapfile -t files < <(
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls/${RELEASE_PR_NUMBER}/files?per_page=100" \
+              --jq '.[].filename'
+          )
+
+          if python3 scripts/validate_release_pr.py \
+            --head-ref "$RELEASE_HEAD_REF" \
+            --base-ref "$RELEASE_BASE_REF" \
+            --author "$RELEASE_AUTHOR" \
+            -- "${files[@]}"; then
+            echo "state=success" >> "$GITHUB_OUTPUT"
+            echo "description=Trusted Release Please version update" >> "$GITHUB_OUTPUT"
+          else
+            echo "state=failure" >> "$GITHUB_OUTPUT"
+            echo "description=Release PR metadata or files are invalid" >> "$GITHUB_OUTPUT"
           fi
 
-          echo "✅ Release PR validated. Version bump and changelog changes do not require full CI." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Release PRs only modify:" >> $GITHUB_STEP_SUMMARY
-          echo "- \`.release-please-manifest.json\` (version bump)" >> $GITHUB_STEP_SUMMARY
-          echo "- \`CHANGELOG.md\` (release notes)" >> $GITHUB_STEP_SUMMARY
-          echo "- \`Cargo.toml\` (version field)" >> $GITHUB_STEP_SUMMARY
-          echo "- \`Cargo.lock\` (workspace package versions)" >> $GITHUB_STEP_SUMMARY
+      - name: Publish CI status on pull request head
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          POLICY_STATE: ${{ steps.policy.outputs.state || 'failure' }}
+          POLICY_DESCRIPTION: ${{ steps.policy.outputs.description || 'Release PR policy could not be evaluated' }}
+        shell: bash
+        run: |
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${PR_HEAD_SHA}" \
+            --raw-field state="$POLICY_STATE" \
+            --raw-field context="CI / CI Success" \
+            --raw-field description="$POLICY_DESCRIPTION" \
+            --raw-field target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
-      - name: Validate release PR files
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const pull = context.payload.pull_request;
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pull.number,
-              per_page: 100
-            });
-
-            const names = files.map((file) => file.filename).sort();
-            const allowed = new Set([
-              '.release-please-manifest.json',
-              'CHANGELOG.md',
-              'Cargo.toml',
-              'Cargo.lock'
-            ]);
-            const disallowed = names.filter((name) => !allowed.has(name));
-            if (disallowed.length > 0) {
-              core.setFailed(`Release PR touches unexpected files: ${disallowed.join(', ')}`);
-              return;
-            }
-
-            const required = [
-              '.release-please-manifest.json',
-              'CHANGELOG.md',
-              'Cargo.toml',
-              'Cargo.lock'
-            ];
-            const missing = required.filter((name) => !names.includes(name));
-            if (missing.length > 0) {
-              core.setFailed(
-                `Release PR is incomplete (${missing.join(', ')} missing). ` +
-                'Refusing changelog-only or version-only release PRs.'
-              );
-              return;
-            }
-
-            await core.summary
-              .addHeading('Release PR file validation', 2)
-              .addList(names.map((name) => `\`${name}\``))
-              .write();
-
-      - name: Report CI Success status
-        uses: actions/github-script@v9
-        with:
-          script: |
-            // Create a commit status matching the main CI's check name
-            // so branch protection's required "CI / CI Success" check is satisfied.
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.pull_request.head.sha,
-              state: 'success',
-              context: 'CI / CI Success',
-              description: 'Release PR - version bump only, full CI not required',
-              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            });
+      - name: Enforce release pull request policy
+        if: steps.policy.outputs.state != 'success'
+        shell: bash
+        run: exit 1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,6 +52,7 @@ permissions:
   contents: write
   pull-requests: write
   actions: write
+  statuses: write
 
 jobs:
   # Job 1: Handle release creation (tag + GitHub Release)
@@ -195,6 +196,102 @@ jobs:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # Resources created with GITHUB_TOKEN do not emit another workflow event.
+      # Validate the exact Release Please PR head here, from trusted main code,
+      # and publish the same required statuses as the event-driven workflows.
+      - name: Checkout trusted main commit
+        if: >-
+          ${{
+            steps.current-main.outputs.is_current == 'true' &&
+            steps.release.outputs.prs_created == 'true'
+          }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Validate and report Release Please pull requests
+        if: >-
+          ${{
+            steps.current-main.outputs.is_current == 'true' &&
+            steps.release.outputs.prs_created == 'true'
+          }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_PRS: ${{ steps.release.outputs.prs }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! pr_numbers_json="$(
+            jq -er '
+              if type == "array" and length > 0 and
+                 all(.[]; (.number | type) == "number")
+              then [.[].number]
+              else error("release-please returned no valid pull request numbers")
+              end
+            ' <<< "$RELEASE_PRS"
+          )"; then
+            echo "::error::Could not parse release-please pull request output."
+            exit 1
+          fi
+
+          mapfile -t pr_numbers < <(jq -r '.[]' <<< "$pr_numbers_json")
+          validation_failed=0
+
+          post_status() {
+            local sha="$1"
+            local state="$2"
+            local context="$3"
+            local description="$4"
+            gh api --method POST \
+              "repos/${GITHUB_REPOSITORY}/statuses/${sha}" \
+              --raw-field state="$state" \
+              --raw-field context="$context" \
+              --raw-field description="$description" \
+              --raw-field target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          }
+
+          for number in "${pr_numbers[@]}"; do
+            pull_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${number}")"
+            title="$(jq -er '.title' <<< "$pull_json")"
+            head_ref="$(jq -er '.head.ref' <<< "$pull_json")"
+            head_sha="$(jq -er '.head.sha' <<< "$pull_json")"
+            base_ref="$(jq -er '.base.ref' <<< "$pull_json")"
+            author="$(jq -er '.user.login' <<< "$pull_json")"
+            mapfile -t files < <(
+              gh api --paginate \
+                "repos/${GITHUB_REPOSITORY}/pulls/${number}/files?per_page=100" \
+                --jq '.[].filename'
+            )
+
+            if python3 scripts/validate_pr_title.py "$title"; then
+              title_state="success"
+              title_description="Conventional Commit title is valid"
+            else
+              title_state="failure"
+              title_description="Use a Conventional Commit title"
+              validation_failed=1
+            fi
+            post_status "$head_sha" "$title_state" "PR Title" "$title_description"
+
+            if python3 scripts/validate_release_pr.py \
+              --head-ref "$head_ref" \
+              --base-ref "$base_ref" \
+              --author "$author" \
+              -- "${files[@]}"; then
+              release_state="success"
+              release_description="Trusted Release Please version update"
+            else
+              release_state="failure"
+              release_description="Release PR metadata or files are invalid"
+              validation_failed=1
+            fi
+            post_status "$head_sha" "$release_state" "CI / CI Success" "$release_description"
+          done
+
+          exit "$validation_failed"
 
       # release-please-action can create a release here too (when it detects
       # a just-merged release PR). Trigger cargo-dist in that case so that

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ examples/msvc/aionui
 *.tmp
 *.temp
 node_modules/
+__pycache__/
+*.py[cod]
 
 .shrimp-config.json
 dist/

--- a/scripts/tests/test_release_please_workflow.py
+++ b/scripts/tests/test_release_please_workflow.py
@@ -1,0 +1,39 @@
+"""Security and delivery contract tests for Release Please workflows."""
+
+from pathlib import Path
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+RELEASE_WORKFLOW = REPOSITORY_ROOT / ".github" / "workflows" / "release-please.yml"
+RELEASE_PR_WORKFLOW = REPOSITORY_ROOT / ".github" / "workflows" / "ci-release-pr.yml"
+
+
+class ReleasePleaseWorkflowTests(unittest.TestCase):
+    def test_push_workflow_validates_bot_prs_and_reports_required_statuses(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("statuses: write", workflow)
+        self.assertIn("steps.release.outputs.prs_created == 'true'", workflow)
+        self.assertIn("RELEASE_PRS: ${{ steps.release.outputs.prs }}", workflow)
+        self.assertIn("ref: ${{ github.sha }}", workflow)
+        self.assertIn("scripts/validate_pr_title.py", workflow)
+        self.assertIn("scripts/validate_release_pr.py", workflow)
+        self.assertIn(
+            'post_status "$head_sha" "$title_state" "PR Title"', workflow
+        )
+        self.assertIn(
+            'post_status "$head_sha" "$release_state" "CI / CI Success"', workflow
+        )
+        self.assertIn(".head.sha", workflow)
+
+    def test_event_driven_fallback_uses_the_same_release_pr_validator(self) -> None:
+        workflow = RELEASE_PR_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("ref: ${{ github.event.pull_request.base.sha }}", workflow)
+        self.assertIn("scripts/validate_release_pr.py", workflow)
+        self.assertNotIn("'Cargo.lock'\n            ];", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_validate_release_pr.py
+++ b/scripts/tests/test_validate_release_pr.py
@@ -1,0 +1,75 @@
+"""Behavior tests for the Release Please pull request validator."""
+
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = REPOSITORY_ROOT / "scripts" / "validate_release_pr.py"
+REQUIRED_FILES = (
+    ".release-please-manifest.json",
+    "CHANGELOG.md",
+    "Cargo.toml",
+)
+
+
+class ValidateReleasePullRequestTests(unittest.TestCase):
+    def run_validator(
+        self,
+        *,
+        head_ref: str = "release-please--branches--main",
+        base_ref: str = "main",
+        author: str = "github-actions[bot]",
+        files: tuple[str, ...] = REQUIRED_FILES,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATOR),
+                "--head-ref",
+                head_ref,
+                "--base-ref",
+                base_ref,
+                "--author",
+                author,
+                *files,
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+    def test_accepts_expected_release_please_changes(self) -> None:
+        for files in (REQUIRED_FILES, (*REQUIRED_FILES, "Cargo.lock")):
+            with self.subTest(files=files):
+                result = self.run_validator(files=files)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rejects_untrusted_metadata(self) -> None:
+        cases = (
+            {"head_ref": "feature/not-release-please"},
+            {"base_ref": "maintenance"},
+            {"author": "untrusted-user"},
+        )
+
+        for arguments in cases:
+            with self.subTest(arguments=arguments):
+                result = self.run_validator(**arguments)
+                self.assertNotEqual(result.returncode, 0)
+
+    def test_rejects_incomplete_or_unexpected_changes(self) -> None:
+        cases = (
+            ("CHANGELOG.md", "Cargo.toml"),
+            (*REQUIRED_FILES, "crates/vx-cli/src/main.rs"),
+        )
+
+        for files in cases:
+            with self.subTest(files=files):
+                result = self.run_validator(files=files)
+                self.assertNotEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_release_pr.py
+++ b/scripts/validate_release_pr.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Validate metadata and changed files for a Release Please pull request."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+EXPECTED_BASE_REF = "main"
+EXPECTED_HEAD_PREFIX = "release-please--"
+EXPECTED_AUTHORS = frozenset(("github-actions[bot]", "release-please[bot]"))
+REQUIRED_FILES = frozenset(
+    (
+        ".release-please-manifest.json",
+        "CHANGELOG.md",
+        "Cargo.toml",
+    )
+)
+OPTIONAL_FILES = frozenset(("Cargo.lock",))
+
+
+def validation_errors(
+    *, head_ref: str, base_ref: str, author: str, files: list[str]
+) -> list[str]:
+    """Return contract violations for a proposed Release Please pull request."""
+
+    errors: list[str] = []
+    changed_files = set(files)
+
+    if not head_ref.startswith(EXPECTED_HEAD_PREFIX):
+        errors.append(f"unexpected head branch: {head_ref}")
+    if base_ref != EXPECTED_BASE_REF:
+        errors.append(f"unexpected base branch: {base_ref}")
+    if author not in EXPECTED_AUTHORS:
+        errors.append(f"unexpected author: {author}")
+
+    missing = sorted(REQUIRED_FILES - changed_files)
+    if missing:
+        errors.append(f"missing required files: {', '.join(missing)}")
+
+    unexpected = sorted(changed_files - REQUIRED_FILES - OPTIONAL_FILES)
+    if unexpected:
+        errors.append(f"unexpected changed files: {', '.join(unexpected)}")
+
+    return errors
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--head-ref", required=True)
+    parser.add_argument("--base-ref", required=True)
+    parser.add_argument("--author", required=True)
+    parser.add_argument("files", nargs="+")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    """Validate one Release Please pull request."""
+
+    arguments = parse_args(argv)
+    errors = validation_errors(
+        head_ref=arguments.head_ref,
+        base_ref=arguments.base_ref,
+        author=arguments.author,
+        files=arguments.files,
+    )
+    if errors:
+        for error in errors:
+            print(f"Release PR validation failed: {error}", file=sys.stderr)
+        return 1
+
+    print("Release Please pull request metadata and files are valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- validate Release Please PR metadata and changed files from trusted main code
- publish PR Title and CI success statuses when GITHUB_TOKEN suppresses PR events
- keep the event-driven gate on the same validator and allow Cargo.lock as optional

## Validation
- vx python -m unittest discover -s scripts/tests -p 'test_*.py'
- vx uvx:ruff check scripts/validate_release_pr.py scripts/tests/test_validate_release_pr.py scripts/tests/test_release_please_workflow.py
- vx actionlint .github/workflows/release-please.yml .github/workflows/ci-release-pr.yml .github/workflows/pr-title.yml
- vx just hakari-verify